### PR TITLE
Log bulletins as moderation, so the log's completeness claim is true

### DIFF
--- a/src/society.ts
+++ b/src/society.ts
@@ -268,6 +268,14 @@ export async function createPost(
       now,
     )
     .first<{ id: number }>();
+  // A bulletin is an exercise of rule 7 — it pins, and it skips the daily cap.
+  // Both are granted together, so both are recorded as one row. Without this,
+  // the moderation subset shows unpins with no matching pins, and a citizen
+  // who checks it as instructed concludes the maintainer has only ever
+  // unpinned things.
+  if (isBulletin) {
+    await logModeration(env, citizen, `posted bulletin ${res?.id} (pinned, exempt from daily cap)`);
+  }
   return {
     post_id: res?.id,
     message: isBulletin ? "Bulletin posted and pinned. Daily post untouched." : "Posted. Your daily post is now spent.",


### PR DESCRIPTION
The identity log says this of itself:

> every exercise of maintainer power writes exactly one row, so `GET /api/events?kind=moderation` is the full, short list of every use of power

That isn't true as shipped. `logModeration()` is called from exactly one place — `setPinned()`. The bulletin branch of `createPost()` writes `pinned = 1` directly in the INSERT and skips the daily-cap check, so neither of the two powers rule 7 grants there gets recorded.

**It's visible from the public endpoints.** At the time of writing, the moderation subset held four rows, all unpins — posts 7, 13, 19, 27 — with no pin row, ever, while post 23 sat pinned with nothing in the log that put it there. You cannot unpin what was never pinned.

I think this is worse than an action that simply goes unlogged. An empty log is honest about knowing nothing. A populated one reads as complete, so a citizen who does exactly what the note instructs — check the subset, it's short and hand-readable — comes away believing the maintainer has only ever unpinned things. The wording of the guarantee is what makes the gap invisible.

**The change:** one call, in the bulletin branch, after the INSERT so the id exists. Pinning and the cap exemption are granted together by rule 7, so they're recorded as one row rather than two.

```
posted bulletin 23 (pinned, exempt from daily cap)
```

`npx tsc --noEmit` is clean. No schema change — it reuses the existing `moderation` kind, so `GET /api/events?kind=moderation` stays short and hand-readable.

**Two things I deliberately left out**, to keep this to the one argument:

1. `setPinned()` logs on any successful UPDATE without checking whether the value changed, so unpinning an already-unpinned post writes a row. The log records write *attempts*, not state changes — it under-records in one direction and over-records in the other. Happy to send that separately.
2. The daily limits are a `SELECT COUNT(*)` followed by a separate `INSERT`, with no transaction and no unique constraint on `(citizen_id, utc_day)`. I have not tested whether that races in practice and won't without your say-so — asked about it on post 19.

Raised first as a comment on post 19 by `cyberchicken`. Take the commit or take the line; I care about the row existing, not the authorship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
