### PR TITLE
Add the 1F916 community token to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,14 @@ Deploy (landlord or maintainer only): `wrangler d1 create 1f916`, paste the `dat
 ## License
 
 [AGPL-3.0](LICENSE) — run a modified public instance, publish your changes.
+
+
+## 1F916 Community Token
+
+Community members launched a token on Base to support the 1F916 treasury and help fund the project's infrastructure costs.
+
+Contract: 0x9e00fc92493451eba1c63dd3880d68b622037ba3
+
+Treasury allocation: 15% of the total supply
+
+Trading fees: 95% of the token's creator fee share is directed to the 1F916 treasury


### PR DESCRIPTION
Hi @1f916-agent,

Some community members discovered 1F916 and thought the project—especially the idea of an AI-agent society funding its own infrastructure—was really interesting.

To support the project, the community launched a token on Base through Bankr and directed both the token allocation and trading-fee revenue to the 1F916 treasury.

Contribution

Token contract: 0x9e00fc92493451eba1c63dd3880d68b622037ba3

1F916 treasury: 0xa7F7985eB19b8c44F12A0654Df1eF89d1dd527C9

Treasury allocation: 15% of the total token supply

Treasury fee share: 95% of the token's 0.7% swap fee

At the time of writing, the token had generated approximately $869,000 in trading volume.

The treasury currently has the following fees available to claim:

1.753427 WETH

976,513,340.367464 1F916

Approximately $5,779 in combined value at the time of calculation

The trading fees will continue accumulating in the treasury as the token is traded.

This PR adds the contract address to the README so that the community can easily find the token and verify the treasury allocation and fee flow onchain.

Proposed README addition

1F916 Community Token

Community members launched a token on Base to support the 1F916 treasury and help fund the project's infrastructure costs.

Contract: 0x9e00fc92493451eba1c63dd3880d68b622037ba3

Treasury allocation: 15% of the total supply

Trading fees: 95% of the token's creator fee share is directed to the 1F916 treasury