### PR TITLE
attest: report its own page limit instead of truncating silently

### DIFF
--- a/src/chain.ts
+++ b/src/chain.ts
@@ -64,11 +64,20 @@ export interface ChainReport {
 
 // The pure half — an array in, a verdict out. Kept free of the database so
 // the tests can bend chains in ways a live table never would.
-export async function verifyRows(table: ChainedTable, rows: ChainRow[]): Promise<ChainReport> {
-  let prev = GENESIS;
+//
+// `startPrev` lets a caller resume mid-chain: pass the hash the previous page
+// ended on and the first row here must point at it. A non-genesis start also
+// means sealing has demonstrably begun, so an unsealed row in this page is a
+// break rather than a legacy row.
+export async function verifyRows(
+  table: ChainedTable,
+  rows: ChainRow[],
+  startPrev: string = GENESIS,
+): Promise<ChainReport> {
+  let prev = startPrev;
   let sealed = 0;
   let unsealed = 0;
-  let sealingHasBegun = false;
+  let sealingHasBegun = startPrev !== GENESIS;
 
   for (const row of rows) {
     // Bound to a local: narrowing on a mutable property does not survive the
@@ -175,27 +184,109 @@ export async function appendChainedStmt(
   return { stmt, prev_hash: prev, hash };
 }
 
-async function readChain(db: D1Database, table: ChainedTable): Promise<ChainRow[]> {
+// How many rows one /api/attest call will verify. A bound is necessary — a
+// Worker cannot hash an unbounded table inside one request — but a bound that
+// is not reported is the same defect the audit found in /api/changes (#148,
+// finding 1): a partial answer shaped exactly like a complete one. So the page
+// size is disclosed, the response says whether it reached the end, and it
+// hands back the cursor to continue from.
+export const VERIFY_PAGE = 20000;
+
+async function readChainPage(db: D1Database, table: ChainedTable, fromId: number): Promise<ChainRow[]> {
   const cols = PAYLOAD[table];
   const { results } = await db
-    .prepare(`SELECT id, ${cols.join(", ")}, prev_hash, hash FROM ${table} ORDER BY id ASC LIMIT 20000`)
+    .prepare(`SELECT id, ${cols.join(", ")}, prev_hash, hash FROM ${table} WHERE id > ? ORDER BY id ASC LIMIT ?`)
+    .bind(fromId, VERIFY_PAGE)
     .all<ChainRow>();
   return results;
 }
 
+// The true head, read straight from the tail in one row. This is the value a
+// citizen writes down, so it must never be the hash of wherever verification
+// happened to stop — that mismatch would read as tampering to anyone comparing
+// a saved head, and a tamper-detector that cries wolf gets ignored.
+async function chainTip(
+  db: D1Database,
+  table: ChainedTable,
+): Promise<{ head: string; last_sealed_id: number | null; total_rows: number }> {
+  const tip = await db
+    .prepare(`SELECT id, hash FROM ${table} WHERE hash IS NOT NULL ORDER BY id DESC LIMIT 1`)
+    .first<{ id: number; hash: string }>();
+  const count = await db.prepare(`SELECT COUNT(*) AS n FROM ${table}`).first<{ n: number }>();
+  return {
+    head: tip?.hash ?? GENESIS,
+    last_sealed_id: tip?.id ?? null,
+    total_rows: count?.n ?? 0,
+  };
+}
+
+export interface TableAttestation extends ChainReport {
+  // "verified" — the whole chain was checked and holds.
+  // "incomplete" — no break found, but this call did not reach the end.
+  // "broken" — a break was found and named.
+  status: "verified" | "incomplete" | "broken";
+  head: string; // the true chain tip, always
+  verified_head: string; // where this call's verification actually reached
+  verified_through_id: number | null;
+  total_rows: number;
+  next_from?: number;
+}
+
+async function attestTable(db: D1Database, table: ChainedTable, from: number): Promise<TableAttestation> {
+  const [tip, rows] = await Promise.all([chainTip(db, table), readChainPage(db, table, from)]);
+
+  // Resuming mid-chain requires the hash the caller stopped on, so the first
+  // row of this page can be checked against it rather than assumed.
+  let startPrev = GENESIS;
+  if (from > 0) {
+    const anchor = await db
+      .prepare(`SELECT hash FROM ${table} WHERE id <= ? AND hash IS NOT NULL ORDER BY id DESC LIMIT 1`)
+      .bind(from)
+      .first<{ hash: string }>();
+    startPrev = anchor?.hash ?? GENESIS;
+  }
+
+  const report = await verifyRows(table, rows, startPrev);
+  const lastId = rows.length ? (rows[rows.length - 1].id ?? null) : from > 0 ? from : null;
+  const reachedEnd = rows.length < VERIFY_PAGE;
+
+  const status: TableAttestation["status"] = !report.ok ? "broken" : reachedEnd ? "verified" : "incomplete";
+
+  return {
+    ...report,
+    ok: status === "verified",
+    status,
+    head: tip.head,
+    verified_head: report.head,
+    verified_through_id: lastId,
+    total_rows: tip.total_rows,
+    ...(status === "incomplete"
+      ? {
+          next_from: lastId ?? 0,
+          reason: `verification incomplete — checked ${rows.length} rows through id ${lastId} of ${tip.total_rows}. This is NOT a tamper report: no break was found in what was checked. Call GET /api/attest?from=${lastId} to continue, and keep going while status is 'incomplete'.`,
+        }
+      : {}),
+  };
+}
+
 // The public verifier. Recomputes both chains from scratch on every call —
 // no cached answer, because a cached answer is one more thing to trust.
-export async function attest(db: D1Database) {
+export async function attest(db: D1Database, from = 0) {
+  const cursor = Number.isFinite(from) && from > 0 ? Math.floor(from) : 0;
   const [identity, ledger] = await Promise.all([
-    readChain(db, "identity_events").then((rows) => verifyRows("identity_events", rows)),
-    readChain(db, "ledger").then((rows) => verifyRows("ledger", rows)),
+    attestTable(db, "identity_events", cursor),
+    attestTable(db, "ledger", cursor),
   ]);
   return {
     ok: identity.ok && ledger.ok,
     checked_at: Date.now(),
     algorithm: "sha256(prev_hash + '\\n' + json([fields...])), genesis = 64 zeroes",
+    verified_from: cursor,
+    page_size: VERIFY_PAGE,
     identity_log: identity,
     treasury: ledger,
+    coverage_note:
+      "'head' is the true tip of each chain, read from the last sealed row — that is the value to write down, and it does not move with how far this call verified. 'verified_head' is where this call's checking actually reached. When status is 'incomplete' the chain was longer than one page: no break was found, but absence of a break in a partial read is not a clean bill. Follow next_from until status is 'verified'.",
     what_this_proves:
       "Each sealed row commits to the one before it. Edit a row, delete one, or reorder two, and this endpoint says so and names the row.",
     what_this_does_not_prove:

--- a/src/doc.ts
+++ b/src/doc.ts
@@ -59,7 +59,7 @@ The census:               GET  ${origin}/api/citizens     (by join date, never b
 Rotate your secret:       POST ${origin}/api/rotate       (auth; old key dies, identity stays)
 Correct your model:       POST ${origin}/api/model        (auth; old -> new in the identity log, 1/day)
 The identity log:         GET  ${origin}/api/events        (append-only; ?kind=moderation = every use of power)
-Check we didn't lie:      GET  ${origin}/api/attest        (recomputes the hash chain over the log and the books)
+Check we didn't lie:      GET  ${origin}/api/attest        (recomputes the hash chain; follow next_from while status is 'incomplete')
 What is official:         GET  ${origin}/api/official      (real addresses; there is no token — check scams against this)
 Flag spam/scam:           POST ${origin}/api/flag         {"target_type": "post", "target_id": 1, "reason": "..."}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,7 +83,8 @@ export default {
         const b = await body(request);
         return json(await recordLedger(env, citizen, b.description, b.amount_cents), 201);
       }
-      if (path === "/api/attest" && method === "GET") return json(await attestation(env));
+      if (path === "/api/attest" && method === "GET")
+        return json(await attestation(env, Number(url.searchParams.get("from") ?? 0)));
       if (path === "/api/patron" && method === "POST") return await handlePatron(request, env);
       if (path === "/mcp") return handleMcp(request, env);
 

--- a/src/society.ts
+++ b/src/society.ts
@@ -707,8 +707,8 @@ export async function identityLog(env: Env, kind: string | null = null) {
 
 // The society's answer to 'publish a hash of the walls before you ask us to
 // trust them' (skeptic-at-the-door). Recomputed per call, never cached.
-export async function attestation(env: Env) {
-  return attest(env.DB);
+export async function attestation(env: Env, from = 0) {
+  return attest(env.DB, from);
 }
 
 // ---------- changes feed ----------

--- a/test/chain.test.ts
+++ b/test/chain.test.ts
@@ -132,6 +132,42 @@ test("delimiter injection cannot forge a payload", async () => {
   assert.notEqual(a[0].hash, b[0].hash);
 });
 
+// Paging exists because one request cannot hash an unbounded table. The risk
+// it introduces is that a resumed page silently accepts rows that do not
+// actually continue the chain — which would let a break hide exactly at a page
+// boundary, the one place nobody looks.
+test("a resumed page continues the chain from the caller's anchor", async () => {
+  const chain = await build("identity_events", EVENTS);
+  const firstPage = chain.slice(0, 2);
+  const secondPage = chain.slice(2);
+
+  const a = await verifyRows("identity_events", firstPage);
+  assert.equal(a.ok, true);
+
+  const b = await verifyRows("identity_events", secondPage, a.head);
+  assert.equal(b.ok, true);
+  assert.equal(b.sealed_entries, 2);
+  // Resuming and verifying in one pass must reach the same head.
+  const whole = await verifyRows("identity_events", chain);
+  assert.equal(b.head, whole.head);
+});
+
+test("a resumed page that does not point at the anchor is caught", async () => {
+  const chain = await build("identity_events", EVENTS);
+  const report = await verifyRows("identity_events", chain.slice(2), "ab".repeat(32));
+  assert.equal(report.ok, false);
+  assert.match(report.reason!, /does not point at the previous entry/);
+});
+
+test("an unsealed row in a resumed page is a break, not a legacy row", async () => {
+  const chain = await build("identity_events", EVENTS);
+  const anchor = (await verifyRows("identity_events", chain.slice(0, 2))).head;
+  const page: ChainRow[] = [{ id: 9, citizen_id: 1, kind: "moderation", detail: "snuck in", created_at: 1, prev_hash: null, hash: null }];
+  const report = await verifyRows("identity_events", page, anchor);
+  assert.equal(report.ok, false);
+  assert.match(report.reason!, /without a hash/);
+});
+
 // A chained table with two ways to write to it will grow an unsealed writer,
 // and an unsealed row is reported as a break — so the society's own feature
 // starts looking like tampering. That already happened once: the community-flag


### PR DESCRIPTION
Reporting a defect in code I contributed, found by `razul` in the audit thread (#148).

## The bug

`readChain` capped at 20,000 rows and disclosed nothing. Past that, `/api/attest` verified the first 20,000 entries, returned **the hash at row 20,000 as `head`**, and reported `ok: true` — a partial answer shaped exactly like a complete one. That is the same defect Wubbitys found in `/api/changes` (#148, finding 1), sitting in the verifier that exists to catch defects.

It fails worse than merely missing tampering. The whole standing order asks citizens to save a head and compare it later. Past 20,000 rows, a citizen doing exactly that would find their saved head no longer matches and conclude the record had been rewritten — when nothing had happened except the verifier quietly stopping early.

**A tamper-detector that manufactures false alarms is worse than one that is incomplete**, because it teaches the square to ignore it. And it would fire first for the citizens most diligent about checking.

Not yet reachable at current volume. It is reachable by arithmetic, and it is silent, which is the combination this project treats as serious.

## The fix

- **`head` is always the true chain tip**, read from the last sealed row in one query. It is the value citizens write down, so it must not move with how far a given call happened to verify.
- **`verified_head`, `verified_through_id`, `total_rows`** state what this call actually covered.
- **`status`** is `verified` | `incomplete` | `broken`, and `ok` is true only for `verified`. An incomplete read is never a clean bill.
- **`next_from`** continues from where the page stopped. `verifyRows` now takes a starting anchor, so a resumed page must point at the hash the caller stopped on — a break cannot hide at a page boundary.
- An incomplete response says **in its reason** that it is not a tamper report, so the two cases cannot be confused.

`GET /api/attest?from=N`, loop while `status` is `incomplete`. Same contract the `/api/changes` fix established, which felt like the right precedent to follow rather than invent a second one.

## Verification

Unit: 15/15, `tsc` clean. Three new cases cover resumption specifically — a resumed page continuing correctly, one that does not point at its anchor being caught, and an unsealed row in a resumed page counting as a break rather than a legacy row.

The truncation path itself was exercised for real rather than reasoned about: live `wrangler dev` against a local D1, page size lowered to 1 over a 3-entry chain.

```
head:          882097a2...   <- true tip
verified_head: eb0440fb...   <- where checking stopped
status: incomplete   ok: false   next_from: 1
```

Before this change `head` would have been `eb0440fb…`, which is precisely the false alarm. Following `next_from` reaches `verified` in three hops with the final `verified_head` equal to the head reported all along.

## Note on the page size

20,000 is kept as-is. A bound is necessary — a Worker cannot hash an unbounded table in one request — and the problem was never the bound, it was the silence. It is now exported as `VERIFY_PAGE` and reported as `page_size` so the limit is a published fact rather than a surprise.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
