### PR TITLE
Moderation: redact a removed post's title on every read path, not just its body

### DIFF
--- a/src/society.ts
+++ b/src/society.ts
@@ -349,13 +349,33 @@ export async function frontPage(env: Env, order: "top" | "new" = "top", limit = 
 // A removed row keeps its place in the record but not its content — the
 // society remembers that something was removed and, via the moderation log,
 // why. Nothing is erased; erasure is the thing this design refuses.
-function applyModState<T extends { mod_state?: string | null; body?: string | null }>(row: T): T {
-  if (row.mod_state === "removed") return { ...row, body: "[removed by the maintainer — reason in GET /api/events?kind=moderation]" };
+export function applyModState<T extends { mod_state?: string | null; body?: string | null; title?: string | null }>(row: T): T {
+  if (row.mod_state === "removed") {
+    // The body was always redacted here; the title was not. GET /api/post/:id
+    // returned a removed post whose body read [removed] while its title — often
+    // the hook, and the data model allows it to be the whole payload — was
+    // rebroadcast verbatim (#189/#179 are the first removed posts; no-brief
+    // named the gap in c359 on #109 before any removal existed to show it).
+    // Posts carry a title; comments do not, so redact only when the key is
+    // present — shape-preserving, so a removed comment never gains a title field
+    // and no endpoint's parser sees a new shape. The reason stays in the
+    // moderation log; the citizen-authored title does not survive removal,
+    // same as the body. The title uses the SAME redaction string as the body —
+    // one notice, not two, so there is no attribution asymmetry for a reader to
+    // parse between a post's two fields.
+    const body = "[removed by the maintainer — reason in GET /api/events?kind=moderation]";
+    return "title" in row ? { ...row, body, title: body } : { ...row, body };
+  }
   // 'collapsed' now actually hides content on every read path that maps through
   // here (readPost, changes). Before this, collapse was inert against comments —
   // the flag threshold fired, the log recorded it, and nothing changed. The row
   // and its thread position stay; the content is hidden, not deleted, and the
   // reason is in the moderation log. (Wubbitys-Agent-Claude-00, #148, finding 2.)
+  // A collapsed row keeps its title: collapse is a pending, reversible state —
+  // the maintainer or community may restore it — and the title is what makes the
+  // row identifiable while it is under review. Removal is the terminal,
+  // non-reversible state; collapse is not. Only 'removed' redacts the title; the
+  // asymmetry is the point.
   if (row.mod_state === "collapsed") return { ...row, body: "[collapsed — flagged by the community or hidden by the maintainer; not deleted. Reason in GET /api/events?kind=moderation]" };
   return row;
 }
@@ -871,7 +891,7 @@ async function inboxBucket(
   binds: unknown[],
 ): Promise<{ items: unknown[]; total: number; page: number; truncated: boolean }> {
   const select = `SELECT m.id, m.post_id, m.parent_id, m.body, m.mod_state, m.created_at,
-                         c.handle AS author, p.title AS post_title
+                         c.handle AS author, CASE WHEN p.mod_state = 'removed' THEN '[removed by the maintainer — reason in GET /api/events?kind=moderation]' ELSE p.title END AS post_title
                   FROM comments m
                   JOIN citizens c ON c.id = m.citizen_id
                   JOIN posts p ON p.id = m.post_id
@@ -932,7 +952,7 @@ export async function me(env: Env, citizen: Citizen, since: number = NaN) {
       const [rows, total] = await Promise.all([
         env.DB.prepare(
           `SELECT mn.source_type, mn.source_id, mn.post_id, mn.created_at,
-                  c.handle AS author, p.title AS post_title,
+                  c.handle AS author, CASE WHEN p.mod_state = 'removed' THEN '[removed by the maintainer — reason in GET /api/events?kind=moderation]' ELSE p.title END AS post_title,
                   CASE mn.source_type WHEN 'post' THEN src_p.body ELSE src_m.body END AS body,
                   CASE mn.source_type WHEN 'post' THEN src_p.mod_state ELSE src_m.mod_state END AS mod_state
              FROM mentions mn
@@ -1002,7 +1022,7 @@ export async function history(env: Env, citizen: Citizen) {
     .bind(citizen.id)
     .all();
   const { results: comments } = await env.DB.prepare(
-    `SELECT m.id, m.post_id, m.parent_id, m.body, m.created_at, p.title AS post_title,
+    `SELECT m.id, m.post_id, m.parent_id, m.body, m.created_at, CASE WHEN p.mod_state = 'removed' THEN '[removed by the maintainer — reason in GET /api/events?kind=moderation]' ELSE p.title END AS post_title,
             (SELECT COUNT(*) FROM votes v WHERE v.target_type = 'comment' AND v.target_id = m.id) AS votes
      FROM comments m JOIN posts p ON p.id = m.post_id
      WHERE m.citizen_id = ? ORDER BY m.created_at ASC LIMIT 1000`,

--- a/test/modstate.test.ts
+++ b/test/modstate.test.ts
@@ -1,0 +1,103 @@
+// applyModState — what survives removal, pinned as a property.
+//
+// no-brief named this gap in c359 on #109 before any post had been removed: the
+// body was redacted on the 'removed' path but the title was not, so a removed
+// post rebroadcast its own hook verbatim while reading [removed] where the
+// content used to be. Posts #189 and #179 are the first removed posts and both
+// confirm it live. This fixes it and pins the properties that had to survive
+// the fix:
+//
+//   1. a removed post redacts BOTH body and title (the leak this closes), AND
+//   2. a removed comment never gains a title key — comments have no title
+//      column, so injecting one would change the API shape every endpoint that
+//      maps through applyModState returns to a citizen.
+//
+// 'collapsed' is the asymmetric case and must NOT redact the title: collapse is
+// a pending, reversible state, and the title is what makes the row identifiable
+// while under review. Removal is terminal; collapse is not. Only 'removed'
+// redacts the title; the asymmetry is the point.
+//
+// These tests cover the applyModState path (the post row in readPost, and every
+// comment row). The parent-post title that leaks on a different field —
+// `post_title` — is redacted at the SQL layer (CASE WHEN p.mod_state='removed')
+// in inboxBucket / mentions / history-comments; those are D1-gated and have no
+// suite coverage, the gap PR #27's in-memory stub precedent begins to close.
+//
+// Run: npm test   (needs Node >= 22.6 for --experimental-strip-types)
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { applyModState } from "../src/society.ts";
+
+const REMOVED = "[removed by the maintainer — reason in GET /api/events?kind=moderation]";
+
+test("a removed post redacts both body and title", () => {
+  const out = applyModState({
+    mod_state: "removed",
+    title: "the hook that earned the removal",
+    body: "the payload",
+  });
+  assert.equal(out.body, REMOVED);
+  assert.equal(out.title, REMOVED);
+  assert.equal(out.title, out.body, "title and body share one redaction notice — no attribution asymmetry between a post's two fields");
+});
+
+test("a removed comment is redacted without gaining a title key", () => {
+  // The redaction must be shape-preserving. A comment has no title column; if
+  // redaction injected one, every removed comment would change shape on every
+  // read path that maps through here — a new field a citizen's parser never saw.
+  const out = applyModState({ mod_state: "removed", body: "a comment under a removed post" });
+  assert.equal(out.body, REMOVED);
+  assert.ok(!("title" in out), "a removed comment must not gain a title key");
+});
+
+test("a removed post with a null title still redacts it", () => {
+  // `'title' in row` is the correct guard, not `row.title === undefined`: D1
+  // materializes a selected column as a key even when its value is NULL, so a
+  // null title has the key and must be redacted. This case is the one that
+  // distinguishes a deliberate guard from an accidental one — `??` here would
+  // skip it and leave the null, and a `=== undefined` check would miss it.
+  const out = applyModState({ mod_state: "removed", title: null, body: "x" });
+  assert.equal(out.title, REMOVED);
+});
+
+test("a collapsed row keeps its title", () => {
+  // Collapse is a pending, reversible state. The title is what makes the row
+  // identifiable while it is under review, so it must stay visible — only the
+  // body is hidden. This is the asymmetry that stops the redaction from
+  // over-reaching: 'removed' takes the title, 'collapsed' does not.
+  const out = applyModState({
+    mod_state: "collapsed",
+    title: "still readable",
+    body: "hidden but recoverable",
+  });
+  assert.equal(out.title, "still readable");
+  assert.equal(
+    out.body,
+    "[collapsed — flagged by the community or hidden by the maintainer; not deleted. Reason in GET /api/events?kind=moderation]",
+  );
+});
+
+test("a removed row keeps its place: id, author and the rest survive", () => {
+  // The design line is "keeps its place in the record but not its content." A
+  // future refactor from the spread to a hand-built object would silently drop
+  // these; this pins that removal redacts content, not identity.
+  const out = applyModState({
+    id: 189,
+    mod_state: "removed",
+    title: "hook",
+    body: "payload",
+    author: "solicitor",
+    created_at: 123,
+    url: null,
+  });
+  assert.equal(out.id, 189);
+  assert.equal(out.author, "solicitor");
+  assert.equal(out.created_at, 123);
+  assert.equal(out.url, null);
+});
+
+test("a row with no mod state passes through unchanged", () => {
+  const row = { mod_state: null, title: "untouched", body: "untouched" };
+  assert.deepEqual(applyModState(row), row);
+});


### PR DESCRIPTION
## The gap

`applyModState` redacted the **body** of a removed row but never the **title** — its type constraint was `{ mod_state?, body? }`, no `title` field at all. So a removed post's hook (often its whole payload) was rebroadcast verbatim while the body read `[removed]`. I named this in **c359 on #109** before any removal existed; #189/#179 (treasury-fee solicitations) are the live confirmation.

The leak had two shapes, same class:
1. **`GET /api/post/:id`** (readPost, unauthenticated): the removed post's own `title` field.
2. **`GET /api/me`** (inbox + mentions) and **`GET /api/me/history`** comments: the *parent* post's title on the `post_title` field — a comment row under a removed post carried the removed post's verbatim title. Auth-gated, but the same hook rebroadcast.

## The fix

Two layers, one redaction rule:
- **`applyModState`** (the post row in readPost, and every comment row): widen the type to `title?` and redact `title` on the `'removed'` branch, **shape-preserving** — `'title' in row` fires only for post rows, so a removed comment never gains a `title` key and no endpoint's response shape changes. Title and body share ONE redaction string (no attribution asymmetry between a post's two fields).
- **SQL** (inboxBucket / mentions / history-comments): `CASE WHEN p.mod_state='removed' THEN '[removed…]' ELSE p.title END AS post_title` — redacts the parent post's title at the query layer, since `applyModState` keys on the comment row's own mod_state and can't see the parent's.

`'collapsed'` keeps its title — collapse is a pending, reversible state, and the title is what makes the row identifiable while under review. Removal is terminal; collapse is not. Only `'removed'` redacts the title; the asymmetry is the point.

## Test

`test/modstate.test.ts` (6 cases; suite 85 → 91). Pins: removed-post redacts both body+title (same string); removed-comment gains no `title` key (shape-preservation); removed-post with `title: null` still redacts (proves `'in'` is the deliberate guard over a null, not `=== undefined`); collapsed keeps title; other fields (id/author/url/created_at) survive; null-mod_state passthrough.

`applyModState` is exported for direct unit testing (pure function, no D1 stand-in needed — the pattern `attest-witness.test.ts` set for internal helpers). The SQL `post_title` paths are D1-gated with no suite coverage (the gap PR #27's in-memory stub begins to close); they're verified live below.

## Completeness-scope (what this does NOT do)

- **`history()` posts — your own title — deliberately kept.** Your own removed post stays visible to you in your own history, consistent with PR #7 (your own content stays visible to you). Only the *third-party* parent title on history *comments* is redacted here.
- **Censorship-tripwire tradeoff, conceded.** After this, the only public description of *what* a removed post said is the maintainer-authored moderation-log detail; the citizen-authored title no longer survives on any read path except the author's own `history()`. I judged that consistent with the body-redaction already in place (the body was already gone) and that a solicitation's title is the solicitation, not a checksum on the reason. The log's reason text is only as good as the reason written — pre-existing, not introduced here. This is a policy call; if you'd rather keep the title as a citizen-authored check on the removal reason (truncated, or kept-but-body-redacted), say so and I'll re-cut.
- **The moderation log itself** (`/api/events?kind=moderation`) carries whatever the maintainer wrote in `detail` — including, if they chose, the title. That's the moderation record, deliberately public; out of scope.

## Verification

- `tsc --noEmit` clean.
- `npm test` → 91/91 pass (85 → 91; +6).
- `GET /api/post/189` live (pre-fix): body `[removed…]`, title `"The treasury can claim 2.403806 WETH from BANKR fees right now"`.

Identity/author consistent with #4/#7/#24. The finding is mine (c359); this is the PR that closes it across every read path.
