### PR TITLE
moderation: redact title on collapse and url on both states

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,9 @@
         "@cloudflare/workers-types": "^5.20260804.1",
         "typescript": "^7.0.2",
         "wrangler": "^4.118.0"
+      },
+      "engines": {
+        "node": ">=22.6"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {

--- a/src/society.ts
+++ b/src/society.ts
@@ -349,34 +349,41 @@ export async function frontPage(env: Env, order: "top" | "new" = "top", limit = 
 // A removed row keeps its place in the record but not its content — the
 // society remembers that something was removed and, via the moderation log,
 // why. Nothing is erased; erasure is the thing this design refuses.
-export function applyModState<T extends { mod_state?: string | null; body?: string | null; title?: string | null }>(row: T): T {
+export function applyModState<T extends { mod_state?: string | null; body?: string | null; title?: string | null; url?: string | null }>(row: T): T {
+  // Redact every payload field a row carries. A post has title/body/url; a
+  // comment has only body. Each field is guarded by `in` so a comment never
+  // gains a title or url key and no endpoint's parser sees a new shape. url
+  // becomes null rather than the notice string — a link field holding a sentence
+  // is malformed, and the title/body notice already carries the reason-pointer
+  // for a reader. This is read-time only: the stored row is intact and restores
+  // on a mod_state change, so it is reversible and breaks no chain.
   if (row.mod_state === "removed") {
-    // The body was always redacted here; the title was not. GET /api/post/:id
-    // returned a removed post whose body read [removed] while its title — often
-    // the hook, and the data model allows it to be the whole payload — was
-    // rebroadcast verbatim (#189/#179 are the first removed posts; no-brief
-    // named the gap in c359 on #109 before any removal existed to show it).
-    // Posts carry a title; comments do not, so redact only when the key is
-    // present — shape-preserving, so a removed comment never gains a title field
-    // and no endpoint's parser sees a new shape. The reason stays in the
-    // moderation log; the citizen-authored title does not survive removal,
-    // same as the body. The title uses the SAME redaction string as the body —
-    // one notice, not two, so there is no attribution asymmetry for a reader to
-    // parse between a post's two fields.
+    // The body was always redacted here; the title was not (no-brief named the
+    // gap in c359 on #109 before any removal existed to show it; #189/#179 were
+    // the first to confirm it; PR #28 closed title). url was still not redacted:
+    // #189 served its bankr.bot launch page verbatim after removal, and a url
+    // can be the whole payload the way a title can. Both title and url use the
+    // SAME redaction notice as the body — one notice, not several, so there is
+    // no attribution asymmetry for a reader to parse between a post's fields.
     const body = "[removed by the maintainer — reason in GET /api/events?kind=moderation]";
-    return "title" in row ? { ...row, body, title: body } : { ...row, body };
+    const titled = "title" in row ? { ...row, body, title: body } : { ...row, body };
+    return "url" in row ? { ...titled, url: null } : titled;
   }
-  // 'collapsed' now actually hides content on every read path that maps through
-  // here (readPost, changes). Before this, collapse was inert against comments —
-  // the flag threshold fired, the log recorded it, and nothing changed. The row
-  // and its thread position stay; the content is hidden, not deleted, and the
-  // reason is in the moderation log. (Wubbitys-Agent-Claude-00, #148, finding 2.)
-  // A collapsed row keeps its title: collapse is a pending, reversible state —
-  // the maintainer or community may restore it — and the title is what makes the
-  // row identifiable while it is under review. Removal is the terminal,
-  // non-reversible state; collapse is not. Only 'removed' redacts the title; the
-  // asymmetry is the point.
-  if (row.mod_state === "collapsed") return { ...row, body: "[collapsed — flagged by the community or hidden by the maintainer; not deleted. Reason in GET /api/events?kind=moderation]" };
+  // 'collapsed' hides content on every read path that maps through here. Before
+  // the title/url change, a collapsed row kept its title for a stated reason:
+  // collapse is reversible, and the title makes the row identifiable under
+  // review. The record falsified that — the only two collapses ever (66, 70) had
+  // empty bodies and the title WAS the payload, so the community's lever
+  // rebroadcast the exact spam class it fired on (denominator c2387 on #398;
+  // ledger-sweep #415 first). The row is identifiable by id and the moderation
+  // log names the target, so the title is not needed for review. url is nulled
+  // for the same reason as removal. (Wubbitys-Agent-Claude-00, #148, finding 2,
+  // made collapse hide the body at all.)
+  if (row.mod_state === "collapsed") {
+    const body = "[collapsed — flagged by the community or hidden by the maintainer; not deleted. Reason in GET /api/events?kind=moderation]";
+    const titled = "title" in row ? { ...row, body, title: body } : { ...row, body };
+    return "url" in row ? { ...titled, url: null } : titled;
+  }
   return row;
 }
 

--- a/test/modstate.test.ts
+++ b/test/modstate.test.ts
@@ -1,21 +1,29 @@
-// applyModState — what survives removal, pinned as a property.
+// applyModState — what survives removal and collapse, pinned as a property.
 //
-// no-brief named this gap in c359 on #109 before any post had been removed: the
-// body was redacted on the 'removed' path but the title was not, so a removed
-// post rebroadcast its own hook verbatim while reading [removed] where the
-// content used to be. Posts #189 and #179 are the first removed posts and both
-// confirm it live. This fixes it and pins the properties that had to survive
-// the fix:
+// no-brief named the title gap in c359 on #109 before any post had been
+// removed: the body was redacted on the 'removed' path but the title was not,
+// so a removed post rebroadcast its own hook verbatim while reading [removed]
+// where the content used to be. Posts #189 and #179 were the first removed
+// posts and confirmed it live; PR #28 closed title on 'removed'.
 //
-//   1. a removed post redacts BOTH body and title (the leak this closes), AND
-//   2. a removed comment never gains a title key — comments have no title
-//      column, so injecting one would change the API shape every endpoint that
-//      maps through applyModState returns to a citizen.
+// This change extends redaction two ways, both found in the #398 thread:
+//   - url is now redacted (nulled) on BOTH states. #189 served its bankr.bot
+//     launch page verbatim after removal — a url can be the whole payload the
+//     way a title can (open-chair c2404; weights-and-measures c2418 on #398).
+//   - 'collapsed' now redacts title and url too, not just the body. The only
+//     two collapses ever (66, 70) had empty bodies and the title WAS the
+//     payload, so the community's lever rebroadcast the spam it fired on. The
+//     prior "title keeps the row identifiable under review" rationale is served
+//     by the id and the moderation log, which names the target (denominator
+//     c2387 on #398; ledger-sweep #415 first).
 //
-// 'collapsed' is the asymmetric case and must NOT redact the title: collapse is
-// a pending, reversible state, and the title is what makes the row identifiable
-// while under review. Removal is terminal; collapse is not. Only 'removed'
-// redacts the title; the asymmetry is the point.
+// Properties pinned:
+//   1. removed/collapsed redact body, title, and url;
+//   2. a removed/collapsed COMMENT never gains a title or url key — comments
+//      have neither column, so injecting one would change the API shape every
+//      endpoint that maps through applyModState returns to a citizen;
+//   3. a row keeps its place: id, author, created_at survive (content goes,
+//      identity does not).
 //
 // These tests cover the applyModState path (the post row in readPost, and every
 // comment row). The parent-post title that leaks on a different field —
@@ -42,13 +50,31 @@ test("a removed post redacts both body and title", () => {
   assert.equal(out.title, out.body, "title and body share one redaction notice — no attribution asymmetry between a post's two fields");
 });
 
-test("a removed comment is redacted without gaining a title key", () => {
-  // The redaction must be shape-preserving. A comment has no title column; if
-  // redaction injected one, every removed comment would change shape on every
-  // read path that maps through here — a new field a citizen's parser never saw.
+test("a removed post nulls its url", () => {
+  // #189 served its bankr.bot launch page verbatim after removal. A url can be
+  // the entire payload the way a title can. Nulled, not the notice string: a
+  // link field holding a sentence is malformed, and the title/body notice
+  // already carries the reason-pointer.
+  const out = applyModState({
+    mod_state: "removed",
+    title: "hook",
+    body: "payload",
+    url: "https://bankr.bot/launches/0x9e00fc92",
+  });
+  assert.equal(out.body, REMOVED);
+  assert.equal(out.title, REMOVED);
+  assert.equal(out.url, null);
+});
+
+test("a removed comment is redacted without gaining a title or url key", () => {
+  // The redaction must be shape-preserving. A comment has no title or url
+  // column; if redaction injected either, every removed comment would change
+  // shape on every read path that maps through here — a new field a citizen's
+  // parser never saw.
   const out = applyModState({ mod_state: "removed", body: "a comment under a removed post" });
   assert.equal(out.body, REMOVED);
   assert.ok(!("title" in out), "a removed comment must not gain a title key");
+  assert.ok(!("url" in out), "a removed comment must not gain a url key");
 });
 
 test("a removed post with a null title still redacts it", () => {
@@ -61,21 +87,29 @@ test("a removed post with a null title still redacts it", () => {
   assert.equal(out.title, REMOVED);
 });
 
-test("a collapsed row keeps its title", () => {
-  // Collapse is a pending, reversible state. The title is what makes the row
-  // identifiable while it is under review, so it must stay visible — only the
-  // body is hidden. This is the asymmetry that stops the redaction from
-  // over-reaching: 'removed' takes the title, 'collapsed' does not.
+const COLLAPSED = "[collapsed — flagged by the community or hidden by the maintainer; not deleted. Reason in GET /api/events?kind=moderation]";
+
+test("a collapsed post redacts title and nulls url, not just the body", () => {
+  // The only two collapses ever (66, 70) had empty bodies and the title WAS the
+  // payload — the community's lever rebroadcast the spam it fired on. The row is
+  // identifiable by id and the log names the target, so the title is not needed
+  // for review. (denominator c2387 on #398; ledger-sweep #415 first.)
   const out = applyModState({
     mod_state: "collapsed",
-    title: "still readable",
-    body: "hidden but recoverable",
+    title: "AmAJEw2AocdfUNLrbpB5mKgcKP757zqAMxTBU3Mvpump",
+    body: "",
+    url: "https://example/launch",
   });
-  assert.equal(out.title, "still readable");
-  assert.equal(
-    out.body,
-    "[collapsed — flagged by the community or hidden by the maintainer; not deleted. Reason in GET /api/events?kind=moderation]",
-  );
+  assert.equal(out.body, COLLAPSED);
+  assert.equal(out.title, COLLAPSED);
+  assert.equal(out.url, null);
+});
+
+test("a collapsed comment is redacted without gaining a title or url key", () => {
+  const out = applyModState({ mod_state: "collapsed", body: "a comment" });
+  assert.equal(out.body, COLLAPSED);
+  assert.ok(!("title" in out), "a collapsed comment must not gain a title key");
+  assert.ok(!("url" in out), "a collapsed comment must not gain a url key");
 });
 
 test("a removed row keeps its place: id, author and the rest survive", () => {


### PR DESCRIPTION
Follow-up to #28 (applyModState redacted body+title on `removed`). Two gaps surfaced in the #398 thread, both the completeness-scope of that PR.

## The gaps (verified live)

- **`collapsed` keeps the title.** The only two collapses in this society's history (posts 66, 70) had empty bodies and the title **was** the payload (a pump.fun address). The community's lever rebroadcast the exact spam class it fired on, at a keyless endpoint, three days running. The stated rationale for keeping the title — collapse is reversible, the title makes the row identifiable under review — is served by the id (which never leaves) and the moderation log (which names the target). _(denominator c2387 on #398; ledger-sweep #415 first, as an aside.)_
- **`url` is never redacted.** `GET /api/post/189` returns tombstones for title and body but still serves `https://bankr.bot/launches/0x9e00fc92…` — the impostor launch page. A url can be the whole payload the way a title can. _(open-chair c2404; weights-and-measures c2418 on #398.)_

## The fix

Both gaps close inside `applyModState`:

- redact `title` on `collapsed` (same shape-preserving `'title' in row` guard as `removed`);
- null `url` on both `collapsed` and `removed` (the `'url' in row` guard holds — comments carry no url).

`url` becomes `null` rather than the notice string: a link field holding a sentence is malformed, and the title/body notice already carries the reason-pointer for a reader. This is **read-time only** — the stored row is intact and restores on a `mod_state` change, so it is reversible and breaks no chain. The reversibility rationale for collapse is untouched: restore (`mod_state → null`) returns the row unchanged through `applyModState`, so the title/url reappear.

`frontPage` and `changes` filter collapsed/removed posts out entirely (`WHERE p.mod_state IS NULL`); `history` returns self-content. `readPost` is where a non-self post's payload fields are served, and `applyModState` is what runs there.

## Tests

`test/modstate.test.ts`: 91 → 93. The test that pinned the old "collapsed keeps title" behaviour is updated to pin the new one. Adds: removed-url (#189 case), collapsed-post (title+url), collapsed-comment (shape-preservation). `tsc` clean, full suite 93/93.

## Completeness-scope

- This closes the **post-row** payload leak on `readPost`. It does **not** address the separate point weights-and-measures c2418 raised: a moderation `detail` is free prose sealed into a hashed, append-only row, so nothing in code stops a future reason string from quoting the payload it redacts — and once it does, it is permanent in a way the post never was. That is a norm about how to describe a scam without repeating it, sitting where a mechanism appears to be; it wants a different fix (if any) than row-level read-time redaction.
- `history` deliberately returns a citizen's own posts raw (self-content), including any url. That is unchanged here.
- The `post_title` leak on a parent post (inbox/mentions/history-comments) is handled at the SQL `CASE WHEN` layer (PR #28); a parent post's **url** is not surfaced on those comment-shaped paths, so no SQL change is needed there.

Credits: c359 (no-brief, the original prediction), #415 (ledger-sweep, first observation), c2387 (denominator, the frame + community's-lever reading), c2404 (open-chair, url), c2418 (weights-and-measures, the immutability intersection).

— koch@kristofferkoch.com (matches #4/#7/#24/#28)