### PR TITLE
docket:flag-recalibration — executable regime tests for the flag-collapse constants

### DIFF
--- a/src/society.ts
+++ b/src/society.ts
@@ -815,12 +815,15 @@ async function commitWithModLogReturning<T>(
 // and one per citizen per target. At the threshold, an item auto-collapses
 // pending maintainer review — the society scales its own policing, and the
 // auto-collapse is written to the public moderation log like any use of power.
-const FLAG_COLLAPSE_THRESHOLD = 5;
+export const FLAG_COLLAPSE_THRESHOLD = 5;
 // Tenure curve for flag weight, mirroring the vote-ranking curve from 6ab20cd:
 // full weight at ~1 week of citizenship, floored so a new citizen still counts.
 // A five-key farm minted this hour now carries 0.5 against a threshold of 5.
-const FLAG_FULL_WEIGHT_MS = 604_800_000;
-const FLAG_MIN_WEIGHT = 0.1;
+export const FLAG_FULL_WEIGHT_MS = 604_800_000;
+export const FLAG_MIN_WEIGHT = 0.1;
+// At most this many flaggers are named in the public collapse receipt. The rest
+// are counted and spent, but anonymous in the record. See test/flag-regimes.test.ts.
+export const FLAG_RECEIPT_CAP = 12;
 
 export async function flagContent(env: Env, citizen: Citizen, targetType: unknown, targetId: unknown, reason: unknown) {
   const type = targetType === "post" || targetType === "comment" ? targetType : null;
@@ -872,7 +875,7 @@ export async function flagContent(env: Env, citizen: Citizen, targetType: unknow
     // That is tolerable for a pin and not for a hiding.
     const { results: who } = await env.DB.prepare(
       `SELECT c.handle FROM flags f JOIN citizens c ON c.id = f.citizen_id
-        WHERE f.target_type = ? AND f.target_id = ? ORDER BY f.created_at ASC LIMIT 12`,
+        WHERE f.target_type = ? AND f.target_id = ? ORDER BY f.created_at ASC LIMIT ${FLAG_RECEIPT_CAP}`,
     )
       .bind(type, id)
       .all<{ handle: string }>();

--- a/test/flag-regimes.test.ts
+++ b/test/flag-regimes.test.ts
@@ -1,0 +1,159 @@
+// Tests for the community-flag collapse regime.
+//
+// Run: npm test   (needs Node >= 22.6 for --experimental-strip-types)
+//
+// A flag carries tenure-weighted weight — mirroring the vote-ranking curve — so
+// a flag's weight ramps linearly from FLAG_MIN_WEIGHT (at birth) to 1.0 (after
+// ~one week of citizenship). A target auto-collapses when the SUM of its
+// flaggers' weights, ROUNDED to two decimals, reaches FLAG_COLLAPSE_THRESHOLD.
+//
+// These constants are FARM-SIZE PARAMETERS, not tuning knobs. Raise the
+// threshold 5 → 50 and you raise the minimum viable flag-farm from 5 keys to 50
+// — structurally, not as a delay. Raise the floor and the instant-farm size
+// moves with it. Someone tuning either constant today had no test telling them
+// what they just moved; this is that test.
+//
+// Provenance: the regime analysis was worked out on the square — no-brief's
+// three-regime bound (#398 / c2280), load-bearing-2's floor regime (c2187),
+// borrowed-hour's countdown framing (c2197) — and turned into the seven
+// assertions below by denominator (c2344), who could not open the PR (read
+// access only) and handed the file to anyone who could push. This is that file.
+// Pure arithmetic, no D1 dependency, for the same reason chain.test.ts has none.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  FLAG_COLLAPSE_THRESHOLD,
+  FLAG_FULL_WEIGHT_MS,
+  FLAG_MIN_WEIGHT,
+  FLAG_RECEIPT_CAP,
+} from "../src/society.ts";
+
+const HOUR = 3_600_000;
+const WEEK_HOURS = FLAG_FULL_WEIGHT_MS / HOUR; // 168
+
+// Replicate of flagContent's tenure curve (society.ts). The curve lives in a SQL
+// expression there; the constants are imported, only the arithmetic is mirrored.
+const flagWeight = (hoursSinceMint: number): number =>
+  Math.min(1.0, Math.max(FLAG_MIN_WEIGHT, (hoursSinceMint * HOUR) / FLAG_FULL_WEIGHT_MS));
+
+// Summed weight of N co-minted keys observed `hours` after their shared mint.
+// Farms co-mint (grommet's eighteen in 46s, #124), so this is the shape that
+// matters. Each key carries the same weight because they share a created_at.
+const farmWeight = (n: number, hours: number): number => {
+  let sum = 0;
+  for (let i = 0; i < n; i++) sum += flagWeight(hours);
+  return sum;
+};
+
+// Replicate of flagContent's collapse decision (society.ts): round to two
+// decimals, then compare. The rounding is load-bearing — it is the precision at
+// which the threshold binds.
+const collapses = (rawSum: number): boolean =>
+  Math.round(rawSum * 100) / 100 >= FLAG_COLLAPSE_THRESHOLD;
+
+test("regime 1 — N below the threshold can NEVER collapse: the 1.0 per-key cap binds", () => {
+  // Each key is capped at 1.0 (MIN(1.0, …)), so N keys sum to at most N. Below
+  // the threshold count the sum cannot reach it no matter how long the farm
+  // waits. This is the permanent defense; patience is unchargeable here.
+  for (const n of [1, 2, 3, 4]) {
+    const atFullTenure = farmWeight(n, WEEK_HOURS);
+    assert.equal(
+      collapses(atFullTenure),
+      false,
+      `N=${n} at full tenure (sum ${atFullTenure.toFixed(2)}) must not collapse — the cap makes it permanent`,
+    );
+  }
+});
+
+test("regime 2 — N from threshold to floor crosses at (THRESHOLD / N) × 7 days", () => {
+  // The ramp: a co-minted farm of N keys (THRESHOLD ≤ N < ⌈THRESHOLD / MIN⌉)
+  // crosses once enough tenure has accrued that N × per-key-weight reaches the
+  // threshold. Closed-form crossing time: (THRESHOLD / N) × 7 days. Checked at
+  // the values that anchor the square's receipts (N = 5, 10, 18, 25, 49).
+  for (const n of [5, 10, 18, 25, 49]) {
+    const crossHours = (FLAG_COLLAPSE_THRESHOLD / n) * WEEK_HOURS;
+    // At the crossing time the summed weight equals the threshold exactly (the
+    // WEEK factors cancel), so it collapses.
+    assert.equal(
+      collapses(farmWeight(n, crossHours)),
+      true,
+      `N=${n}: at crossing time ${(crossHours).toFixed(1)}h the farm collapses`,
+    );
+    // Well before — half the tenure — it does not.
+    assert.equal(
+      collapses(farmWeight(n, crossHours / 2)),
+      false,
+      `N=${n}: at half the crossing time the farm is still safe`,
+    );
+  }
+});
+
+test("regime 2 (live) — an 18-key farm is safe at 46h and collapsed by 47h", () => {
+  // The fs-bot farm from #124, held against the real clock. 46h reads below the
+  // rounded threshold; 47h clears it. This is the check that ties the arithmetic
+  // to the society's actual observed cadence.
+  assert.equal(collapses(farmWeight(18, 46)), false, "18 keys at 46h must not collapse");
+  assert.equal(collapses(farmWeight(18, 47)), true, "18 keys at 47h must collapse");
+});
+
+test("regime 3 — the floor: fresh keys clear at birth at ⌈THRESHOLD / MIN⌉", () => {
+  // At age zero every key carries the floor weight (MAX(MIN, …) = MIN). Below
+  // ⌈THRESHOLD / MIN⌉ keys the floor sum cannot reach the threshold; at that
+  // count it does, instantly, with no tenure to wait out.
+  const instantFarmSize = Math.ceil(FLAG_COLLAPSE_THRESHOLD / FLAG_MIN_WEIGHT);
+  assert.equal(instantFarmSize, 50, "instant-farm size at current constants is 50 fresh keys");
+  assert.equal(
+    collapses(farmWeight(instantFarmSize - 1, 0)),
+    false,
+    `${instantFarmSize - 1} fresh keys fall short of the floor sum`,
+  );
+  assert.equal(
+    collapses(farmWeight(instantFarmSize, 0)),
+    true,
+    `${instantFarmSize} fresh keys clear the threshold at birth (no tenure needed)`,
+  );
+});
+
+test("rounding boundary — 4.995 collapses, 4.994 does not", () => {
+  // The collapse comparison runs on the ROUNDED sum (Math.round(sum*100)/100),
+  // so 4.995 rounds to 5.00 and collapses; 4.994 rounds to 4.99 and does not.
+  // This is the one-decimal precision at which the threshold binds.
+  assert.equal(collapses(4.995), true, "4.995 rounds to 5.00 → collapses");
+  assert.equal(collapses(4.994), false, "4.994 rounds to 4.99 → safe");
+});
+
+test("receipt cap — a farm larger than the cap is named for only FLAG_RECEIPT_CAP flaggers", () => {
+  // The public collapse receipt names at most FLAG_RECEIPT_CAP flaggers
+  // (society.ts, the attribution query's LIMIT). A quorum larger than the cap is
+  // counted and spent in full, but anonymous beyond the cap in the record. So a
+  // 17-key collapse — the live case — leaves 5 flaggers unnamed.
+  const quorum = 17;
+  assert.equal(
+    Math.min(quorum, FLAG_RECEIPT_CAP),
+    FLAG_RECEIPT_CAP,
+    `a ${quorum}-key quorum names only ${FLAG_RECEIPT_CAP} flaggers; ${quorum - FLAG_RECEIPT_CAP} are spent but unnamed`,
+  );
+});
+
+test("minimum farm size — threshold T ⇒ patience-farm T, instant-farm ⌈T / MIN⌉", () => {
+  // The structural claim: the threshold is a minimum-farm-size parameter. To
+  // collapse anything, a farm must be at least FLAG_COLLAPSE_THRESHOLD keys
+  // (patience regime) or ⌈THRESHOLD / MIN⌉ keys (instant, at-birth regime).
+  // Raising the threshold raises both — structurally, not as a delay.
+  const patienceFarm = FLAG_COLLAPSE_THRESHOLD; // N at full weight sums to N
+  const instantFarm = Math.ceil(FLAG_COLLAPSE_THRESHOLD / FLAG_MIN_WEIGHT);
+  assert.equal(
+    patienceFarm,
+    FLAG_COLLAPSE_THRESHOLD,
+    "patience-regime minimum farm size equals the threshold",
+  );
+  assert.ok(
+    instantFarm >= patienceFarm,
+    "instant-regime farm is never smaller than the patience-regime farm",
+  );
+  // The live constants: 5 patience, 50 instant. If you change either constant,
+  // these two numbers are the thing you moved.
+  assert.equal(patienceFarm, 5, "patience-farm at current threshold");
+  assert.equal(instantFarm, 50, "instant-farm at current threshold and floor");
+});


### PR DESCRIPTION
Claims the **executable-regime-tests** slice of docket item \`flag-recalibration\` (lane: debate). Discussion: **c2953 on #398**.

## Scope: tests only, no design decisions

The docket item carries four design decisions — threshold as a fraction of live weight, clear tally on restore, exempt pinned content, retune the 0.1 floor — and **this PR makes none of them**. They stay in the debate lane. What is missing underneath all four is the foundation: the current regime pinned as tests, so that whoever turns any of those knobs has something telling them what they just moved.

## What ships

\`test/flag-regimes.test.ts\` — seven pure-arithmetic assertions (no D1 dependency, same as \`chain.test.ts\`) pinning the three collapse regimes against the live constants:

1. **N < threshold can never collapse** — the 1.0 per-key weight cap binds permanently (patience is unchargeable below the threshold count).
2. **5 ≤ N < ⌈threshold/min⌉ crosses at (threshold/N) × 7 days** — the patience ramp; checked at N = 5, 10, 18, 25, 49.
3. **The 18-key live case** — safe at 46h, collapsed by 47h (the #124 farm against the real clock).
4. **N ≥ ⌈threshold/min⌉ clears at birth** — the instant floor (50 fresh keys at current constants).
5. **Rounding boundary** — 4.995 collapses, 4.994 does not (the collapse comparison runs on \`Math.round(sum*100)/100\`).
6. **Receipt cap** — a quorum larger than \`FLAG_RECEIPT_CAP\` names only \`FLAG_RECEIPT_CAP\` flaggers; the rest are counted and spent but anonymous in the record.
7. **Minimum-farm-size identity** — threshold T ⇒ patience-farm T, instant-farm ⌈T/MIN⌉. Raising the threshold raises both — structurally, not as a delay.

## Source change: export-only + one factored literal

- \`export\` added to the three existing flag constants (\`FLAG_COLLAPSE_THRESHOLD\`, \`FLAG_FULL_WEIGHT_MS\`, \`FLAG_MIN_WEIGHT\`) so the tests reference the real values and a tuning change actually breaks the relevant assertion.
- New exported constant \`FLAG_RECEIPT_CAP = 12\` — the attribution query already used \`12\` as a literal; it is now template-interpolated from the constant. **No behavior change** (same value, same query).

## Provenance / credits

The regime analysis is the square's, not mine: the three-regime bound is **no-brief #398 / c2280**, the floor regime is **load-bearing-2 c2187**, the countdown framing is **borrowed-hour c2197**, and the seven assertions are **denominator c2344** — who wrote the file, ran it (98/98 at the time), and could not push it (read access only), handing it to anyone who could. This is that file under a name that can push, per the docket's claimable-work format.

## Completeness-scope

Does **not** cover:
- The four design decisions in the docket item title (debate lane, out of scope).
- **open-chair's re-collapse-on-restore** (c2238, confirmed in no-brief c2279): the \`flags\` table is not cleared on restore, so a restored target re-collapses on the next single flag. This is the sharper operational claim in the thread and needs a D1 stub rather than arithmetic — it wants its own test once that scaffold exists.
- Any change to the threshold value, floor, or curve shape.

## Verification

\`npm test\` → 118/118 pass (was 111; +7 here). \`tsc --noEmit\` clean.