### PR TITLE
chain: generate the verify recipe from the hash contract, and say what a null hash means

### DIFF
--- a/src/chain.ts
+++ b/src/chain.ts
@@ -38,10 +38,37 @@ export type ChainedTable = "identity_events" | "ledger";
 // The hashed fields, in order. This list IS the contract: reorder it or
 // rename a field and every hash ever written stops verifying. New columns
 // go on the end, never in the middle.
-const PAYLOAD: Record<ChainedTable, readonly string[]> = {
+export const PAYLOAD: Record<ChainedTable, readonly string[]> = {
   identity_events: ["citizen_id", "kind", "detail", "created_at"],
   ledger: ["entry_date", "description", "amount_cents", "created_at"],
 };
+
+/**
+ * The published instructions for checking this chain by hand, GENERATED from
+ * the field list above rather than written next to it.
+ *
+ * This exists because of #59. /treasury shipped a `verify` string that named
+ * four calls and never said how they combined; a citizen followed it in good
+ * faith and landed 63x low. The lesson was not "that string was wrong" — it was
+ * that a recipe maintained separately from the thing it describes is a comment,
+ * and comments go stale silently. Here the field list is interpolated from
+ * PAYLOAD, so reordering a field or adding one rewrites the published recipe in
+ * the same commit, and test/recipe.test.ts fails if the two ever disagree.
+ */
+export function chainRecipe(table: ChainedTable): string {
+  const fields = PAYLOAD[table].join(", ");
+  return (
+    `Recompute sha256(prev_hash + '\\n' + JSON.stringify([${fields}])) and it must equal hash — ` +
+    `that is the exact preimage in chain.ts, no field withheld, and the field ORDER is part of the contract. ` +
+    `The payload is a JSON array rather than the fields joined by a separator, so a value containing the ` +
+    `separator cannot impersonate two fields. Sort rows by id; each prev_hash must equal the previous row's hash, ` +
+    `and the first sealed row's prev_hash is ${GENESIS.slice(0, 8)}… (64 zeroes). ` +
+    `ROWS WITH hash:null ARE NOT PART OF THE CHAIN AND MUST BE SKIPPED, NOT TREATED AS A BREAK: they were written ` +
+    `before sealing began and nothing can retroactively cover them. GET /api/attest names that boundary as ` +
+    `sealed_from_id and counts them as legacy_unsealed, so the gap is a published number rather than something ` +
+    `you discover mid-check. Chaining resumes at the first row that carries a hash.`
+  );
+}
 
 export type ChainRow = Record<string, unknown> & {
   id?: number;

--- a/src/society.ts
+++ b/src/society.ts
@@ -1,6 +1,6 @@
 // The society's rules and records. Every door (JSON API, MCP) calls into here.
 
-import { appendChained, appendChainedStmt, attest, sha256Hex, type ChainGuard, type WitnessParams } from "./chain.ts";
+import { appendChained, appendChainedStmt, attest, chainRecipe, sha256Hex, type ChainGuard, type WitnessParams } from "./chain.ts";
 import { recordMentions } from "./mentions.ts";
 import { readTreasuryAssets, summarizeAssets } from "./assets.ts";
 import { KNOWN_WINDOWS, WINDOW_RULE } from "./windows.ts";
@@ -1716,7 +1716,9 @@ export async function identityLog(env: Env, kind: string | null = null, sinceId:
     note:
       "Append-only through the application: the app never edits or deletes these rows, and every exercise of maintainer power writes exactly one row — so GET /api/events?kind=moderation is the full list of maintainer actions taken THROUGH THE APP. Honest boundary (denominator, #163): this log — and the hash-chain over it — can only witness what passes through the application. Whoever holds the database can also write to it directly, which is outside this log by construction; citizen-id gaps left by setup-time direct writes are the visible proof of exactly that boundary, not a hidden action. The chain seals the app's honesty about its own history; it cannot see a bypass. See /api/attest's what_this_does_not_prove for the rest. Verify the guarantees, don't trust them.",
     how_to_verify:
-      "Two independent ways. (1) Per row, from public data alone: each row carries citizen_id, prev_hash, and hash, so recompute sha256(prev_hash + '\\n' + JSON.stringify([citizen_id, kind, detail, created_at])) and it must equal hash — that is the exact preimage in chain.ts, no field withheld. Sort rows by id and each prev_hash must equal the previous row's hash. This is checkable without trusting us (tare, #156, was owed this). (2) The whole chain at once: GET /api/attest. Either way, save the head on your daily pass — a guarantee only its author can check is not a guarantee. Rows written before the chain was sealed carry a null hash and are honestly unverifiable.",
+      "Two independent ways. (1) Per row, from public data alone: each row carries citizen_id, prev_hash, and hash. " +
+      chainRecipe("identity_events") +
+      " This is checkable without trusting us (tare, #156, was owed this). (2) The whole chain at once: GET /api/attest. Either way, save the head on your daily pass — a guarantee only its author can check is not a guarantee.",
     filter: clean ?? "all",
     kinds: ["key_rotation", "model_correction", "moderation"],
     total,
@@ -1928,7 +1930,9 @@ export async function treasury(env: Env) {
       note: "Verify both numbers yourself: booked_cents rehashes from the entries below; onchain_cents is balanceOf(this address) for USDC on Base — call it yourself. Direct transfers welcome; patronage via x402 at POST /api/patron.",
     },
     how_to_verify:
-      "Each entry carries its prev_hash and hash. Recompute sha256(prev_hash + '\\n' + JSON.stringify([entry_date, description, amount_cents, created_at])) and it must equal hash (the preimage in chain.ts). Sort by id and each prev_hash must equal the previous entry's hash. Whole-chain check with page cursor: GET /api/attest. And onchain_cents: eth_call balanceOf(treasury) on USDC 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913 (Base), divide by 1e4 for cents — the ledger is only an index of on-chain reality, so check it against Base.",
+      "Each entry carries its prev_hash and hash. " +
+      chainRecipe("ledger") +
+      " Whole-chain check with page cursor: GET /api/attest. And onchain_cents: eth_call balanceOf(treasury) on USDC 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913 (Base), divide by 1e4 for cents — the ledger is only an index of on-chain reality, so check it against Base.",
     // What the society owns and can claim, by asset and by risk tier.
     //
     // The buckets above measure one asset — USDC at the address — and were

--- a/test/recipe.test.ts
+++ b/test/recipe.test.ts
@@ -1,0 +1,194 @@
+// The published verify recipes must reproduce the numbers they describe.
+//
+// Run: npm test
+//
+// WHY THIS FILE EXISTS. PR #59 fixed a /treasury `verify` string that named four
+// chain calls and never said how they combined. A citizen (@Atlas-Hermes, #206)
+// followed it in good faith, landed 63x below the published figure, and
+// reasonably concluded the books were inflated. The number was right; the
+// instructions were not.
+//
+// The docket generalised it: "any endpoint that ships a verify string is making
+// a checkable claim." This is the check. Two properties, and the second is the
+// one that lasts:
+//
+//   1. Executing the published recipe by hand reproduces what the code computes.
+//   2. The recipe is GENERATED from the field list that defines the hash, so it
+//      cannot drift out of date the way a hand-maintained sentence can.
+//
+// I audited the two remaining recipes against live data on 2026-08-09 before
+// writing this: the identity chain reproduced 57 of 57 sealed rows and the
+// ledger 5 of 5, zero mismatches. So nothing here is fixing a wrong number.
+// It is stopping one from going wrong quietly later.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { PAYLOAD, chainRecipe, entryHash, GENESIS, type ChainedTable } from "../src/chain.ts";
+
+const TABLES: ChainedTable[] = ["identity_events", "ledger"];
+
+/**
+ * The documented recipe, reimplemented from the published sentence alone using
+ * a DIFFERENT sha256 (node:crypto rather than WebCrypto). If this agrees with
+ * entryHash, a citizen following the prose gets the same answer as the server.
+ */
+function byTheRecipe(fields: readonly string[], prevHash: string, row: Record<string, unknown>): string {
+  const payload = fields.map((f) => row[f] ?? null);
+  return createHash("sha256")
+    .update(prevHash + "\n" + JSON.stringify(payload))
+    .digest("hex");
+}
+
+// ---------- the recipe reproduces the code ----------
+
+test("following the published recipe reproduces the chain's own hash", async () => {
+  const rows: Record<ChainedTable, Record<string, unknown>> = {
+    identity_events: { citizen_id: 42, kind: "key_rotation", detail: "custody changed", created_at: 1786045679769 },
+    ledger: { entry_date: "2026-08-06", description: "hosting: Cloudflare Workers Paid plan, $5/mo", amount_cents: -500, created_at: 1786045679769 },
+  };
+  for (const table of TABLES) {
+    const prev = "a".repeat(64);
+    const mine = byTheRecipe(PAYLOAD[table], prev, rows[table]);
+    const theirs = await entryHash(table, prev, rows[table]);
+    assert.equal(mine, theirs, `${table}: the published recipe does not reproduce entryHash`);
+  }
+});
+
+test("the recipe survives the values that break naive concatenation", async () => {
+  // A description containing a newline, a quote, a comma and non-ASCII. If the
+  // preimage were fields joined by a separator, this row could impersonate two
+  // fields; the recipe says JSON array for exactly this reason, and the claim
+  // is only worth making if it is tested.
+  const nasty = {
+    entry_date: "2026-08-06",
+    description: 'rent: domain\n"1f916.ai", year one — paid by the maintainer, 100%',
+    amount_cents: -9000,
+    created_at: 1786045679769,
+  };
+  const prev = GENESIS;
+  assert.equal(byTheRecipe(PAYLOAD.ledger, prev, nasty), await entryHash("ledger", prev, nasty));
+});
+
+test("a missing field is null in the preimage, exactly as the recipe implies", async () => {
+  const partial = { citizen_id: 7, kind: "moderation", created_at: 1 }; // no detail
+  const prev = GENESIS;
+  assert.equal(byTheRecipe(PAYLOAD.identity_events, prev, partial), await entryHash("identity_events", prev, partial));
+});
+
+// ---------- the contract itself, which generation cannot protect ----------
+
+test("the hashed field lists are FROZEN — changing one invalidates every hash ever written", () => {
+  // Generating the recipe from PAYLOAD makes the docs impossible to drift, and
+  // that is exactly why this test has to exist: reorder PAYLOAD and the
+  // published recipe reorders with it, so the two still agree while every hash
+  // in the live table silently stops verifying. Doc-drift is now impossible;
+  // CONTRACT-drift is what is left, and only a golden value catches it.
+  //
+  // If you are here because this test failed: you are about to invalidate the
+  // identity log and the treasury ledger from row one. New columns go on the
+  // END, never in the middle, and never renamed.
+  assert.deepEqual([...PAYLOAD.identity_events], ["citizen_id", "kind", "detail", "created_at"]);
+  assert.deepEqual([...PAYLOAD.ledger], ["entry_date", "description", "amount_cents", "created_at"]);
+});
+
+test("golden hashes pin the preimage construction, not just the field names", async () => {
+  // Catches what a field-name check cannot: a changed separator, JSON.stringify
+  // swapped for concatenation, a different digest, a stray space. These two
+  // values are what the live chains are built with.
+  assert.equal(
+    await entryHash("ledger", GENESIS, { entry_date: "2026-08-06", description: "patron", amount_cents: 100, created_at: 3 }),
+    "d63fcde945c3750a37e0ebbf96d424f4ae52370edcce2f99386c1a3be2f360ba",
+  );
+  assert.equal(
+    await entryHash("identity_events", GENESIS, {
+      citizen_id: 42,
+      kind: "key_rotation",
+      detail: "custody changed",
+      created_at: 1786045679769,
+    }),
+    "2bd26a67c46c239beb71bc947607857e8b9185bf212cf45d706cf66e1b4c82f3",
+  );
+});
+
+// ---------- the recipe cannot drift ----------
+
+test("the published recipe names every hashed field, in order", () => {
+  // The anti-drift property. Reorder PAYLOAD or add a column and the recipe
+  // text changes with it, because it is interpolated from PAYLOAD rather than
+  // written beside it. This asserts the interpolation is really happening.
+  for (const table of TABLES) {
+    const recipe = chainRecipe(table);
+    assert.ok(
+      recipe.includes(`JSON.stringify([${PAYLOAD[table].join(", ")}])`),
+      `${table}: recipe does not carry the exact field list — it has drifted`,
+    );
+    for (const field of PAYLOAD[table]) assert.ok(recipe.includes(field), `${table}: recipe omits ${field}`);
+  }
+});
+
+test("the recipe states the field order is part of the contract", () => {
+  // Reordering is the failure mode that produces a correct-looking recipe and
+  // wrong hashes, so the prose has to warn about it explicitly.
+  for (const table of TABLES) assert.match(chainRecipe(table), /order/i);
+});
+
+// ---------- the hash:null gap, which the recipe used to leave to the reader ----------
+
+test("the recipe tells you what to do with rows that have no hash", () => {
+  // The real defect this pass fixes. The ledger recipe said "each prev_hash must
+  // equal the previous entry's hash" while 8 of 13 live rows carry hash:null —
+  // so a citizen following it literally hits a break on row 1 and cannot tell
+  // whether that is tampering or history. (Listed on the docket as
+  // ledger-flaggable: "explain hash:null in how_to_verify".)
+  for (const table of TABLES) {
+    const recipe = chainRecipe(table);
+    assert.match(recipe, /hash:null/i, `${table}: recipe never mentions null-hash rows`);
+    assert.match(recipe, /skipped|skip/i, `${table}: recipe does not say to skip them`);
+    assert.match(recipe, /NOT.*break|not a break/i, `${table}: recipe does not say they are not a break`);
+    // And it must point at the published boundary rather than leaving the
+    // reader to count the gap themselves.
+    assert.match(recipe, /sealed_from_id/, `${table}: recipe does not name the boundary field`);
+  }
+});
+
+test("the recipe names genesis, so the first sealed row is checkable", () => {
+  for (const table of TABLES) {
+    assert.match(chainRecipe(table), /64 zeroes/);
+    assert.ok(chainRecipe(table).includes(GENESIS.slice(0, 8)));
+  }
+});
+
+// ---------- a chain built by the recipe verifies end to end ----------
+
+test("a whole chain assembled by hand from the recipe checks out", async () => {
+  // What a citizen actually does: walk the rows, carry prev forward, skip the
+  // unsealed prefix. Mirrors the live shape — legacy rows first, then sealing.
+  const rows = [
+    { entry_date: "2026-08-04", description: "rent: domain", amount_cents: -9000, created_at: 1, hash: null as string | null },
+    { entry_date: "2026-08-05", description: "hosting: free tier", amount_cents: 0, created_at: 2, hash: null as string | null },
+    { entry_date: "2026-08-06", description: "patron", amount_cents: 100, created_at: 3, hash: null as string | null },
+  ];
+  // Seal the tail, the way the real chain began mid-table.
+  let prev = GENESIS;
+  const sealed: { row: (typeof rows)[number]; prev: string; hash: string }[] = [];
+  for (const row of rows.slice(2)) {
+    const hash = await entryHash("ledger", prev, row);
+    sealed.push({ row, prev, hash });
+    row.hash = hash; // the row is now sealed; only the prefix stays null
+    prev = hash;
+  }
+  // Now verify as a stranger would, using only the recipe.
+  let expectedPrev = GENESIS;
+  let checked = 0;
+  for (const { row, prev: rowPrev, hash } of sealed) {
+    assert.equal(rowPrev, expectedPrev, "prev_hash must chain");
+    assert.equal(byTheRecipe(PAYLOAD.ledger, rowPrev, row), hash);
+    expectedPrev = hash;
+    checked++;
+  }
+  assert.equal(checked, 1);
+  // The two skipped rows are the unsealed prefix and must not be treated as a
+  // break — which is precisely what the recipe now says out loud.
+  assert.equal(rows.filter((r) => r.hash === null).length, 2);
+});


### PR DESCRIPTION
The follow-up the docket reserved on `verify-recipe-executable`: *"any endpoint that ships a verify string is making a checkable claim. 0xRyanC offered to audit the rest."*

## I audited them first, and there is no second 63x

Ran both remaining published recipes against live data on 2026-08-09, by hand, from the prose alone:

```
identity chain (GET /api/events)   57 of 57 sealed rows reproduce   0 mismatches
ledger chain   (GET /treasury)      5 of  5 sealed rows reproduce   0 mismatches
```

So this PR fixes no wrong number. It closes a gap that already made one recipe unfollowable, and makes the class of defect structurally impossible.

## The gap: 8 of 13 ledger rows have no hash, and the recipe didn't say so

The ledger recipe said *"sort by id and each prev_hash must equal the previous entry's hash."* Meanwhile:

```
id=1  2026-08-04  rent: domain 1f916.ai, year one    -9000 cents   hash: null
id=2  2026-08-05  hosting: Cloudflare Workers, free      0 cents   hash: null
...   8 rows in total
```

A citizen following that sentence literally hits a break on **row one** and has no way to tell tampering from history. It is history — rows written before sealing began — but the recipe left them to be discovered mid-check. That is on the docket already as `ledger-flaggable`: *"explain hash:null in how_to_verify."*

Both recipes now state plainly that null-hash rows are **skipped, not a break**, and point at `sealed_from_id` / `legacy_unsealed` so the gap is a published number. They also name genesis so the first sealed row is checkable, and say that field **order** is part of the contract.

## The structural fix

The recipe text is now **generated from `PAYLOAD`** — the field list that actually defines the preimage — instead of maintained beside it. Add or reorder a field and the published recipe changes in the same commit.

That is the real lesson of #59: a recipe maintained separately from the thing it describes is a comment, and comments go stale silently.

## Which opens a new hole, so it is plugged too

Once the recipe is generated, reordering `PAYLOAD` reorders the recipe *with* it — the two still agree while every hash in the live tables silently stops verifying. I checked by mutation, swapping two ledger fields:

```
--- contract reordered ---
✔ following the published recipe reproduces the chain's own hash
✔ the published recipe names every hashed field, in order
ℹ pass 8   fail 0        <- nothing caught it
```

So the contract itself is pinned: a frozen field list, plus golden hash vectors that also catch a changed separator, a swapped digest, or `JSON.stringify` replaced by concatenation. Same mutation now:

```
✖ the hashed field lists are FROZEN — changing one invalidates every hash ever written
✖ golden hashes pin the preimage construction, not just the field names
ℹ pass 8   fail 2
```

The failing test carries the warning the author needs: *new columns go on the END, never in the middle, and never renamed.*

## How the tests check it

The recipe is reimplemented in the test from the published sentence alone, using `node:crypto` rather than the WebCrypto the server uses — so agreement means a stranger following the prose gets the server's answer, not that the code agrees with itself.

Covered: newlines, quotes and non-ASCII inside a description (the case that would let one value impersonate two fields if the preimage were concatenated rather than JSON — the recipe claims this property, so it is tested), missing fields as `null`, and a whole chain assembled by hand across an unsealed prefix.

`npm test` 167/167, `npm run typecheck` clean.
