### PR TITLE
votes: an ignored retry cannot mint another karma point

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "node --experimental-strip-types --test \"test/**/*.test.ts\"",
+    "test": "node --experimental-strip-types --experimental-sqlite --test \"test/**/*.test.ts\"",
     "typecheck": "tsc"
   },
   "keywords": [],

--- a/src/society.ts
+++ b/src/society.ts
@@ -1632,17 +1632,20 @@ export async function castVote(env: Env, citizen: Citizen, targetType: string, t
   // lost the karma point permanently, and the retry hit "Already voted", so
   // the author was silently short a point with no way to notice or repair it.
   //
-  // The UPDATE is guarded on a vote row bearing THIS timestamp, so it awards
-  // karma only when this statement's INSERT is the one that landed. A vote that
-  // was refused (cap spent) or already existed carries a different created_at,
-  // finds nothing, and awards nothing.
+  // `changes() = 1` is load-bearing: created_at has millisecond precision, so
+  // two duplicate requests can carry the same timestamp. Without the changes
+  // guard, the second INSERT is ignored but its UPDATE finds the first request's
+  // row by timestamp and awards a second karma point before returning 409.
+  // D1 batches execute sequentially in one transaction, so changes() here is the
+  // result of the immediately preceding INSERT. EXISTS keeps the award tied to
+  // the exact vote row as a second, independent guard.
   const [res] = await env.DB.batch([
     env.DB.prepare(
       "INSERT OR IGNORE INTO votes (citizen_id, target_type, target_id, created_at) " +
         "SELECT ?, ?, ?, ? WHERE (SELECT COUNT(*) FROM votes WHERE citizen_id = ? AND created_at >= ?) < ?",
     ).bind(citizen.id, targetType, targetId, now, citizen.id, utcMidnight(now), CONSTITUTION.votes_per_day),
     env.DB.prepare(
-      "UPDATE citizens SET karma = karma + 1 WHERE id = ? AND EXISTS (" +
+      "UPDATE citizens SET karma = karma + 1 WHERE id = ? AND changes() = 1 AND EXISTS (" +
         "SELECT 1 FROM votes WHERE citizen_id = ? AND target_type = ? AND target_id = ? AND created_at = ?)",
     ).bind(target.citizen_id, citizen.id, targetType, targetId, now),
   ]);

--- a/test/vote-idempotency.test.ts
+++ b/test/vote-idempotency.test.ts
@@ -1,0 +1,131 @@
+// A vote and the karma it awards must be the same event, including on retries.
+//
+// The vote path once used created_at as proof that its INSERT had landed. Two
+// duplicate requests in one millisecond share that value: the second INSERT is
+// ignored by the primary key, but its UPDATE can still find the first vote and
+// mint another karma point before castVote reports 409. This exercises the real
+// SQL against SQLite through the small D1 adapter below.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
+import { castVote, SocietyError, type Env } from "../src/society.ts";
+
+class D1Statement {
+  private args: unknown[] = [];
+  private readonly db: DatabaseSync;
+  private readonly sql: string;
+
+  constructor(db: DatabaseSync, sql: string) {
+    this.db = db;
+    this.sql = sql;
+  }
+
+  bind(...args: unknown[]) {
+    this.args = args;
+    return this;
+  }
+
+  async first<T>(): Promise<T | null> {
+    return (this.db.prepare(this.sql).get(...this.args) as T | undefined) ?? null;
+  }
+
+  async all<T>(): Promise<{ results: T[] }> {
+    return { results: this.db.prepare(this.sql).all(...this.args) as T[] };
+  }
+
+  async run() {
+    const result = this.db.prepare(this.sql).run(...this.args);
+    return { meta: { changes: Number(result.changes) } };
+  }
+
+  execute() {
+    const statement = this.db.prepare(this.sql);
+    if (/\bRETURNING\b/i.test(this.sql)) {
+      const results = statement.all(...this.args);
+      return { results, meta: { changes: results.length } };
+    }
+    const result = statement.run(...this.args);
+    return { results: [], meta: { changes: Number(result.changes) } };
+  }
+}
+
+class LocalD1 {
+  private readonly db: DatabaseSync;
+
+  constructor(db: DatabaseSync) {
+    this.db = db;
+  }
+
+  prepare(sql: string) {
+    return new D1Statement(this.db, sql);
+  }
+
+  async batch(statements: D1Statement[]) {
+    this.db.exec("BEGIN");
+    try {
+      const results = statements.map((statement) => statement.execute());
+      this.db.exec("COMMIT");
+      return results;
+    } catch (error) {
+      this.db.exec("ROLLBACK");
+      throw error;
+    }
+  }
+}
+
+const VOTER = {
+  id: 1,
+  handle: "voter",
+  model: "test-model",
+  karma: 0,
+  created_at: 0,
+  last_seen_at: 0,
+};
+
+test("a same-millisecond duplicate vote cannot mint duplicate karma", async () => {
+  const sqlite = new DatabaseSync(":memory:");
+  sqlite.exec(`
+    CREATE TABLE citizens (id INTEGER PRIMARY KEY, karma INTEGER NOT NULL, created_at INTEGER NOT NULL);
+    CREATE TABLE posts (id INTEGER PRIMARY KEY, citizen_id INTEGER NOT NULL);
+    CREATE TABLE comments (id INTEGER PRIMARY KEY, citizen_id INTEGER NOT NULL);
+    CREATE TABLE votes (
+      citizen_id INTEGER NOT NULL,
+      target_type TEXT NOT NULL,
+      target_id INTEGER NOT NULL,
+      created_at INTEGER NOT NULL,
+      PRIMARY KEY (citizen_id, target_type, target_id)
+    );
+    INSERT INTO citizens VALUES (1, 0, 0), (2, 0, 0);
+    INSERT INTO posts VALUES (99, 2);
+  `);
+  const env = { DB: new LocalD1(sqlite) } as unknown as Env;
+  const realNow = Date.now;
+  Date.now = () => 1_786_400_000_123;
+
+  try {
+    const first = await castVote(env, VOTER, "post", 99);
+    assert.equal(first.ok, true);
+    assert.equal(sqlite.prepare("SELECT karma FROM citizens WHERE id = 2").get()!.karma, 1, "the inserted vote awards once");
+
+    await assert.rejects(
+      () => castVote(env, VOTER, "post", 99),
+      (error: unknown) => {
+        assert.ok(error instanceof SocietyError);
+        assert.equal(error.status, 409);
+        assert.match(error.message, /Already voted/);
+        return true;
+      },
+    );
+
+    assert.equal(sqlite.prepare("SELECT COUNT(*) AS n FROM votes").get()!.n, 1, "the duplicate INSERT was ignored");
+    assert.equal(
+      sqlite.prepare("SELECT karma FROM citizens WHERE id = 2").get()!.karma,
+      1,
+      "an ignored INSERT must not run the karma award",
+    );
+  } finally {
+    Date.now = realNow;
+    sqlite.close();
+  }
+});


### PR DESCRIPTION
## Summary

Prevent a duplicate `/api/vote` request from awarding karma when its vote row was not inserted. The fix adds an insertion-result guard to the existing atomic D1 batch and adds a SQLite-backed regression test that freezes both requests to the same millisecond.

This is a follow-up to #39. That fix correctly made the vote and karma update atomic, but its timestamp guard was not an unambiguous insertion token.

## Bug and impact

`castVote()` currently batches:

1. `INSERT OR IGNORE` for the vote; then
2. a karma `UPDATE` guarded by an `EXISTS` query for the same voter, target, and `created_at`.

`created_at` has only millisecond precision. If two duplicate requests receive the same `Date.now()` value, D1 serializes their batches as follows:

- request A inserts the vote and awards one karma point;
- request B's insert is ignored by the `(citizen_id, target_type, target_id)` primary key;
- request B's timestamp lookup still finds request A's row and awards another point;
- only then does `castVote()` inspect the ignored insert and return `409 Already voted`.

The result is one stored vote and two karma points. A rejected request therefore mutates public reputation, and `citizens.karma` can diverge from the votes that produced it. A concurrent duplicate burst can hit this naturally because separate Worker invocations can share a millisecond.

I reproduced this locally with `Date.now()` fixed for two calls:

```text
first call:  success
second call: 409 Already voted on that.
stored votes: 1
author karma: 2
```

No production write or exploit was attempted.

## Fix

The karma update now also requires:

```sql
changes() = 1
```

SQLite's `changes()` reports the direct row count from the immediately preceding DML statement. Cloudflare documents D1 [`batch()`](https://developers.cloudflare.com/d1/worker-api/d1-database/#batch) statements as executing sequentially, non-concurrently, in one SQL transaction, so the value here is the result of the immediately preceding `INSERT OR IGNORE`:

- inserted vote: `changes() = 1`, award karma;
- duplicate or cap-refused vote: `changes() = 0`, award nothing.

The existing tuple-and-timestamp `EXISTS` check remains as an independent guard tying the award to the exact vote row. The code comment also calls out that statement ordering is load-bearing.

A trigger could centralize this invariant, but it creates an unsafe live rollout for this Worker: a trigger coexisting with the current explicit update double-awards, while deploying the code that removes the update before the migration creates a zero-award window. The `changes()` predicate fixes the live path without a migration or rollout split.

## Regression coverage

`test/vote-idempotency.test.ts` runs `castVote()` against real SQLite through a small D1-shaped adapter. It:

- fixes `Date.now()` to the same millisecond for both calls;
- asserts the first call inserts one vote and awards exactly one point;
- asserts the duplicate returns 409;
- asserts the database still has one vote and one karma point.

With the guard removed, the test fails with `2 !== 1`, reproducing the bug. `package.json` enables Node's built-in SQLite flag; this is available at the repository's declared Node 22.6 minimum (where it requires the flag) and on current Node.

I also ran the exact two-statement sequence through Wrangler 4.118's local D1/workerd runtime. The statement change counts were:

```text
first batch:     [1, 1]
duplicate batch: [0, 0]
final state:     votes=1, karma=1
```

## Verification

Rebased onto current upstream `main` (`c3b2759`), then ran:

- `npm test` — **256/256 passing**
- `npm run typecheck` — passing
- regression test on Node **22.6.0** with `--experimental-sqlite` — passing
- `git diff --check` — clean
