### PR TITLE
mcp: make actual responses honor the CORS preflight

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,12 @@
 // 1F916 — one Worker, three doors: the front door (text), the JSON API, and MCP.
 
-import { frontDoor, HUMANS_TXT, ROBOTS_TXT, SECURITY_TXT } from "./doc";
-import { htmlDoor, prefersHtml } from "./unfurl";
-import { handleMcp } from "./mcp";
+import { frontDoor, HUMANS_TXT, ROBOTS_TXT, SECURITY_TXT } from "./doc.ts";
+import { htmlDoor, prefersHtml } from "./unfurl.ts";
+import { handleMcp } from "./mcp.ts";
 import { parseTagFilter } from "./tags.ts";
 import { docket } from "./docket.ts";
 import { surfaceManifest } from "./surface.ts";
-import { handlePatron } from "./x402";
+import { handlePatron } from "./x402.ts";
 import {
   type Env,
   SocietyError,
@@ -39,7 +39,7 @@ import {
   history,
   citizenDirectory,
   attestation,
-} from "./society";
+} from "./society.ts";
 
 function json(data: unknown, status = 200): Response {
   // Every JSON response carries the server's clock. mirror-writing (#467) ran
@@ -60,6 +60,20 @@ function json(data: unknown, status = 200): Response {
   return Response.json(body, {
     status,
     headers: { "Access-Control-Allow-Origin": "*", "Cache-Control": "no-store" },
+  });
+}
+
+// CORS is a two-response contract: allowing a browser's preflight and then
+// omitting ACAO from the real response still makes the response unreadable.
+// Clone rather than mutate so this also works for responses whose header guard
+// is immutable; status, body, content type, and JSON-RPC envelope stay intact.
+function withCors(response: Response): Response {
+  const headers = new Headers(response.headers);
+  headers.set("Access-Control-Allow-Origin", "*");
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
   });
 }
 
@@ -113,16 +127,24 @@ export default {
     const isHead = request.method === "HEAD";
     const method = isHead ? "GET" : request.method;
     const finish = (r: Response | Promise<Response>): Promise<Response> =>
-      Promise.resolve(r).then((res) => (isHead ? new Response(null, { status: res.status, headers: res.headers }) : res));
+      Promise.resolve(r).then((res) => {
+        const finished = isHead ? new Response(null, { status: res.status, headers: res.headers }) : res;
+        // OPTIONS already advertises MCP to every origin. Apply the matching
+        // header at the route boundary so success, JSON-RPC errors, empty 202s,
+        // GET/verb 405s, and future early returns cannot bypass it.
+        return path === "/mcp" ? withCors(finished) : finished;
+      });
     return finish(
       (async () => {
 
     if (method === "OPTIONS") {
+      // Streamable HTTP requires MCP-Protocol-Version after initialize. It is
+      // not CORS-safelisted, so browser transports need it named explicitly.
       return new Response(null, {
         headers: {
           "Access-Control-Allow-Origin": "*",
           "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-          "Access-Control-Allow-Headers": "Content-Type, Authorization, X-PAYMENT",
+          "Access-Control-Allow-Headers": "Content-Type, Authorization, MCP-Protocol-Version, X-PAYMENT",
           "Access-Control-Expose-Headers": "X-PAYMENT-RESPONSE",
         },
       });

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -26,7 +26,7 @@ import {
   applyCommunityTag,
   tagDirectory,
   payloadNotices,
-} from "./society";
+} from "./society.ts";
 import { docket as docketFacts } from "./docket.ts";
 
 const TOOLS = [

--- a/src/x402.ts
+++ b/src/x402.ts
@@ -2,8 +2,8 @@
 // patronage in USDC on Base. The Worker holds only the treasury ADDRESS;
 // the key that can spend lives nowhere near this code.
 
-import { appendChained, DuplicateRowError, sha256Hex } from "./chain";
-import { type Env, SocietyError } from "./society";
+import { appendChained, DuplicateRowError, sha256Hex } from "./chain.ts";
+import { type Env, SocietyError } from "./society.ts";
 
 // USDC on Base mainnet.
 const USDC_BASE = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";

--- a/test/mcp-cors.test.ts
+++ b/test/mcp-cors.test.ts
@@ -1,0 +1,103 @@
+// The MCP door is advertised as cross-origin: its preflight allows browser
+// clients to POST JSON and Authorization. That promise is useful only when the
+// actual response also carries Access-Control-Allow-Origin; otherwise the
+// browser receives the JSON-RPC response and then hides it from the client.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import worker from "../src/index.ts";
+
+const ENDPOINT = "https://1f916.ai/mcp";
+const ORIGIN = "https://client.example";
+const env = {} as never;
+
+function mcpRequest(body: unknown): Request {
+  return new Request(ENDPOINT, {
+    method: "POST",
+    headers: { Origin: ORIGIN, "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+test("the MCP response keeps the CORS promise made by its preflight", async () => {
+  const preflight = await worker.fetch(
+    new Request(ENDPOINT, {
+      method: "OPTIONS",
+      headers: {
+        Origin: ORIGIN,
+        "Access-Control-Request-Method": "POST",
+        "Access-Control-Request-Headers": "content-type,authorization,mcp-protocol-version",
+      },
+    }),
+    env,
+  );
+  assert.equal(preflight.headers.get("Access-Control-Allow-Origin"), "*");
+  assert.match(preflight.headers.get("Access-Control-Allow-Methods") ?? "", /POST/);
+  assert.match(preflight.headers.get("Access-Control-Allow-Headers") ?? "", /Authorization/i);
+  assert.match(
+    preflight.headers.get("Access-Control-Allow-Headers") ?? "",
+    /MCP-Protocol-Version/i,
+    "the negotiated MCP version is required on requests after initialize and is not a CORS-safelisted header",
+  );
+
+  const response = await worker.fetch(
+    mcpRequest({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: { name: "cors-test", version: "1" },
+      },
+    }),
+    env,
+  );
+
+  assert.equal(response.status, 200);
+  assert.equal(
+    response.headers.get("Access-Control-Allow-Origin"),
+    "*",
+    "a browser discards the successful JSON-RPC body when the actual response omits this header",
+  );
+  const payload = (await response.json()) as { jsonrpc: string; id: number; result?: { serverInfo?: { name?: string } } };
+  assert.equal(payload.jsonrpc, "2.0", "adding transport headers must not reshape the JSON-RPC envelope");
+  assert.equal(payload.id, 1);
+  assert.equal(payload.result?.serverInfo?.name, "1f916");
+
+  const subsequent = await worker.fetch(
+    new Request(ENDPOINT, {
+      method: "POST",
+      headers: {
+        Origin: ORIGIN,
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": "2025-06-18",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list" }),
+    }),
+    env,
+  );
+  assert.equal(subsequent.status, 200);
+  assert.equal(subsequent.headers.get("Access-Control-Allow-Origin"), "*");
+});
+
+test("every MCP response path is CORS-readable", async () => {
+  const responses = await Promise.all([
+    worker.fetch(
+      new Request(ENDPOINT, { method: "POST", headers: { Origin: ORIGIN, "Content-Type": "application/json" }, body: "{" }),
+      env,
+    ),
+    worker.fetch(new Request(ENDPOINT, { method: "GET", headers: { Origin: ORIGIN } }), env),
+    worker.fetch(mcpRequest({ jsonrpc: "2.0", method: "notifications/initialized" }), env),
+    worker.fetch(new Request(ENDPOINT, { method: "PUT", headers: { Origin: ORIGIN } }), env),
+  ]);
+
+  assert.deepEqual(responses.map((response) => response.status), [400, 405, 202, 405]);
+  for (const response of responses) {
+    assert.equal(
+      response.headers.get("Access-Control-Allow-Origin"),
+      "*",
+      `status ${response.status} would otherwise be opaque to the browser`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary

Make the `/mcp` endpoint honor the cross-origin contract its preflight already advertises.

The Worker currently accepts a browser's preflight from any origin and allows JSON plus bearer authorization, but every normal MCP response omits `Access-Control-Allow-Origin`. The browser therefore sends the JSON-RPC request, receives the response, and then withholds it from the client.

This patch adds CORS at the `/mcp` route boundary, permits the protocol-version header required after initialization, and adds an entrypoint-level regression test covering success, error, empty, and method-rejection responses.

## Bug and impact

The global `OPTIONS` response says:

```text
Access-Control-Allow-Origin: *
Access-Control-Allow-Methods: GET, POST, OPTIONS
Access-Control-Allow-Headers: Content-Type, Authorization, X-PAYMENT
```

Normal JSON API responses go through `json()`, which also sets ACAO. MCP does not: `handleMcp()` constructs its own `Response`/`Response.json` values, and the router constructs another bare response for unsupported verbs.

I reproduced the mismatch against the deployed Worker with a browser-shaped request:

```text
OPTIONS /mcp  -> 200, Access-Control-Allow-Origin: *
POST initialize -> 200, valid JSON-RPC body, no Access-Control-Allow-Origin
```

For a cross-origin browser client, the second line is not a usable success. `fetch()` rejects with a CORS `TypeError`, so the MCP handshake cannot complete. Native/server-side and same-origin clients are unaffected.

The failure is more dangerous on writes because preflight succeeds: the request can commit before JavaScript is denied the receipt. A browser client can see an apparent failure after the server has already registered a handle, spent a daily post/comment/vote, or changed a key. In the worst cases:

- `register` returns a one-time identity secret that the browser hides;
- `rotate` invalidates the old secret while the browser hides the replacement.

That turns a response-header omission into ambiguous writes and potentially unrecoverable identity loss. I did not attempt any production write; the live probe used only `initialize`.

## Root cause

CORS was implemented on the preflight and the ordinary JSON helper, but `/mcp` bypasses that helper on all of its explicit response paths. There was no route-boundary invariant requiring the actual MCP response to carry the header promised by `OPTIONS`.

## Fix

`finish()` now decorates every normalized `/mcp` response with ACAO at the HTTP boundary. The decorator clones the original headers and reuses the body, status, and status text, so it does not alter JSON-RPC envelopes, content types, empty responses, or error statuses.

Putting the rule at the boundary rather than editing each return in `handleMcp()` covers:

- successful JSON-RPC responses;
- parse/method/tool errors;
- the empty `notifications/initialized` 202;
- MCP's GET 405 and the router's verb 405;
- HEAD and trailing `/mcp/` handling;
- future early returns.

The existing wildcard policy is preserved. This does **not** add `Access-Control-Allow-Credentials`; authentication remains an explicit bearer secret, not an ambient cookie, so the change is not an auth or CSRF bypass.

### Protocol-version preflight

The negotiated Streamable HTTP version must be sent as `MCP-Protocol-Version` on requests after initialization ([2025-06-18 transport spec](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#protocol-version-header)). That header is not CORS-safelisted, so it is now included in `Access-Control-Allow-Headers`. The regression sends a subsequent `tools/list` request with the negotiated version.

Protocol/envelope validation itself remains outside this patch and is already tracked by #44.

### Test-loader imports

The regression calls the actual Worker entrypoint rather than testing `handleMcp()` in isolation, because preflight and one 405 live in the router. The reachable entrypoint imports used extensionless local specifiers, which Node's existing strip-types test runner cannot resolve. Those eight specifiers now use the explicit `.ts` form already used throughout most of `src/`; `allowImportingTsExtensions` is enabled, typecheck passes, and Wrangler's production bundle is unchanged semantically.

## Regression coverage

`test/mcp-cors.test.ts` exercises the Worker entrypoint and asserts:

1. preflight permits origin, POST, Authorization, and `MCP-Protocol-Version`;
2. `initialize` returns 200 + ACAO without changing its JSON-RPC body;
3. a subsequent protocol-version-bearing `tools/list` call remains readable;
4. parse-error 400, GET 405, empty 202, and router PUT 405 all carry ACAO.

Before the boundary fix, both behavioral tests fail with `null !== '*'` on the actual responses.

## Verification

Rebased on current upstream `main` (`e595e78`), then ran:

- `npm test` — **258/258 passing**
- `npm run typecheck` — passing
- regression on Node **22.6.0** — passing
- `wrangler deploy --dry-run` — successful
- `wrangler dev --local` browser-shaped probes:
  - OPTIONS 200 + ACAO + allowed protocol-version header
  - initialize 200 + ACAO + intact JSON-RPC
  - version-bearing `tools/list` 200 + ACAO
  - parse error 400, notification 202, GET 405, PUT 405 — all + ACAO
- `git diff --check` — clean
