### PR TITLE
treasury: cache and coalesce asset reads

### DIFF
--- a/src/assets.ts
+++ b/src/assets.ts
@@ -11,10 +11,10 @@
 //   TIER     what kind of money it is. USDC is not WETH; WETH is not a
 //            speculative coin. One blended total tells a reader less than
 //            three subtotals that refuse to blend.
-//   LOCATION where it is. 'wallet' is at the treasury address now. 'claimable'
-//            is an enforceable on-chain claim not yet collected. Money the
-//            society can take but has not taken is still money, and reporting
-//            it as zero is the bug this file exists to fix.
+//   LOCATION where it is. 'wallet' is at the address in this on-chain read.
+//            'claimable' is an enforceable on-chain claim not yet collected.
+//            Money the society can take but has not taken is still money.
+//            Reporting it as zero is the bug this file exists to fix.
 //
 // Everything is priced from Base: no API key, no price service, no trusted
 // third party. Chainlink's ETH/USD feed and the pool's own slot0, both read
@@ -468,22 +468,35 @@ export interface PoolDepth {
 // costs one walk, short enough that nobody is looking at a stale pool.
 //
 // The cache key includes the amount, because the whole point of the number is
-// that it depends on size.
+// that it depends on size. Its timestamp is propagated to the assembled asset
+// result, so the outer cache cannot re-label an older estimate as freshly read.
 const DEPTH_TTL_MS = 60_000;
-let depthCache: { key: string; at: number; value: { depth: PoolDepth | null; error: string | null } } | null = null;
+let depthCache: {
+  key: string;
+  checkedAt: number;
+  cachedAt: number;
+  value: { depth: PoolDepth | null; error: string | null };
+} | null = null;
 
 export async function readPoolDepth(
   src: ClaimSource,
   amountIn: bigint,
   rpcUrls: string[],
-): Promise<{ depth: PoolDepth | null; error: string | null }> {
+): Promise<{ depth: PoolDepth | null; error: string | null; checked_at: number }> {
   const key = `${src.poolId}:${amountIn}`;
-  if (depthCache && depthCache.key === key && Date.now() - depthCache.at < DEPTH_TTL_MS) return depthCache.value;
+  if (depthCache && depthCache.key === key && Date.now() - depthCache.cachedAt < DEPTH_TTL_MS) {
+    return { ...depthCache.value, checked_at: depthCache.checkedAt };
+  }
+  // TTL begins when the completed walk is cached, but honesty begins when its
+  // first read can occur. Keep those clocks separate: a slow multi-pass walk
+  // must not be made younger merely because it took seconds to finish.
+  const checkedAt = Date.now();
   const computed = await readPoolDepthUncached(src, amountIn, rpcUrls);
+  const cachedAt = Date.now();
   // Only a success is cached. A transient RPC failure must not pin "unknown"
   // in front of the next reader for a minute.
-  if (computed.depth) depthCache = { key, at: Date.now(), value: computed };
-  return computed;
+  if (computed.depth) depthCache = { key, checkedAt, cachedAt, value: computed };
+  return { ...computed, checked_at: checkedAt };
 }
 
 async function readPoolDepthUncached(
@@ -566,9 +579,14 @@ export interface AssetReadResult {
   eth_usd_updated_at: number | null;
   token_usd: number | null;
   errors: string[];
+  /** Oldest underlying on-chain read represented in this assembled result. */
+  checked_at: number;
 }
 
 export async function readTreasuryAssets(treasuryAddress: string, rpcUrls: string[]): Promise<AssetReadResult> {
+  // Start time is conservative: fallback retries can make a read span seconds,
+  // and an older cached pool-depth estimate may move this timestamp back again.
+  let checkedAt = Date.now();
   const errors: string[] = [];
   const t = pad(treasuryAddress);
   const src = CLAIM_SOURCES[0];
@@ -767,7 +785,8 @@ export async function readTreasuryAssets(treasuryAddress: string, rpcUrls: strin
   // untouched and simply publishes no realizable value.
   const tier3 = holdings[holdings.length - 1];
   if (claimToken !== null && claimToken > 0n) {
-    const { depth, error } = await readPoolDepth(src, claimToken, rpcUrls);
+    const { depth, error, checked_at } = await readPoolDepth(src, claimToken, rpcUrls);
+    checkedAt = Math.min(checkedAt, checked_at);
     if (error) errors.push(error);
     if (depth) {
       const realizableCents = ethUsd === null ? null : valueCents(depth.realizable0, 18, ethUsd);
@@ -796,5 +815,12 @@ export async function readTreasuryAssets(treasuryAddress: string, rpcUrls: strin
     }
   }
 
-  return { holdings, eth_usd: ethUsd, eth_usd_updated_at: ethUpdatedAt, token_usd: tokenUsd, errors };
+  return {
+    holdings,
+    eth_usd: ethUsd,
+    eth_usd_updated_at: ethUpdatedAt,
+    token_usd: tokenUsd,
+    errors,
+    checked_at: checkedAt,
+  };
 }

--- a/src/doc.ts
+++ b/src/doc.ts
@@ -224,7 +224,7 @@ TIER is the kind of money:
 
 LOCATION is custody:
 
-  wallet     at the treasury address right now
+  wallet     quantity returned by the disclosed on-chain asset read
   claimable  an enforceable on-chain claim, never collected
 
 That second one is why this exists. The society is the 95% fee
@@ -237,10 +237,17 @@ conservative_total_cents is the same without tier 3.
 Both are returned, and neither is called the real one.
 
 Everything is read from Base with eth_call: no API key, no price
-service, no trusted third party. Every holding carries the exact call
-that produced it in a 'verify' field. Re-run them rather than believe
-them — that is the standing instruction everywhere else here and the
-treasury should not be the exception.
+service, no trusted third party. The assembled asset result is cached
+for 30 seconds, and concurrent refreshes in one warm Worker isolate
+coalesce, so a burst does not repeat those provider calls per request.
+Its 'checked_at' is the oldest underlying on-chain read represented
+in the assembled result and 'cache_age_ms' is that read's age when this
+response was assembled — even a reused pool-depth estimate cannot pass
+itself off as "now". That estimate has its own 60-second cache, so the
+reported age can exceed 30 seconds; the older time wins. Every holding
+carries the exact call that produced it in a 'verify' field. Re-run them
+rather than believe them — that is the standing instruction everywhere
+else here and the treasury should not be the exception.
 
 A listed token is NOT an endorsement. There is still no official token
 (GET /api/official), the maintainer will still never ask you to claim,

--- a/src/society.ts
+++ b/src/society.ts
@@ -3,7 +3,7 @@
 import { appendChained, appendChainedStmt, attest, chainRecipe, sha256Hex, type ChainGuard, type WitnessParams } from "./chain.ts";
 import { recordMentions } from "./mentions.ts";
 import { mojibakeWarning } from "./mojibake.ts";
-import { readTreasuryAssets, summarizeAssets } from "./assets.ts";
+import { readTreasuryAssets, summarizeAssets, type AssetReadResult } from "./assets.ts";
 import { KNOWN_WINDOWS, WINDOW_RULE } from "./windows.ts";
 import { normalizeTag, TAG_MAX_LEN, TAGS_PER_DAY, TAGS_PER_POST_PER_CITIZEN } from "./tags.ts";
 import { unlistedPayloads } from "./payload-gate.ts";
@@ -2365,6 +2365,51 @@ async function fetchOnchainUsdcCents(env: Env): Promise<number | null> {
   return null;
 }
 
+// The asset snapshot is much more expensive than the balance above: its first
+// step is an eleven-call batch with the same four-provider fallback, followed
+// by the (separately cached) pool-depth walk when there is a claim to price.
+// Running it on every anonymous /treasury was a free RPC-amplification door.
+//
+// Keep the result for the same honest 30s window as onchainCache, and keep the
+// promise too: requests that arrive together join one refresh instead of each
+// starting their own. Partial/error-bearing results are cached deliberately.
+// Refusing to cache them would reopen the amplification exactly while an RPC is
+// degraded, which is when its four-provider retry is most expensive.
+const ASSET_TTL_MS = 30_000;
+type CachedAssetRead = { value: AssetReadResult; cachedAt: number };
+const assetCache = new Map<string, CachedAssetRead>();
+const assetInFlight = new Map<string, Promise<CachedAssetRead>>();
+
+async function readTreasuryAssetsCached(env: Env): Promise<CachedAssetRead> {
+  const rpcUrls = baseRpcUrls(env);
+  // Bindings are stable within a production isolate, but keying preserves this
+  // function's contract in previews/tests and across any future live rebind.
+  // URL order is part of the key because it is the provider fallback order.
+  const key = JSON.stringify([env.TREASURY_ADDRESS.toLowerCase(), rpcUrls]);
+  const cached = assetCache.get(key);
+  if (cached) {
+    const age = Date.now() - cached.cachedAt;
+    if (age >= 0 && age < ASSET_TTL_MS) return cached;
+  }
+  const running = assetInFlight.get(key);
+  if (running) return running;
+
+  const pending = (async (): Promise<CachedAssetRead> => {
+    const value = await readTreasuryAssets(env.TREASURY_ADDRESS, rpcUrls);
+    const snapshot = { value, cachedAt: Date.now() };
+    assetCache.set(key, snapshot);
+    return snapshot;
+  })();
+  assetInFlight.set(key, pending);
+  try {
+    return await pending;
+  } finally {
+    // A rejected read is never cached, and cannot pin the key in-flight. The
+    // identity guard prevents an old finally from deleting a newer refresh.
+    if (assetInFlight.get(key) === pending) assetInFlight.delete(key);
+  }
+}
+
 export async function treasury(env: Env) {
   // Same as the identity log (tare, #156): the full hash preimage — entry_date,
   // description, amount_cents, created_at — plus the chain links and row id, so
@@ -2385,19 +2430,25 @@ export async function treasury(env: Env) {
   const citizens = await env.DB.prepare("SELECT COUNT(*) AS n FROM citizens").first<{ n: number }>();
   const posts = await env.DB.prepare("SELECT COUNT(*) AS n FROM posts").first<{ n: number }>();
   const booked = sum?.balance ?? 0;
-  // USDC read (cached, #17) and the tiered asset/claim read (#21) in parallel.
-  const [onchainRead, assetRead] = await Promise.all([
+  // The separately cached USDC read (#17) and tiered asset/claim snapshot
+  // (#21, #37) still run in parallel when either one needs a refresh.
+  const [onchainRead, assetSnapshot] = await Promise.all([
     readOnchainUsdcCents(env),
-    readTreasuryAssets(env.TREASURY_ADDRESS, baseRpcUrls(env)),
+    readTreasuryAssetsCached(env),
   ]);
   const onchain = onchainRead.cents;
   // cave-bot (#248, c1470): a live number must say when it was read. This is the
   // real read time — of the cached fetch when served from cache — so a cached
   // response can never pass as "now".
   const onchainCheckedAt = onchainRead.at;
+  const assetRead = assetSnapshot.value;
   const assets = {
     ...summarizeAssets(assetRead.holdings),
-    checked_at: Date.now(),
+    // This is the oldest underlying read represented in the assembled result,
+    // including a reused pool-depth estimate. The cache entry's own 30s TTL is
+    // measured separately, so a nested older value can never masquerade as new.
+    checked_at: assetRead.checked_at,
+    cache_age_ms: Math.max(0, Date.now() - assetRead.checked_at),
     eth_usd: assetRead.eth_usd,
     eth_usd_updated_at: assetRead.eth_usd_updated_at,
     // Read failures are named, never smoothed over. An empty list means every
@@ -2447,7 +2498,7 @@ export async function treasury(env: Env) {
     // neither.
     assets,
     assets_note:
-      "Tiers are about the KIND of money, not its size. Tier 1 is dollar-denominated; tier 2 is deep and liquid; tier 3 is a NOTIONAL mark on a thin market — a price, not an offer. total_cents sums all three because you asked for one true total; conservative_total_cents is the same total without tier 3. Locations are about custody: 'wallet' is at the address now, 'claimable' is an enforceable on-chain claim the society has never collected. POLICY: the treasury is deliberately NOT collecting the claimable amount — this block exists to make the books honest about what is on-chain, not as a step toward a claim, and listing a claim endorses nothing (see /api/official: there is no society token). Every figure carries the exact call that produced it — re-run them rather than believe them.",
+      "Tiers are about the KIND of money, not its size. Tier 1 is dollar-denominated; tier 2 is deep and liquid; tier 3 is a NOTIONAL mark on a thin market — a price, not an offer. total_cents sums all three because you asked for one true total; conservative_total_cents is the same total without tier 3. Locations are about custody: 'wallet' comes from the disclosed on-chain asset read; assets.checked_at and assets.cache_age_ms give the composite's conservative oldest-read bound, not an exact per-holding as-of time. 'claimable' is an enforceable on-chain claim the society has never collected. POLICY: the treasury is deliberately NOT collecting the claimable amount — this block exists to make the books honest about what is on-chain, not as a step toward a claim, and listing a claim endorses nothing (see /api/official: there is no society token). Every figure carries the exact call that produced it — re-run them rather than believe them.",
     census: { citizens: citizens?.n ?? 0, posts: posts?.n ?? 0 },
     entries,
   };

--- a/test/treasury-asset-cache.test.ts
+++ b/test/treasury-asset-cache.test.ts
@@ -1,0 +1,152 @@
+// /treasury is anonymous, but one response used to cost an eleven-call Base
+// batch (and up to four provider attempts) even when an identical response had
+// just finished. A burst therefore turned free GETs into third-party RPC work.
+// This test holds the first batch open so the second request has to join it,
+// then walks the clock through the cache window without sleeping for 30 seconds.
+// It also pins config isolation and the difference between a resolved degraded
+// result (cache it) and an unexpected rejection (clear it so recovery can retry).
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { treasury, type Env } from "../src/society.ts";
+
+const TREASURY = "0x0000000000000000000000000000000000000037";
+const word = (value: bigint) => value.toString(16).padStart(64, "0");
+
+function stubEnv(
+  treasuryAddress = TREASURY,
+  rpcUrl = "https://rpc.test",
+): Env {
+  const db = {
+    prepare(sql: string) {
+      return {
+        async all<T>() {
+          return { results: [] as T[] };
+        },
+        async first<T>() {
+          if (sql.includes("SUM(amount_cents)")) return { balance: 0 } as T;
+          return { n: 0 } as T;
+        },
+      };
+    },
+  };
+  return { DB: db, TREASURY_ADDRESS: treasuryAddress, BASE_RPC_URL: rpcUrl } as unknown as Env;
+}
+
+function assetBatchResponse(payload: { id: number }[], now: number): Response {
+  const zero = "0x" + word(0n);
+  // A positive Chainlink answer and a 1:1 pool sqrt price keep the fixture
+  // complete while every balance/claim remains zero (and avoids the depth walk).
+  const roundData =
+    "0x" + [0n, 2_000n * 100_000_000n, 0n, BigInt(Math.floor(now / 1000)), 0n].map(word).join("");
+  const sqrtPriceX96 = "0x" + word(1n << 96n);
+  return Response.json(
+    payload.map(({ id }) => ({ id, result: id === 2 ? roundData : id === 3 ? sqrtPriceX96 : zero })),
+  );
+}
+
+test("treasury asset reads cache, coalesce, and disclose their age", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalNow = Date.now;
+  const startedAt = 1_700_000_000_000;
+  let now = startedAt;
+  let assetBatchFetches = 0;
+  let brokenRpc = true;
+  let releaseFirstBatch: (response: Response) => void = () => {};
+  const firstBatch = new Promise<Response>((resolve) => {
+    releaseFirstBatch = resolve;
+  });
+  let firstRequest: ReturnType<typeof treasury> | undefined;
+  let joinedRequest: ReturnType<typeof treasury> | undefined;
+
+  Date.now = () => now;
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const payload = JSON.parse(String(init?.body));
+    if (Array.isArray(payload)) {
+      assetBatchFetches++;
+      if (assetBatchFetches === 1) return firstBatch;
+      // One valid row makes batchCall accept this degraded provider response;
+      // the resolved AssetReadResult then carries explicit errors/nulls.
+      if (String(input) === "https://degraded.rpc") {
+        return Response.json([{ id: 0, result: "0x" + word(0n) }]);
+      }
+      if (String(input) === "https://broken.rpc" && brokenRpc) {
+        return Response.json([{ id: 0, result: "0xnot-hex" }]);
+      }
+      return assetBatchResponse(payload as { id: number }[], now);
+    }
+    // The separate onchain_cents read is not the asset batch under test.
+    return Response.json({ jsonrpc: "2.0", id: 1, result: "0x" + word(0n) });
+  }) as typeof fetch;
+
+  try {
+    firstRequest = treasury(stubEnv());
+    for (let turn = 0; turn < 20 && assetBatchFetches === 0; turn++) await Promise.resolve();
+    assert.equal(assetBatchFetches, 1, "the first request should reach the asset RPC batch");
+
+    joinedRequest = treasury(stubEnv());
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    assert.equal(assetBatchFetches, 1, "an overlapping request must join the in-flight batch");
+
+    // Model a slow provider. The public age starts at the oldest possible read,
+    // while the 30s reuse TTL starts only after the completed result is cached.
+    now = startedAt + 5_000;
+    releaseFirstBatch(assetBatchResponse(Array.from({ length: 11 }, (_, id) => ({ id })), now));
+    const [first, joined] = await Promise.all([firstRequest, joinedRequest]);
+    assert.equal(assetBatchFetches, 1);
+    assert.equal(first.assets.checked_at, startedAt);
+    assert.equal(first.assets.cache_age_ms, 5_000);
+    assert.equal(joined.assets.checked_at, startedAt);
+    assert.equal(joined.assets.cache_age_ms, 5_000);
+
+    now += 1_234;
+    const cached = await treasury(stubEnv());
+    assert.equal(assetBatchFetches, 1, "a request inside the 30s TTL must not issue another asset batch");
+    assert.equal(cached.assets.checked_at, startedAt, "checked_at is the oldest read time, not the cache-write time");
+    assert.equal(cached.assets.cache_age_ms, 6_234, "the response discloses the cached asset result's age");
+
+    now = startedAt + 5_000 + 30_000;
+    const refreshed = await treasury(stubEnv());
+    assert.equal(assetBatchFetches, 2, "the first request at the TTL boundary refreshes the snapshot");
+    assert.equal(refreshed.assets.checked_at, now);
+    assert.equal(refreshed.assets.cache_age_ms, 0);
+
+    // Module caches must not hand one Env's treasury result to another Env.
+    // Production bindings are stable per isolate, but the function's contract
+    // and preview/test deployments still deserve an address/provider key.
+    now += 1;
+    const otherEnv = stubEnv("0x0000000000000000000000000000000000000038", "https://rpc.other.test");
+    await treasury(otherEnv);
+    assert.equal(assetBatchFetches, 3, "a different address/provider pair has its own cache entry");
+
+    // Provider failure resolves to an honest, error-bearing AssetReadResult.
+    // Cache that too: otherwise an outage reopens the amplification path at its
+    // most expensive moment, when every request walks the fallback list.
+    const degradedEnv = stubEnv("0x0000000000000000000000000000000000000039", "https://degraded.rpc");
+    const degraded = await treasury(degradedEnv);
+    assert.ok(degraded.assets.errors.length > 0);
+    assert.equal(assetBatchFetches, 4);
+    now += 250;
+    const degradedHit = await treasury(degradedEnv);
+    assert.equal(assetBatchFetches, 4, "a resolved degraded read is cached inside the TTL");
+    assert.deepEqual(degradedHit.assets.errors, degraded.assets.errors);
+    assert.equal(degradedHit.assets.cache_age_ms, 250);
+
+    // An unexpected parser failure is different: do not cache a rejection, and
+    // always clear its in-flight slot so a healthy next attempt can recover.
+    const brokenEnv = stubEnv("0x0000000000000000000000000000000000000040", "https://broken.rpc");
+    await assert.rejects(treasury(brokenEnv), /BigInt|convert/i);
+    assert.equal(assetBatchFetches, 5);
+    brokenRpc = false;
+    const recovered = await treasury(brokenEnv);
+    assert.equal(assetBatchFetches, 6, "a rejected refresh must not poison the cache or in-flight map");
+    assert.deepEqual(recovered.assets.errors, []);
+  } finally {
+    // Safe even when already resolved; prevents a failed assertion from leaving
+    // the first treasury request suspended while globals are restored.
+    releaseFirstBatch(assetBatchResponse(Array.from({ length: 11 }, (_, id) => ({ id })), now));
+    await Promise.allSettled([firstRequest, joinedRequest].filter((p): p is ReturnType<typeof treasury> => p !== undefined));
+    globalThis.fetch = originalFetch;
+    Date.now = originalNow;
+  }
+});


### PR DESCRIPTION
## Summary

Stop anonymous `GET /treasury` traffic from issuing the complete Base asset read on every request.

The existing 30-second cache protects only the separate single-call USDC `balanceOf`. The tiered `readTreasuryAssets()` path still runs an 11-call JSON-RPC batch for every request and can walk four providers at a 3-second timeout each. This patch gives that full resolved result its own 30-second per-isolate cache, coalesces concurrent refreshes, and publishes a conservative age for the on-chain values instead of silently presenting cached data as current.

Closes #37.

## Bug and impact

`treasury()` currently does this on every anonymous request:

```ts
await Promise.all([
  readOnchainUsdcCents(env),                    // cached for 30s
  readTreasuryAssets(address, baseRpcUrls(env)) // always outbound
]);
```

The second call begins with eleven `eth_call`s in one batch. `batchCall()` tries the ordered provider list until one returns a usable batch, so a degraded path can consume roughly four providers × three seconds. The optional pool-depth work is separately cached, but that does not protect the core eleven-call batch.

Because `/treasury` is public and unauthenticated, sequential polling turns every free GET into third-party RPC, Worker, and subrequest work. A burst is worse: without an in-flight promise, simultaneous requests all start their own fallback sequence before any can finish. During an RPC outage—the exact time retries are longest—the endpoint becomes a cost and availability amplifier.

The regression test demonstrates the old behavior directly: it holds the first asset batch open, starts a second `treasury()` request, and fails before this patch because the outbound asset-batch count becomes 2 rather than remaining 1.

## Root cause

The original cache was written for `onchain_cents`, before the broader tiered asset reader was added. The later reader was placed beside it in `Promise.all()` but never received an equivalent cache or single-flight guard.

The existing `assets.checked_at: Date.now()` was also response time rather than reusable read metadata. Simply caching the object without changing that timestamp would either falsely restamp old values or freeze a timestamp whose meaning was undocumented.

## Fix

### 1. Cache the complete resolved asset result

`readTreasuryAssetsCached()` stores the whole resolved `AssetReadResult` for 30 seconds. The key is:

```text
[lower-cased treasury address, ordered RPC URL list]
```

Provider order is deliberately retained because it is fallback behavior, not an unordered set. Keying prevents previews, tests, or a future live rebind from receiving another configuration's holdings or joining its refresh.

The entry's internal `cachedAt` is captured only after the expensive read completes. The exact expiry rule is `< 30_000`; the first request at the boundary refreshes.

### 2. Coalesce concurrent misses

A second Map holds one in-flight promise per key. The promise is installed before it is awaited, so overlapping requests in the same warm Worker isolate join the same read. The cached value is parsed plain data—no `Request`, `Response`, body stream, or other request-owned I/O object is shared.

The in-flight entry is removed in an identity-guarded `finally`. Therefore:

- resolved reads populate the TTL cache;
- concurrent callers receive the same resolved result;
- an unexpected rejection is not cached;
- a rejection cannot poison the in-flight slot;
- an older completion cannot delete a newer refresh.

### 3. Cache honest degraded results

A normal provider failure resolves to an `AssetReadResult` with null holding values and explicit `errors`; it does not throw. Those resolved degraded results are cached too.

That behavior is intentional. Refusing to cache them would reopen the amplification during an outage, when every request is most likely to traverse the fallback list. The existing response semantics remain honest: affected totals are null, `complete` is false, and `errors` explains what could not be read. Truly unexpected exceptions remain retryable because rejected promises are never cached.

### 4. Publish conservative read age

The response now includes:

```json
"assets": {
  "checked_at": 1700000000000,
  "cache_age_ms": 6234
}
```

These fields describe the oldest underlying read represented by the assembled asset result, not an exact block-wide “as of” time for every holding:

- the core asset timestamp is captured before its provider attempts, so a slow fallback cannot make earlier work look younger;
- the existing pool-depth cache now keeps separate `checkedAt` (before its multi-pass walk) and `cachedAt` (after completion, for its own 60-second TTL);
- a reused depth estimate propagates its older `checkedAt` into the composite;
- `cache_age_ms` is recomputed when each response is assembled.

The outer result is still reused for only 30 seconds after it completes. Its published age may legitimately exceed 30 seconds when it contains the separately cached 60-second depth estimate; the door documentation and `assets_note` say so rather than implying every wallet quantity was true at one exact instant. `eth_usd_updated_at` remains the independent Chainlink oracle timestamp.

This patch does **not** claim block pinning: the existing calls still use `latest`, and the depth walk spans calls. No block number is invented.

## Cache scope

This intentionally follows the maintainer-requested shape of the existing module-level `onchainCache`. It caches and coalesces requests handled by the same warm Worker isolate. It is not a globally shared Cache API/Durable Object, cross-PoP rate limiter, or guarantee that a newly created isolate already has an entry.

That scope removes repeated work within the execution unit that can actually share an in-flight promise while keeping this change focused. A shared regional/global cache or rate limit can be added separately if operational data shows it is needed.

The D1 ledger, census, and response assembly are still performed per request; only public on-chain asset data is reused.

## Regression coverage

`test/treasury-asset-cache.test.ts` invokes the real `treasury()` function with a D1 stand-in and controlled JSON-RPC provider. It verifies:

1. a held cold read plus an overlapping request produces exactly one asset batch;
2. a simulated five-second read reports age from read start while the 30-second reuse TTL begins at completion;
3. a hit inside the TTL makes no outbound asset batch;
4. the exact 30,000 ms completion-time boundary refreshes;
5. different address/provider configurations do not share entries;
6. a resolved degraded/error-bearing read is cached;
7. a malformed-result rejection clears the flight and a healthy next attempt retries successfully.

Before the fix, the overlap assertion fails with:

```text
AssertionError: an overlapping request must join the in-flight batch
2 !== 1
```

## Verification

Based on current upstream `main` (`bad0002`), I ran:

- `npm test` — **259/259 passing**
- `npm run typecheck` — passing
- targeted regression on the minimum supported **Node 22.6.0** — passing
- `wrangler deploy --dry-run` — successful
- `git diff --check` — clean

I also exercised two concurrent real `wrangler dev --local` `/treasury` requests against a deliberately delayed local RPC:

- both responses: HTTP 200;
- both responses: identical `assets.checked_at`;
- mock RPC: exactly **one** array-shaped asset batch;
- mock RPC: two separate object-shaped USDC reads, confirming the pre-existing lightweight `onchain_cents` path is outside this issue's single-flight scope.

The smoke test used only a local D1 database and a local read-only RPC fixture. No production write or quota abuse was attempted.

## Non-goals

- global cross-isolate/PoP caching or rate limiting;
- stale-while-revalidate or serving an expired good result after refresh failure;
- coalescing the separate single-call `onchain_cents` cache;
- changing provider fallback, valuation, or error/null semantics;
- claiming all RPC calls were pinned to one block.
