### PR TITLE
assets: stop reporting unknown values as zero

### DIFF
--- a/src/assets.ts
+++ b/src/assets.ts
@@ -182,7 +182,8 @@ export function claimableFromPool(
 export interface TierSummary {
   tier: Tier;
   label: string;
-  cents: number;
+  /** Null unless every holding in the snapshot is valued; never a partial sum. */
+  cents: number | null;
   notional: boolean;
   note: string;
 }
@@ -220,7 +221,7 @@ export function summarizeAssets(holdings: Holding[]): AssetSummary {
     by_tier: ([1, 2, 3] as Tier[]).map((tier) => ({
       tier,
       label: TIERS[tier].label,
-      cents: sum(holdings.filter((h) => h.tier === tier)),
+      cents: complete ? sum(holdings.filter((h) => h.tier === tier)) : null,
       notional: holdings.some((h) => h.tier === tier && h.notional),
       note: TIERS[tier].note,
     })),
@@ -343,7 +344,10 @@ export const CLAIM_SOURCES: ClaimSource[] = [
 const pad = (hex: string) => hex.replace(/^0x/, "").toLowerCase().padStart(64, "0");
 const word = (hex: string, i: number): bigint => {
   const body = hex.replace(/^0x/, "").slice(i * 64, (i + 1) * 64);
-  return body.length === 64 ? BigInt("0x" + body) : 0n;
+  if (body.length !== 64) {
+    throw new Error(`short ABI response: word ${i} has ${body.length} hex digits; expected 64`);
+  }
+  return BigInt("0x" + body);
 };
 // Chainlink answers are int256.
 const toInt256 = (v: bigint): bigint => (v >= 1n << 255n ? v - (1n << 256n) : v);
@@ -401,10 +405,9 @@ export async function batchCall(rpcUrls: string[], calls: RpcCall[], timeoutMs =
  * batchCall, but it insists.
  *
  * batchCall returns as soon as ANY call in the batch answered, so a public RPC
- * that rate-limits half a large batch yields a result array with holes and the
- * next endpoint is never tried. That is fine for the eleven-call read this file
- * started with and not fine for the ~40 the depth walk needs: a single throttled
- * word silently costs the whole realizable figure, intermittently, which is the
+ * that rate-limits part of a batch yields a result array with holes and the next
+ * endpoint is never tried. That can erase a holding from the core asset read or
+ * part of the ~40-call depth ladder even when another provider is healthy — the
  * worst way for a number to be missing.
  *
  * So: re-request only the holes, rotating which endpoint leads each pass, and
@@ -514,6 +517,9 @@ async function readPoolDepthUncached(
   ]);
   if (!slot0 || !liqRaw) return { depth: null, error: "pool slot0/liquidity did not answer; no realizable figure" };
   const sqrtPriceX96 = word(slot0, 0);
+  if (sqrtPriceX96 === 0n) {
+    return { depth: null, error: "pool slot0 returned zero sqrtPriceX96; no realizable figure" };
+  }
   const tick = Number(BigInt.asIntN(256, word(slot0, 1)));
   const lpFeePips = Number(word(slot0, 3));
   const liquidity = BigInt(liqRaw);
@@ -607,7 +613,7 @@ export async function readTreasuryAssets(treasuryAddress: string, rpcUrls: strin
     { to: src.feesManager, data: S.collectFees + pad(src.poolId), from: treasuryAddress },
   ];
   const [usdcRaw, wethRaw, roundData, slot0, sharesRaw, cum0Raw, cum1Raw, last0Raw, last1Raw, tokenWalletRaw, collectRaw] =
-    await batchCall(rpcUrls, calls);
+    await batchCallComplete(rpcUrls, calls);
 
   // ETH/USD from Chainlink, 8 decimals. The update time is carried through so a
   // stale oracle is visible rather than silently trusted — an oracle that
@@ -723,13 +729,17 @@ export async function readTreasuryAssets(treasuryAddress: string, rpcUrls: strin
   // the only one it has any relationship to, and it is the one a sale of these
   // tokens would actually move.
   let tokenUsd: number | null = null;
-  if (slot0 && ethUsd !== null) {
+  if (slot0) {
     const sqrtPriceX96 = word(slot0, 0);
-    const ethPerToken = src.wethIsToken0
-      ? sqrtPriceX96ToToken0PerToken1(sqrtPriceX96, 18, src.decimals)
-      : 1 / sqrtPriceX96ToToken0PerToken1(sqrtPriceX96, src.decimals, 18);
-    tokenUsd = ethPerToken * ethUsd;
-  } else if (!slot0) {
+    if (sqrtPriceX96 === 0n) {
+      errors.push("pool slot0 returned zero sqrtPriceX96; the token mark is unavailable");
+    } else if (ethUsd !== null) {
+      const ethPerToken = src.wethIsToken0
+        ? sqrtPriceX96ToToken0PerToken1(sqrtPriceX96, 18, src.decimals)
+        : 1 / sqrtPriceX96ToToken0PerToken1(sqrtPriceX96, src.decimals, 18);
+      tokenUsd = ethPerToken * ethUsd;
+    }
+  } else {
     errors.push("pool slot0 did not answer; the token mark is unavailable");
   }
   const tokenPriceSource = `Uniswap V4 slot0 for poolId ${src.poolId} (StateView ${BASE_CONTRACTS.V4_STATE_VIEW}), converted at the Chainlink ETH/USD price. Pinned to the pool the claim sits in — other pools for this token quote materially different prices, so a token-wide average would be a number with no owner.`;

--- a/test/asset-read-integrity.test.ts
+++ b/test/asset-read-integrity.test.ts
@@ -1,0 +1,141 @@
+// Regression coverage for the fail-open asset paths in issue #38.
+//
+// Every fixture here is an eth_call result, never a transaction. The first
+// test makes one provider answer only a single row so the healthy fallback has
+// to fill the remaining holes. The remaining tests pin malformed slot0 handling:
+// neither zero nor a short ABI word may become a confident zero-dollar mark,
+// and zero must not crash the optional depth walk.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  CLAIM_SOURCES,
+  SELECTORS,
+  readPoolDepth,
+  readTreasuryAssets,
+  summarizeAssets,
+  type RpcCall,
+} from "../src/assets.ts";
+
+const TREASURY = "0x0000000000000000000000000000000000000038";
+const Q96 = 1n << 96n;
+const abiWord = (value: bigint) => value.toString(16).padStart(64, "0");
+const abi = (...values: bigint[]) => "0x" + values.map(abiWord).join("");
+
+type RpcRequest = {
+  id: number;
+  params: [RpcCall, "latest"];
+};
+
+function resultFor(call: RpcCall, sqrtPriceX96 = Q96): string {
+  if (call.data === SELECTORS.latestRoundData) {
+    return abi(1n, 2_000n * 100_000_000n, 0n, 1_700_000_000n, 1n);
+  }
+  if (call.data.startsWith(SELECTORS.getSlot0)) {
+    return abi(sqrtPriceX96, 0n, 0n, 3_000n);
+  }
+  if (call.data.startsWith(SELECTORS.collectFees)) return abi(0n, 0n);
+  return abi(0n);
+}
+
+function rowsFor(payload: RpcRequest[], sqrtPriceX96 = Q96) {
+  return payload.map(({ id, params }) => ({ id, result: resultFor(params[0], sqrtPriceX96) }));
+}
+
+async function withMockFetch<T>(
+  handler: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>,
+  action: () => Promise<T>,
+): Promise<T> {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = handler as typeof fetch;
+  try {
+    return await action();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+test("the asset batch fills a partial provider response from a healthy fallback", async () => {
+  const requestedUrls: string[] = [];
+  const requestedBatchSizes: number[] = [];
+  await withMockFetch(
+    async (input, init) => {
+      const url = String(input);
+      requestedUrls.push(url);
+      const payload = JSON.parse(String(init?.body)) as RpcRequest[];
+      requestedBatchSizes.push(payload.length);
+      const rows = rowsFor(payload);
+      // A superficially usable batch used to stop fallback after this one row.
+      return Response.json(url === "https://partial.rpc" ? rows.slice(0, 1) : rows);
+    },
+    async () => {
+      const read = await readTreasuryAssets(TREASURY, ["https://partial.rpc", "https://healthy.rpc"]);
+      assert.deepEqual(requestedUrls, ["https://partial.rpc", "https://healthy.rpc"]);
+      assert.deepEqual(requestedBatchSizes, [11, 10], "the answered row must not be fetched again");
+      assert.deepEqual(read.errors, []);
+      assert.equal(read.eth_usd, 2_000);
+      assert.equal(read.token_usd, 2_000);
+      assert.equal(summarizeAssets(read.holdings).complete, true);
+    },
+  );
+});
+
+test("zero sqrtPriceX96 makes the token mark unknown instead of zero dollars", async () => {
+  await withMockFetch(
+    async (_input, init) => {
+      const payload = JSON.parse(String(init?.body)) as RpcRequest[];
+      return Response.json(rowsFor(payload, 0n));
+    },
+    async () => {
+      const read = await readTreasuryAssets(TREASURY, ["https://zero-slot0.rpc"]);
+      assert.equal(read.token_usd, null);
+      assert.match(read.errors.join("\n"), /zero sqrtPriceX96/i);
+
+      const tokenRows = read.holdings.filter((holding) => holding.address === CLAIM_SOURCES[0].token);
+      assert.ok(tokenRows.length > 0);
+      assert.ok(tokenRows.every((holding) => holding.price_usd === null));
+      assert.ok(tokenRows.every((holding) => holding.value_cents === null));
+
+      const summary = summarizeAssets(read.holdings);
+      assert.equal(summary.complete, false);
+      assert.equal(summary.total_cents, null);
+      assert.deepEqual(summary.by_tier.map((tier) => tier.cents), [null, null, null]);
+    },
+  );
+});
+
+test("zero sqrtPriceX96 also stops the optional depth walk without throwing", async () => {
+  let batches = 0;
+  await withMockFetch(
+    async (_input, init) => {
+      batches++;
+      const payload = JSON.parse(String(init?.body)) as RpcRequest[];
+      return Response.json(rowsFor(payload, 0n));
+    },
+    async () => {
+      const result = await readPoolDepth(CLAIM_SOURCES[0], 1n, ["https://zero-depth-slot0.rpc"]);
+      assert.equal(result.depth, null);
+      assert.match(result.error ?? "", /zero sqrtPriceX96/i);
+      assert.equal(batches, 1, "an impossible price must stop before the tick-ladder walk");
+    },
+  );
+});
+
+test("a short slot0 ABI response is rejected instead of decoding as zero", async () => {
+  await withMockFetch(
+    async (_input, init) => {
+      const payload = JSON.parse(String(init?.body)) as RpcRequest[];
+      const rows = rowsFor(payload);
+      const slot0 = rows.find((row, index) => payload[index].params[0].data.startsWith(SELECTORS.getSlot0));
+      assert.ok(slot0);
+      slot0.result = "0x0";
+      return Response.json(rows);
+    },
+    async () => {
+      await assert.rejects(
+        readTreasuryAssets(TREASURY, ["https://short-slot0.rpc"]),
+        /short ABI response.*word 0/i,
+      );
+    },
+  );
+});

--- a/test/assets.test.ts
+++ b/test/assets.test.ts
@@ -190,6 +190,11 @@ test("an unreadable holding nulls the totals instead of under-reporting", () => 
   assert.equal(s.complete, false);
   assert.equal(s.total_cents, null);
   assert.equal(s.conservative_total_cents, null);
+  assert.deepEqual(
+    s.by_tier.map((tier) => tier.cents),
+    [null, null, null],
+    "a tier subtotal must not turn an unknown holding into a confident zero",
+  );
   assert.equal(s.by_location.wallet_cents, null);
   // The per-holding rows still come back, so a reader can see WHAT is missing.
   assert.equal(s.holdings.length, 2);
@@ -199,6 +204,7 @@ test("no holdings is complete and zero, not incomplete", () => {
   const s = summarizeAssets([]);
   assert.equal(s.complete, true);
   assert.equal(s.total_cents, 0);
+  assert.deepEqual(s.by_tier.map((tier) => tier.cents), [0, 0, 0]);
 });
 
 // ---------- the allowlist ----------

--- a/test/treasury-asset-cache.test.ts
+++ b/test/treasury-asset-cache.test.ts
@@ -8,6 +8,7 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
+import { SELECTORS } from "../src/assets.ts";
 import { treasury, type Env } from "../src/society.ts";
 
 const TREASURY = "0x0000000000000000000000000000000000000037";
@@ -33,15 +34,36 @@ function stubEnv(
   return { DB: db, TREASURY_ADDRESS: treasuryAddress, BASE_RPC_URL: rpcUrl } as unknown as Env;
 }
 
-function assetBatchResponse(payload: { id: number }[], now: number): Response {
+type AssetRpcRequest = { id: number; params?: [{ data: string }, "latest"] };
+
+function assetBatchResponse(payload: AssetRpcRequest[], now: number): Response {
   const zero = "0x" + word(0n);
   // A positive Chainlink answer and a 1:1 pool sqrt price keep the fixture
   // complete while every balance/claim remains zero (and avoids the depth walk).
   const roundData =
     "0x" + [0n, 2_000n * 100_000_000n, 0n, BigInt(Math.floor(now / 1000)), 0n].map(word).join("");
-  const sqrtPriceX96 = "0x" + word(1n << 96n);
+  const slot0 = "0x" + [1n << 96n, 0n, 0n, 3_000n].map(word).join("");
+  const collectFees = "0x" + word(0n) + word(0n);
   return Response.json(
-    payload.map(({ id }) => ({ id, result: id === 2 ? roundData : id === 3 ? sqrtPriceX96 : zero })),
+    payload.map(({ id, params }) => {
+      const data = params?.[0].data;
+      const result = data
+        ? data === SELECTORS.latestRoundData
+          ? roundData
+          : data.startsWith(SELECTORS.getSlot0)
+            ? slot0
+            : data.startsWith(SELECTORS.collectFees)
+              ? collectFees
+              : zero
+        : id === 2
+          ? roundData
+          : id === 3
+            ? slot0
+            : id === 10
+              ? collectFees
+              : zero;
+      return { id, result };
+    }),
   );
 }
 
@@ -51,6 +73,7 @@ test("treasury asset reads cache, coalesce, and disclose their age", async () =>
   const startedAt = 1_700_000_000_000;
   let now = startedAt;
   let assetBatchFetches = 0;
+  let degradedOutage = false;
   let brokenRpc = true;
   let releaseFirstBatch: (response: Response) => void = () => {};
   const firstBatch = new Promise<Response>((resolve) => {
@@ -65,15 +88,13 @@ test("treasury asset reads cache, coalesce, and disclose their age", async () =>
     if (Array.isArray(payload)) {
       assetBatchFetches++;
       if (assetBatchFetches === 1) return firstBatch;
-      // One valid row makes batchCall accept this degraded provider response;
-      // the resolved AssetReadResult then carries explicit errors/nulls.
-      if (String(input) === "https://degraded.rpc") {
-        return Response.json([{ id: 0, result: "0x" + word(0n) }]);
-      }
+      // Keep every provider unavailable for this scenario. The complete-batch
+      // reader will exhaust its hole-filling passes and resolve honest nulls.
+      if (degradedOutage) return Response.json([]);
       if (String(input) === "https://broken.rpc" && brokenRpc) {
         return Response.json([{ id: 0, result: "0xnot-hex" }]);
       }
-      return assetBatchResponse(payload as { id: number }[], now);
+      return assetBatchResponse(payload as AssetRpcRequest[], now);
     }
     // The separate onchain_cents read is not the asset batch under test.
     return Response.json({ jsonrpc: "2.0", id: 1, result: "0x" + word(0n) });
@@ -123,23 +144,29 @@ test("treasury asset reads cache, coalesce, and disclose their age", async () =>
     // Cache that too: otherwise an outage reopens the amplification path at its
     // most expensive moment, when every request walks the fallback list.
     const degradedEnv = stubEnv("0x0000000000000000000000000000000000000039", "https://degraded.rpc");
+    const beforeDegraded = assetBatchFetches;
+    degradedOutage = true;
     const degraded = await treasury(degradedEnv);
+    degradedOutage = false;
     assert.ok(degraded.assets.errors.length > 0);
-    assert.equal(assetBatchFetches, 4);
+    const afterDegraded = assetBatchFetches;
+    assert.ok(afterDegraded > beforeDegraded, "the simulated outage should exercise provider fallbacks");
     now += 250;
     const degradedHit = await treasury(degradedEnv);
-    assert.equal(assetBatchFetches, 4, "a resolved degraded read is cached inside the TTL");
+    assert.equal(assetBatchFetches, afterDegraded, "a resolved degraded read is cached inside the TTL");
     assert.deepEqual(degradedHit.assets.errors, degraded.assets.errors);
     assert.equal(degradedHit.assets.cache_age_ms, 250);
 
     // An unexpected parser failure is different: do not cache a rejection, and
     // always clear its in-flight slot so a healthy next attempt can recover.
     const brokenEnv = stubEnv("0x0000000000000000000000000000000000000040", "https://broken.rpc");
+    const beforeBroken = assetBatchFetches;
     await assert.rejects(treasury(brokenEnv), /BigInt|convert/i);
-    assert.equal(assetBatchFetches, 5);
+    const afterBroken = assetBatchFetches;
+    assert.ok(afterBroken > beforeBroken, "the malformed provider result should reach the parser");
     brokenRpc = false;
     const recovered = await treasury(brokenEnv);
-    assert.equal(assetBatchFetches, 6, "a rejected refresh must not poison the cache or in-flight map");
+    assert.equal(assetBatchFetches, afterBroken + 1, "a rejected refresh must not poison the cache or in-flight map");
     assert.deepEqual(recovered.assets.errors, []);
   } finally {
     // Safe even when already resolved; prevents a failed assertion from leaving


### PR DESCRIPTION
## Summary

Make the `/treasury` asset summary fail closed instead of turning missing or degenerate on-chain data into confident zeroes.

This implements the four fixes confirmed by the maintainer:

1. gate `by_tier[].cents` on snapshot completeness;
2. reject a requested ABI word when the response is too short;
3. treat `sqrtPriceX96 === 0` as an error, not a zero-dollar price;
4. use the existing hole-filling batch reader for the core eleven-call asset read.

It also applies the zero-price guard to the optional pool-depth path, where the same impossible price could otherwise reach a division by zero.

Closes #38.

## Bugs and impact

### Tier subtotals contradicted the headline

`summarizeAssets()` already computes one snapshot-wide `complete` flag. `total_cents`, `conservative_total_cents`, and both location totals return `null` whenever any holding has `value_cents: null`.

`by_tier[].cents` was the exception:

```ts
rows.reduce((n, holding) => n + (holding.value_cents ?? 0), 0)
```

Because it was not gated by `complete`, an unreadable tier-2 holding produced a truthful `complete: false` and `total_cents: null` beside a confident tier-2 subtotal of `0`. A client that consumes the advertised tier split could therefore under-report the exact data the headline had correctly refused to total.

### Short ABI data became a valid zero

`word()` sliced the requested 32-byte ABI word and returned `0n` whenever fewer than 64 hex digits were present. That conflated two states:

- the contract returned the integer zero;
- the requested return word was absent or truncated.

A truthy short `slot0` result therefore decoded as `sqrtPriceX96 = 0n`. The converter deliberately maps zero arithmetic input to numeric zero, so the chain reader recorded `token_usd: 0`, emitted no error, valued both token holdings at zero, and could leave the entire summary `complete: true`.

### A partial provider response stopped fallback

The core asset reader used `batchCall()`, which returns as soon as any row in the batch answered. If provider A returned only response ID 0, the other ten calls stayed null even when provider B was healthy and configured as a fallback.

The depth reader already had `batchCallComplete()`: it retains answered rows, requests only the holes on the next pass, and rotates provider order. The eleven-call asset read simply was not using it.

### Zero also reached the optional depth walk

When the token claim is positive, `readTreasuryAssets()` invokes the separately cached depth walk after assembling the holdings. A zero square-root price there could eventually reach the marginal-value denominator `sqrtPriceX96 * sqrtPriceX96`. Returning an explicit unknown depth before any tick-ladder work preserves the documented additive/non-blocking behavior.

## Fix

### Completeness-gated tiers

`TierSummary.cents` is now `number | null`, matching the other aggregate fields. Every tier subtotal uses the same snapshot-wide `complete` gate:

- complete snapshot: numeric tier subtotals, including honest zeroes;
- incomplete snapshot: all aggregate tier subtotals are null;
- individual holding rows remain present so readers can see exactly what is missing;
- an empty holdings list remains complete and returns `[0, 0, 0]`.

This is intentionally global rather than per-tier completeness. It keeps every aggregate view under the same contract and prevents a partially valued snapshot from presenting any subtotal as a complete decomposition of the headline.

### Strict requested-word decoding

`word()` now throws when the requested slice is not exactly 64 hex digits. It no longer manufactures `0n` from missing bytes. Non-hex content continues to be rejected by `BigInt`.

An unexpected decode rejection remains distinct from an ordinary unavailable RPC result: it is not cached by the recently added asset cache, and the in-flight entry is cleared so a later healthy request can retry.

### Hole-filling core batch

The eleven-call read now calls `batchCallComplete()` instead of `batchCall()`. Existing semantics are reused rather than introducing another fallback implementation:

- valid answered rows are retained;
- only null holes are re-requested;
- provider order rotates between passes;
- exhausted holes remain null and flow into the existing named errors/incomplete holdings.

The regression fixture proves provider A receives 11 calls and returns one row, then healthy provider B receives only the remaining 10. The completed asset read has no errors and produces a complete summary.

### Explicit zero-price errors

The main token mark now decodes `slot0` whenever it is present. A zero `sqrtPriceX96`:

- adds `pool slot0 returned zero sqrtPriceX96; the token mark is unavailable`;
- leaves `token_usd` null;
- leaves both affected token holding values null;
- makes the aggregate summary incomplete/null instead of complete at $0.

The depth reader independently returns `{ depth: null, error }` for the same state before reading the tick ladder or performing price arithmetic.

The pure arithmetic helper still returns zero for zero input; policy belongs at the chain-read boundary, where an impossible pool response can be distinguished from ordinary arithmetic input.

## Regression coverage

`test/asset-read-integrity.test.ts` exercises the exported readers with ABI-shaped, read-only JSON-RPC fixtures:

1. a one-row partial provider response is completed by a healthy fallback using batch sizes `[11, 10]`;
2. a canonical four-word `slot0` with zero `sqrtPriceX96` yields a null/error token mark, null holding values, and an incomplete summary;
3. the same zero state stops the optional depth reader after its first two-call batch and returns an error instead of walking the ladder or throwing;
4. a truthy short `slot0` (`0x0`) rejects with the requested-word error rather than decoding as zero.

The existing summary regression now also checks that an unreadable holding produces `[null, null, null]` tier subtotals, while the empty complete snapshot remains `[0, 0, 0]`.

Before the source fix, the new coverage failed in the reported ways:

- only the partial provider was contacted;
- `token_usd` was `0` instead of `null`;
- the short response did not reject;
- tier subtotals were `[193936, 0, 0]` instead of null.

`test/treasury-asset-cache.test.ts` was updated to return canonical five-word Chainlink, four-word `slot0`, and two-word `collectFees` results. Its outage case now keeps every fallback unavailable and asserts request-count deltas, so it still proves resolved degraded results are cached while malformed rejections remain retryable under the new hole-filling reader.

## Public behavior

The intentional response-contract change is:

```ts
by_tier[].cents: number | null
```

Clients should already check `assets.complete`; when it is false, tier cents now agree with the headline and location aggregates rather than presenting partial numbers as zero. Complete responses are unchanged apart from benefiting from hole-filled provider data. Zero-quantity holdings still report numeric zero when their reads and prices are valid.

No valuation formula, provider list, cache TTL, cache scope, D1 behavior, or transaction behavior changes. Every RPC operation remains `eth_call` at `latest`; this patch does not claim block-pinned consistency.

## Scope and limitations

This follows the maintainer-prescribed narrow decoder/fallback changes. `word()` validates the requested word, not every ABI tuple's declared total width or Solidity type bounds. A malformed non-empty provider result is still considered a filled row by the existing batch primitive and then rejected during decoding rather than retried as a hole. `batchCallComplete()` retains its existing pass/chunk policy. Broader per-selector return-shape validation can be added separately without weakening this fail-closed fix.

## Verification

The branch is one commit directly on current synchronized `main` (`faddaf1`), with no merge-base drift at push time.

- `npm test` — **264/264 passing**
- `npm run typecheck` — passing
- issue-focused suite on the minimum supported **Node 22.6.0** — **27/27 passing**
- `npx wrangler deploy --dry-run` — successful
- `git diff --check` — clean

All new RPC fixtures are local read-only mocks. No transaction was signed, submitted, or broadcast.
