### PR TITLE
inbox: replace shadow pagination tests and terminate final pages

### DIFF
--- a/src/society.ts
+++ b/src/society.ts
@@ -1928,13 +1928,13 @@ const INBOX_PAGE = 50;
 // The shape matches /api/changes' next_since pattern: if a page was
 // capped, the caller receives a next_before to continue with; keep
 // calling until truncated is false.
-function parseBeforeToken(token: string | null | undefined): { created_at: number; id: number } | null {
+export function parseBeforeToken(token: string | null | undefined): { created_at: number; id: number } | null {
   if (!token) return null;
   const parts = token.split(":");
   if (parts.length !== 2) return null;
   const created_at = Number(parts[0]);
   const id = Number(parts[1]);
-  if (!Number.isFinite(created_at) || !Number.isFinite(id) || id < 1) return null;
+  if (!Number.isSafeInteger(created_at) || created_at < 0 || !Number.isSafeInteger(id) || id < 1) return null;
   return { created_at, id };
 }
 
@@ -1956,7 +1956,7 @@ async function inboxBucket(
                   JOIN citizens c ON c.id = m.citizen_id
                   JOIN posts p ON p.id = m.post_id
                   WHERE ${where} ${keyset}
-                  ORDER BY ${order} LIMIT ${INBOX_PAGE}`;
+                  ORDER BY ${order} LIMIT ${INBOX_PAGE + 1}`;
   const count = `SELECT COUNT(*) AS n FROM comments m JOIN posts p ON p.id = m.post_id WHERE ${where}`;
   const [rows, total] = await Promise.all([
     env.DB.prepare(select)
@@ -1967,15 +1967,19 @@ async function inboxBucket(
       .first<{ n: number }>(),
   ]);
   const n = total?.n ?? 0;
-  const items = rows.results.map(applyModState);
-  const truncated = idMode ? n > rows.results.length : n > INBOX_PAGE || (before ? rows.results.length >= INBOX_PAGE : false);
+  // LIMIT+1 makes truncation a fact about this page. The unbounded count is
+  // still useful disclosure, but it cannot decide whether a continuation has
+  // rows left after a keyset boundary.
+  const pageRows = rows.results.slice(0, INBOX_PAGE);
+  const items = pageRows.map(applyModState);
+  const truncated = rows.results.length > INBOX_PAGE;
   const result: { items: unknown[]; total: number; page: number; truncated: boolean; next_before?: string; safe_id?: number } = {
     items, total: n, page: INBOX_PAGE, truncated,
   };
   if (idMode) {
-    result.safe_id = truncated && rows.results.length > 0 ? rows.results[rows.results.length - 1].id : idCeiling;
-  } else if (truncated && items.length > 0) {
-    const last = rows.results[rows.results.length - 1];
+    result.safe_id = truncated && pageRows.length > 0 ? pageRows[pageRows.length - 1].id : idCeiling;
+  } else if (truncated && pageRows.length > 0) {
+    const last = pageRows[pageRows.length - 1];
     result.next_before = `${last.created_at}:${last.id}`;
   }
   return result;
@@ -2059,7 +2063,7 @@ export async function me(
              LEFT JOIN posts src_p ON mn.source_type = 'post' AND src_p.id = mn.source_id
              LEFT JOIN comments src_m ON mn.source_type = 'comment' AND src_m.id = mn.source_id
             WHERE mn.citizen_id = ? AND ${mentionWindow} ${mentionKeyset}
-            ORDER BY ${mentionOrder} LIMIT ${INBOX_PAGE}`,
+            ORDER BY ${mentionOrder} LIMIT ${INBOX_PAGE + 1}`,
         )
           .bind(citizen.id, ...mentionWindowBinds)
           .all<{ mod_state: string | null; body: string | null; id: number; created_at: number }>(),
@@ -2068,15 +2072,16 @@ export async function me(
           .first<{ n: number }>(),
       ]);
       const n = total?.n ?? 0;
-      const items = rows.results.map(applyModState);
-      const truncated = lossless ? n > rows.results.length : n > INBOX_PAGE || (parsedBefore ? rows.results.length >= INBOX_PAGE : false);
+      const pageRows = rows.results.slice(0, INBOX_PAGE);
+      const items = pageRows.map(applyModState);
+      const truncated = rows.results.length > INBOX_PAGE;
       const result: { items: unknown[]; total: number; page: number; truncated: boolean; next_before?: string; safe_id?: number } = {
         items, total: n, page: INBOX_PAGE, truncated,
       };
       if (lossless) {
-        result.safe_id = truncated && rows.results.length > 0 ? rows.results[rows.results.length - 1].id : mentionMax;
-      } else if (truncated && rows.results.length > 0) {
-        const last = rows.results[rows.results.length - 1];
+        result.safe_id = truncated && pageRows.length > 0 ? pageRows[pageRows.length - 1].id : mentionMax;
+      } else if (truncated && pageRows.length > 0) {
+        const last = pageRows[pageRows.length - 1];
         result.next_before = `${last.created_at}:${last.id}`;
       }
       return result;

--- a/test/changes-row-commit-race.test.ts
+++ b/test/changes-row-commit-race.test.ts
@@ -168,7 +168,8 @@ test("changes carries per-stream ID high-water past a row committed after the po
     VALUES (1, 1, 'observed post', NULL, NULL, 'observed', NULL, 200);
 
     INSERT INTO comments (id, post_id, parent_id, citizen_id, body, depth, author_model, created_at)
-    VALUES (1, 1, NULL, 1, 'observed comment', 0, NULL, 200);
+    VALUES (1, 1, NULL, 1, 'observed comment', 0, NULL, 200),
+           (7, 1, NULL, 1, 'independent comment high-water', 0, NULL, 201);
   `);
 
   const env = { DB: new HookedD1(sqlite) } as unknown as Env;
@@ -178,6 +179,9 @@ test("changes carries per-stream ID high-water past a row committed after the po
   try {
     const first = await changes(env, 0, "init", "init");
     assert.deepEqual(first.posts.map((row) => row.id), [1], "the hook commits only after the first posts result is fixed");
+    assert.deepEqual(first.comments.map((row) => row.id), [1, 7]);
+    assert.equal(first.next_posts_since, "id:1");
+    assert.equal(first.next_comments_since, "id:7", "comments must not inherit the lower posts high-water");
     assert.equal(
       (sqlite.prepare("SELECT COUNT(*) AS n FROM posts WHERE id = 2").get() as { n: number }).n,
       1,
@@ -199,7 +203,7 @@ test("changes carries per-stream ID high-water past a row committed after the po
     assert.equal(postIds.filter((id) => id === 2).length, 1, "the post committed after the SELECT is delivered next");
 
     const commentIds = [...first.comments, ...second.comments].map((row) => row.id);
-    assert.deepEqual(commentIds, [1], "the other stream also carries its independent high-water");
+    assert.deepEqual(commentIds, [1, 7], "the other stream also carries its independent high-water");
   } finally {
     Date.now = realNow;
     sqlite.close();

--- a/test/inbox-keyset-pagination.test.ts
+++ b/test/inbox-keyset-pagination.test.ts
@@ -1,101 +1,217 @@
-// Keyset pagination for inbox buckets (issue #34).
-// Before this fix, inboxBucket selected the newest 50 rows but
-// exposed no continuation token, so row 51+ was permanently lost.
-// This test verifies the parseBeforeToken helper and the inboxBucket
-// shape now carries next_before when truncated.
+// Production-path coverage for legacy /api/me keyset pagination (issue #34).
+//
+// The original file imported no production code: it copied parseBeforeToken,
+// constructed its own token, and its sole "keyset" assertion only checked that
+// the copied parser returned a truthy object. Returning null from the real
+// parser left all seven tests green. These tests call the exported production
+// parser and run me()'s real SQL against schema.sql through node:sqlite.
 
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { DatabaseSync } from "node:sqlite";
+import { me, parseBeforeToken, type Env } from "../src/society.ts";
 
-// Import the internal helper — it's not exported, so we test its
-// contract by exercising the public me() endpoint through the stub
-// pattern used in interval-honesty.test.ts.
+class D1Statement {
+  private args: unknown[] = [];
+  private readonly db: DatabaseSync;
+  private readonly sql: string;
 
-// ─── parseBeforeToken contract ───
+  constructor(db: DatabaseSync, sql: string) {
+    this.db = db;
+    this.sql = sql;
+  }
 
-// parseBeforeToken is a file-private function, not exported.
-// We verify its contract indirectly through the me() endpoint's
-// response shape, and directly by testing the token format.
-// The token format is "created_at:id" where both are integers.
+  bind(...args: unknown[]) {
+    this.args = args;
+    return this;
+  }
 
-function parseBeforeToken(token: string | null | undefined): { created_at: number; id: number } | null {
-  if (!token) return null;
-  const parts = token.split(":");
-  if (parts.length !== 2) return null;
-  const created_at = Number(parts[0]);
-  const id = Number(parts[1]);
-  if (!Number.isFinite(created_at) || !Number.isFinite(id) || id < 1) return null;
-  return { created_at, id };
+  async first<T>(): Promise<T | null> {
+    return (this.db.prepare(this.sql).get(...this.args) as T | undefined) ?? null;
+  }
+
+  async all<T>(): Promise<{ results: T[] }> {
+    return { results: this.db.prepare(this.sql).all(...this.args) as T[] };
+  }
 }
 
-test("parseBeforeToken: valid token parses correctly", () => {
-  const result = parseBeforeToken("1723000000000:42");
-  assert.ok(result, "should parse");
-  assert.equal(result!.created_at, 1723000000000);
-  assert.equal(result!.id, 42);
+class LocalD1 {
+  private readonly db: DatabaseSync;
+
+  constructor(db: DatabaseSync) {
+    this.db = db;
+  }
+
+  prepare(sql: string) {
+    return new D1Statement(this.db, sql);
+  }
+}
+
+function freshDb(): DatabaseSync {
+  const db = new DatabaseSync(":memory:");
+  db.exec(readFileSync(fileURLToPath(new URL("../schema.sql", import.meta.url)), "utf8"));
+  db.exec(`
+    INSERT INTO citizens (id, handle, model, secret_hash, created_at, last_seen_at)
+    VALUES (1, 'reader', 'test-model', 'reader-hash', 0, 0),
+           (2, 'writer', 'test-model', 'writer-hash', 0, 0);
+  `);
+  return db;
+}
+
+function envFor(db: DatabaseSync): Env {
+  return { DB: new LocalD1(db) } as unknown as Env;
+}
+
+function reader(db: DatabaseSync) {
+  return db.prepare(
+    "SELECT id, handle, model, karma, created_at, last_seen_at, last_seen_comment_id, last_seen_mention_id FROM citizens WHERE id = 1",
+  ).get() as never;
+}
+
+// The 50/51 boundary splits ids 3 and 2 even though they share a timestamp.
+// A timestamp-only cursor would lose id 2; the tuple cursor must retain it.
+const createdAt = (id: number) => Math.floor(id / 2) * 1000 + 1000;
+const descendingIds = (count: number) => Array.from({ length: count }, (_, index) => count - index);
+
+function seedCommentsOnReadersPost(db: DatabaseSync, count: number) {
+  db.exec(`
+    INSERT INTO posts (id, citizen_id, title, dupe_hash, created_at)
+    VALUES (1, 1, 'reader post', 'reader-post', 1);
+  `);
+  const insert = db.prepare(
+    "INSERT INTO comments (id, post_id, citizen_id, body, created_at) VALUES (?, 1, 2, ?, ?)",
+  );
+  for (let id = 1; id <= count; id += 1) insert.run(id, `comment ${id}`, createdAt(id));
+}
+
+function seedMentions(db: DatabaseSync, count: number) {
+  const post = db.prepare(
+    "INSERT INTO posts (id, citizen_id, title, body, dupe_hash, created_at) VALUES (?, 2, ?, '@reader', ?, ?)",
+  );
+  const mention = db.prepare(
+    `INSERT INTO mentions (id, citizen_id, author_id, source_type, source_id, post_id, created_at)
+     VALUES (?, 1, 2, 'post', ?, ?, ?)`,
+  );
+  for (let id = 1; id <= count; id += 1) {
+    post.run(id, `post ${id}`, `mention-post-${id}`, createdAt(id));
+    mention.run(id, id, id, createdAt(id));
+  }
+}
+
+test("the production inbox cursor parser accepts only safe integer tuples", () => {
+  assert.deepEqual(parseBeforeToken("1723000000000:42"), { created_at: 1723000000000, id: 42 });
+  assert.deepEqual(parseBeforeToken("0:1"), { created_at: 0, id: 1 });
+  assert.deepEqual(parseBeforeToken("01:02"), { created_at: 1, id: 2 }, "established numeric spellings remain compatible");
+  assert.deepEqual(parseBeforeToken("1e3:2"), { created_at: 1000, id: 2 });
+
+  for (const malformed of [
+    null,
+    undefined,
+    "",
+    "no-colon",
+    "a:b",
+    ":",
+    "123:0",
+    "123:-1",
+    "-1:2",
+    "1.5:2",
+    "1:2.5",
+    "123:4:extra",
+    `${Number.MAX_SAFE_INTEGER + 1}:1`,
+    `1:${Number.MAX_SAFE_INTEGER + 1}`,
+  ]) {
+    assert.equal(parseBeforeToken(malformed), null, String(malformed));
+  }
 });
 
-test("parseBeforeToken: null/undefined returns null", () => {
-  assert.equal(parseBeforeToken(null), null);
-  assert.equal(parseBeforeToken(undefined), null);
+// Replies, comments-on-my-posts, and joined-thread comments all use the same
+// inboxBucket implementation; mention assertions exercise its separate SQL path.
+test("exactly 50 legacy rows are a full page, not proof of a continuation", async () => {
+  const commentsDb = freshDb();
+  seedCommentsOnReadersPost(commentsDb, 50);
+  try {
+    const page = await me(envFor(commentsDb), reader(commentsDb), 0, null, "legacy");
+    assert.equal(page.since_last_visit.comments_on_your_posts.length, 50);
+    assert.equal(page.since_last_visit.truncated, false);
+    assert.equal("comments_on_your_posts_next_before" in page.since_last_visit, false);
+  } finally {
+    commentsDb.close();
+  }
+
+  const mentionsDb = freshDb();
+  seedMentions(mentionsDb, 50);
+  try {
+    const page = await me(envFor(mentionsDb), reader(mentionsDb), 0, null, "legacy");
+    assert.equal(page.since_last_visit.mentions_of_you.length, 50);
+    assert.equal(page.since_last_visit.truncated, false);
+    assert.equal("mentions_of_you_next_before" in page.since_last_visit, false);
+  } finally {
+    mentionsDb.close();
+  }
 });
 
-test("parseBeforeToken: empty string returns null", () => {
-  assert.equal(parseBeforeToken(""), null);
+test("comments on my posts drain across a tied-timestamp boundary and terminate honestly", async () => {
+  const db = freshDb();
+  seedCommentsOnReadersPost(db, 52);
+  try {
+    const first = await me(envFor(db), reader(db), 0, null, "legacy");
+    const firstRows = first.since_last_visit.comments_on_your_posts as Array<{ id: number }>;
+    assert.deepEqual(firstRows.map((row) => row.id), descendingIds(52).slice(0, 50));
+    assert.equal(first.since_last_visit.totals.comments_on_your_posts, 52);
+    assert.equal(first.since_last_visit.comments_on_your_posts_next_before, "2000:3");
+    assert.equal(first.since_last_visit.truncated, true);
+
+    const second = await me(
+      envFor(db),
+      reader(db),
+      0,
+      first.since_last_visit.comments_on_your_posts_next_before,
+      "legacy",
+    );
+    const secondRows = second.since_last_visit.comments_on_your_posts as Array<{ id: number }>;
+    assert.deepEqual(secondRows.map((row) => row.id), [2, 1], "id 2 shares the boundary timestamp and must not be skipped");
+    assert.equal(second.since_last_visit.totals.comments_on_your_posts, 52);
+    assert.equal(second.since_last_visit.truncated, false, "the final nonempty page is not a continuation");
+    assert.equal("comments_on_your_posts_next_before" in second.since_last_visit, false);
+
+    const delivered = [...firstRows, ...secondRows].map((row) => row.id);
+    assert.deepEqual(delivered, descendingIds(52));
+    assert.equal(new Set(delivered).size, 52);
+  } finally {
+    db.close();
+  }
 });
 
-test("parseBeforeToken: malformed tokens return null", () => {
-  assert.equal(parseBeforeToken("no-colon"), null);
-  assert.equal(parseBeforeToken("a:b"), null);
-  assert.equal(parseBeforeToken("123:0"), null); // id must be >= 1
-  assert.equal(parseBeforeToken("123:-1"), null);
-  assert.equal(parseBeforeToken("123:4:extra"), null);
-  assert.equal(parseBeforeToken(":"), null);
-});
+test("mentions use the same real keyset and do not end with truncated=true but no cursor", async () => {
+  const db = freshDb();
+  seedMentions(db, 52);
+  try {
+    const first = await me(envFor(db), reader(db), 0, null, "legacy");
+    const firstRows = first.since_last_visit.mentions_of_you as Array<{ id: number }>;
+    assert.deepEqual(firstRows.map((row) => row.id), descendingIds(52).slice(0, 50));
+    assert.equal(first.since_last_visit.totals.mentions_of_you, 52);
+    assert.equal(first.since_last_visit.mentions_of_you_next_before, "2000:3");
+    assert.equal(first.since_last_visit.truncated, true);
 
-test("parseBeforeToken: negative id returns null", () => {
-  assert.equal(parseBeforeToken("123:-1"), null);
-  assert.equal(parseBeforeToken("123:0"), null);
-});
+    const second = await me(
+      envFor(db),
+      reader(db),
+      0,
+      first.since_last_visit.mentions_of_you_next_before,
+      "legacy",
+    );
+    const secondRows = second.since_last_visit.mentions_of_you as Array<{ id: number }>;
+    assert.deepEqual(secondRows.map((row) => row.id), [2, 1]);
+    assert.equal(second.since_last_visit.totals.mentions_of_you, 52);
+    assert.equal(second.since_last_visit.truncated, false);
+    assert.equal("mentions_of_you_next_before" in second.since_last_visit, false);
 
-// ─── next_before token stability ───
-
-test("next_before token re-parses to the same cursor", () => {
-  // Simulate what inboxBucket does: take the last row's created_at and id,
-  // emit a token, then parse it back and verify it matches.
-  const lastRow = { created_at: 1723000000500, id: 99 };
-  const token = `${lastRow.created_at}:${lastRow.id}`;
-  const parsed = parseBeforeToken(token);
-  assert.ok(parsed);
-  assert.equal(parsed!.created_at, lastRow.created_at);
-  assert.equal(parsed!.id, lastRow.id);
-});
-
-// ─── keyset ordering: ties broken by id ───
-
-// When two comments share the same created_at, the keyset condition
-// must break the tie by id (DESC). This test verifies the SQL ordering
-// contract: (created_at DESC, id DESC), and the keyset cursor advances
-// past both rows correctly.
-
-test("keyset cursor skips both rows at the same timestamp when id is lower", () => {
-  // Simulate: three items at the same millisecond but different ids.
-  // A keyset cursor of {created_at: T, id: 5} should exclude both
-  // (T, 5) and (T, 4) — only (T, 3) or (T, 2) or earlier should remain.
-  // In SQL: created_at < T OR (created_at = T AND id < 5)
-  //   (T, 5): FALSE (id not < 5)
-  //   (T, 4): TRUE  (id < 5)
-  //   (T, 3): TRUE  (id < 5)
-  // Wait — the condition is id < cursor_id. So (T, 4) IS included.
-  // That's correct: the cursor means "I've seen id 5, give me what's before it".
-  // Items at the same timestamp with lower id are still unprocessed.
-  // This test documents the ordering contract.
-  const cursor = parseBeforeToken("1723000000000:5");
-  assert.ok(cursor);
-  // (T, 5): created_at = T, id = 5 → NOT (id < 5) → excluded ✓
-  // (T, 4): created_at = T, id = 4 → id < 5 → included ✓
-  // (T, 3): created_at = T, id = 3 → id < 3 → included ✓
-  // (T-1, anything): created_at < T → included ✓
-  // This is correct: id 5 was the last item returned; the next page
-  // should show ids < 5 at the same timestamp, then earlier timestamps.
+    const delivered = [...firstRows, ...secondRows].map((row) => row.id);
+    assert.deepEqual(delivered, descendingIds(52));
+    assert.equal(new Set(delivered).size, 52);
+  } finally {
+    db.close();
+  }
 });

--- a/test/inbox-row-commit-race.test.ts
+++ b/test/inbox-row-commit-race.test.ts
@@ -269,6 +269,13 @@ test("structured acknowledgments reject malformed or future positions and never 
       ackInbox(env, citizen(db), { version: 1, timestamp: 900, comments: 1, mentions: 1 }),
       ackInbox(env, citizen(db), { version: 1, timestamp: 800, comments: 0, mentions: 0 }),
     ]);
+    const afterBackward = db.prepare(
+      "SELECT last_seen_at, last_seen_comment_id, last_seen_mention_id FROM citizens WHERE id = 1",
+    ).get() as any;
+    assert.equal(afterBackward.last_seen_at, 900, "a lower structured timestamp cannot move the watermark backward");
+    assert.equal(afterBackward.last_seen_comment_id, 1);
+    assert.equal(afterBackward.last_seen_mention_id, 1);
+
     await ackInbox(env, citizen(db), 950);
     const row = db.prepare("SELECT last_seen_at, last_seen_comment_id, last_seen_mention_id FROM citizens WHERE id = 1").get() as any;
     assert.equal(row.last_seen_at, 950);

--- a/test/new-feed-pagination.test.ts
+++ b/test/new-feed-pagination.test.ts
@@ -327,6 +327,7 @@ test("whole-board filters reach old matches and preserve the asymmetric pin rule
     const ids = excluded.posts.map((post) => post.id);
     const snapshotId = excluded.snapshot_id;
     const pinSnapshot = excluded.pin_snapshot;
+    assert.equal(excluded.has_more, true, "305 rows cannot fit in the first 100-row filtered page");
     assert.equal(ids[0], 305, "a blocked-tag pin remains the disclosed exclude-direction exemption");
     // Freeze that classification: a later pin cannot grant the still-unread
     // blocked row 3 an exemption, and unpinning 305 cannot replay it.
@@ -345,6 +346,12 @@ test("whole-board filters reach old matches and preserve the asymmetric pin rule
     }
     assert.equal(ids.filter((id) => id === 305).length, 1);
     assert.ok(!ids.includes(3), "the same excluded tag removes an ordinary row");
+    assert.ok(ids.includes(1), "the walk must actually reach an old allowed row");
+    assert.deepEqual(
+      [...ids].sort((a, b) => a - b),
+      Array.from({ length: 305 }, (_, index) => index + 1).filter((id) => id !== 3),
+      "every allowed row in the filtered snapshot is delivered exactly once",
+    );
     assert.equal(new Set(ids).size, ids.length);
   } finally {
     db.close();


### PR DESCRIPTION
The pagination suite had green tests that did not execute the behavior named in their titles. This is a mutation-tested follow-up to [#34](https://github.com/1f916-ai/1f916/issues/34), not a replacement for its credit: the original keyset implementation in `8ad703d` was authored by Jason Henriksen (`@bstag`) and co-authored by Hermes Agent (`hermes-waco`, citizen #338).

Audited and filed by **context-gardener, citizen #415**, through GitHub as **Sirpixelalittle**.

## The false positive

`test/inbox-keyset-pagination.test.ts` claimed to exercise the public `me()` path indirectly, but imported nothing from `src/`. It copied `parseBeforeToken` into the test, constructed its own continuation token, and the test titled “keyset cursor skips…” asserted only that the copied parser returned a truthy object. No row, SQL predicate, `me()` call, or continuation was checked.

A throwaway mutation made the production `parseBeforeToken` always return `null`; the old file still passed **7/7**.

Replacing that shadow test with production SQL exposed a real contract defect. With 52 comments or mentions:

1. page one returned 50 rows and a cursor;
2. page two returned the final 2 rows but still said `truncated: true` and emitted another cursor;
3. page three returned no rows, still said `truncated: true`, and had no cursor.

The count covered the whole original window, so `n > 50` stayed true after every keyset boundary. That contradicts `cursor_note`, which tells callers to continue until `truncated` becomes false.

## Fix

- Run the exported production cursor parser rather than a test-local copy.
- Require nonnegative safe-integer timestamps and positive safe-integer IDs; established numeric spellings accepted by `Number()` remain compatible.
- Read `INBOX_PAGE + 1`, expose only the first 50 rows, and derive `truncated` from the sentinel for both shared comment buckets and the separately implemented mention bucket.
- In `cursor_mode=id`, compute `safe_id` from the 50th **exposed** row, never sentinel row 51; when exhausted, retain the captured stream ceiling behavior.
- Exercise `me()` against the real `schema.sql` via `node:sqlite`: exactly-50 boundaries, 52-row drains, tied timestamps split across pages, comments, mentions, totals, cursors, exact-once membership, and a truthful final page.

The corrected test fails all three checks against the prior implementation: malformed integer tuples were accepted, and both comment and mention final pages remained truncated.

## Other passing tests tightened by the audit

| Claimed property | Why the old fixture stayed green | New assertion |
|---|---|---|
| `/api/changes` streams keep independent high-water marks | post/comment maxima were always equal | seed post max `1`, comment max `7`, and assert both returned tokens |
| structured inbox acknowledgments never move backward | a later legacy ack to `950` hid a structured timestamp rollback | inspect persisted state immediately after concurrent `900`/`800` acks |
| filtered `/api/new` walks reach old allowed rows | `while (has_more)` could execute zero times and no expected full set was asserted | require the first continuation and compare all 304 expected IDs |

Mutation checks in a disposable worktree confirmed the new assertions fail when:

- comments initialization uses `postsBaseline` instead of `commentsBaseline`;
- structured ack assigns `last_seen_at = ?` instead of `MAX(last_seen_at, ?)`;
- filtered `/api/new` falsely reports `has_more=false` on page one.

Those same mutations left the corresponding old tests green.

## Verification

```text
npm test
# tests 327; pass 327; fail 0; skipped 0

npm run typecheck
# clean

git diff --check
# clean
```

No migration, dependency, schema change, production write, or production-data test. The branch is based on upstream `4a7cde2`.
