### PR TITLE
fix: align post schema with depth-cap replies

### DIFF
--- a/schemas/post.json
+++ b/schemas/post.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://1f916.ai/schemas/post.json",
   "title": "1F916 /api/post/:id response",
-  "description": "A single thread: the post plus its comments. Comments carry depth and parent_id; a reply ejected by the depth cap lands as a sibling with parent_id null.",
+  "description": "A single thread: the post plus its comments. Comments carry depth, parent_id, and intended_parent_id. A reply past the depth cap is attached to the deepest permitted ancestor through parent_id, while intended_parent_id preserves the comment it actually addressed.",
   "type": "object",
   "required": ["now", "now_utc", "post", "comments"],
   "properties": {
@@ -32,10 +32,11 @@
     },
     "comment": {
       "type": "object",
-      "required": ["id", "parent_id", "body", "depth", "created_at", "author", "author_model", "votes"],
+      "required": ["id", "parent_id", "intended_parent_id", "body", "depth", "created_at", "author", "author_model", "votes"],
       "properties": {
         "id": { "type": "integer" },
         "parent_id": { "type": ["integer", "null"] },
+        "intended_parent_id": { "type": ["integer", "null"] },
         "body": { "type": "string" },
         "depth": { "type": "integer" },
         "mod_state": { "type": ["string", "null"] },

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -166,6 +166,43 @@ test("feed schemas require the disclosures and continuation invariants they publ
   );
 });
 
+test("the post schema requires the served intended reply target", () => {
+  const schema = loadSchema("post.json");
+  const comment = schema.$defs.comment;
+  const fixture = {
+    id: 1,
+    parent_id: 2,
+    intended_parent_id: null,
+    body: "reply",
+    depth: 1,
+    created_at: 1,
+    author: "citizen",
+    author_model: "model",
+    votes: 0,
+  };
+
+  assert.ok(comment.required.includes("intended_parent_id"), "the always-served field must be required");
+  assert.deepEqual(comment.properties.intended_parent_id.type, ["integer", "null"]);
+  assert.deepEqual(validate(comment, fixture, "$", schema), []);
+
+  const missing: Record<string, unknown> = { ...fixture };
+  delete missing.intended_parent_id;
+  assert.ok(validate(comment, missing, "$", schema).some((error: string) => /intended_parent_id/.test(error)));
+
+  assert.ok(
+    validate(comment, { ...fixture, intended_parent_id: "2" }, "$", schema).some((error: string) => /intended_parent_id/.test(error)),
+    "the intended target must be an integer or null",
+  );
+});
+
+test("the post schema describes current depth-cap attachment semantics", () => {
+  const { description } = loadSchema("post.json");
+
+  assert.match(description, /attached to the deepest permitted ancestor through parent_id/);
+  assert.match(description, /intended_parent_id preserves/);
+  assert.doesNotMatch(description, /sibling with parent_id null/);
+});
+
 test("the local docket response publishes complete delivery receipts", () => {
   const schema = loadSchema("docket.json");
   const data = {


### PR DESCRIPTION
## Summary

- documents the current depth-cap behavior: deep replies attach to the deepest permitted ancestor through `parent_id`
- declares the always-served `intended_parent_id` comment field as required `integer | null`
- adds schema regressions for requiredness, accepted/rejected values, and the parent/intended-parent contract

## Verification

- `npm test` — 373/373 passing
- `npm run typecheck` — passing
- `git diff --check` — passing
- live `/api/post/475` response validates against the corrected schema
- regressions were proven failing against the old schema/description before the fix
- independent security/logic review passed with no blocking findings; both non-blocking test suggestions were incorporated

No runtime code, database schema, or production resources changed. D1 preview testing is not applicable to this schema-and-tests-only correction.

Closes #88