### PR TITLE
Prevent phantom identity events on concurrent key revocation

### DIFF
--- a/src/society.ts
+++ b/src/society.ts
@@ -1752,6 +1752,10 @@ export async function revokeKey(env: Env, citizen: Citizen, body: { thumbprint?:
     stateStmt,
     { citizen_id: citizen.id, kind: "key-revoke", detail: `${thumbprint} revoked (${mode})` },
     "key-revoke chain head moved four times running; refusing to revoke without its anchor",
+    // D1 batches execute sequentially in one transaction, so changes() here is
+    // the result of the UPDATE immediately above. A concurrent loser changes
+    // zero rows and therefore cannot append a second, false revocation boundary.
+    { sql: "changes() = 1", binds: [] },
   );
   if (done.changed === 0) throw new SocietyError(409, "that key stopped being active while this request ran — read GET /api/keys/" + citizen.handle);
   return {

--- a/test/key-revoke-race.test.ts
+++ b/test/key-revoke-race.test.ts
@@ -1,0 +1,105 @@
+// A rejected concurrent revocation must not leave a witnessed event for an
+// operation that changed no state. Run the real statements sequentially in a
+// transaction, as D1 does; a batch stub that only reports success misses this.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
+import { revokeKey, SocietyError, type Env } from "../src/society.ts";
+
+class D1Statement {
+  private args: unknown[] = [];
+  private readonly db: DatabaseSync;
+  private readonly sql: string;
+  constructor(db: DatabaseSync, sql: string) {
+    this.db = db;
+    this.sql = sql;
+  }
+  bind(...args: unknown[]) { this.args = args; return this; }
+  async first<T>(): Promise<T | null> {
+    return (this.db.prepare(this.sql).get(...(this.args as never[])) as T | undefined) ?? null;
+  }
+  async all<T>(): Promise<{ results: T[] }> {
+    return { results: this.db.prepare(this.sql).all(...(this.args as never[])) as T[] };
+  }
+  async run() {
+    const result = this.db.prepare(this.sql).run(...(this.args as never[]));
+    return { meta: { changes: Number(result.changes) } };
+  }
+  _run() {
+    const result = this.db.prepare(this.sql).run(...(this.args as never[]));
+    return { results: [], meta: { changes: Number(result.changes) } };
+  }
+}
+
+function makeEnv() {
+  const db = new DatabaseSync(":memory:");
+  db.exec(`
+    CREATE TABLE keys (
+      id INTEGER PRIMARY KEY, citizen_id INTEGER NOT NULL, public_key TEXT NOT NULL,
+      thumbprint TEXT NOT NULL UNIQUE, status TEXT NOT NULL, ended_at INTEGER
+    );
+    CREATE TABLE identity_events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT, citizen_id INTEGER, kind TEXT, detail TEXT,
+      created_at INTEGER, prev_hash TEXT, hash TEXT UNIQUE
+    );
+  `);
+  const env = {
+    DB: {
+      prepare: (sql: string) => new D1Statement(db, sql),
+      async batch(stmts: D1Statement[]) {
+        db.exec("BEGIN");
+        try {
+          const results = stmts.map((s) => s._run());
+          db.exec("COMMIT");
+          return results;
+        } catch (e) {
+          db.exec("ROLLBACK");
+          throw e;
+        }
+      },
+    },
+  } as unknown as Env;
+  return { env, db };
+}
+
+const citizen = { id: 7, handle: "race-witness", model: "test", karma: 0, created_at: 1, last_seen_at: 1 };
+
+test("a losing concurrent key revocation appends no phantom identity event", async () => {
+  const { env, db } = makeEnv();
+  const thumbprint = "t".repeat(43);
+  db.prepare("INSERT INTO keys (id, citizen_id, public_key, thumbprint, status) VALUES (3, 7, 'unused', ?, 'active')").run(thumbprint);
+
+  // Hold both initial SELECTs until both requests have observed the key active.
+  const originalPrepare = (env.DB as never as { prepare(sql: string): D1Statement }).prepare;
+  let reads = 0;
+  let release!: () => void;
+  const bothRead = new Promise<void>((resolve) => { release = resolve; });
+  (env.DB as never as { prepare(sql: string): D1Statement }).prepare = (sql: string) => {
+    const stmt = originalPrepare(sql);
+    if (!sql.startsWith("SELECT id, public_key, status FROM keys")) return stmt;
+    const first = stmt.first.bind(stmt);
+    stmt.first = async <T>() => {
+      const row = await first<T>();
+      reads++;
+      if (reads === 2) release();
+      await bothRead;
+      return row;
+    };
+    return stmt;
+  };
+
+  const settled = await Promise.allSettled([
+    revokeKey(env, citizen, { thumbprint }),
+    revokeKey(env, citizen, { thumbprint }),
+  ]);
+  assert.equal(settled.filter((r) => r.status === "fulfilled").length, 1);
+  const rejected = settled.find((r) => r.status === "rejected") as PromiseRejectedResult;
+  assert.ok(rejected.reason instanceof SocietyError);
+  assert.equal(rejected.reason.status, 409);
+
+  const key = db.prepare("SELECT status FROM keys WHERE id = 3").get() as { status: string };
+  assert.equal(key.status, "revoked");
+  const events = db.prepare("SELECT id, detail FROM identity_events WHERE citizen_id = 7 AND kind = 'key-revoke'").all();
+  assert.equal(events.length, 1, "only the revocation that changed state may enter the witnessed identity log");
+});


### PR DESCRIPTION
## Bug

Two concurrent `POST /api/keys/revoke` requests can both read the key while it is active. The winner changes the key to `revoked`; the loser's conditional UPDATE changes zero rows. However, `commitWithIdentityEvent()` currently batches that UPDATE with an **unguarded** chained INSERT, so the losing request still appends a second `key-revoke` event before returning 409.

The result is a permanent, checkpointed identity event for an operation the API correctly says did nothing. That breaks the state/event correspondence revocation relies on as its time boundary.

## Fix

Give the chained event INSERT an in-transaction guard tied to the immediately preceding UPDATE:

```sql
changes() = 1
```

D1 batch statements execute sequentially in one transaction. The event statement therefore sees the UPDATE's change count: the winner inserts its event, while a losing UPDATE reports zero changes and inserts no event. The repo already uses this D1/SQLite sequencing property to prevent duplicate vote/karma writes.

## Regression

`test/key-revoke-race.test.ts` uses real SQLite statements and sequential transactional batch execution, synchronizes two requests so both initial reads observe `active`, then proves:

- exactly one request succeeds;
- exactly one returns 409;
- the key is revoked; and
- exactly one `key-revoke` identity event exists.

Without the fix the regression fails `2 !== 1`.

## Verification

- `npm test` — **424/424 passed, 0 skipped**
- `npm run typecheck` — passed
- `npm audit --omit=dev` — 0 vulnerabilities
- `npx wrangler deploy --dry-run` — passed
- `git diff --check` — clean

This PR intentionally fixes exactly this one bug.
