### PR TITLE
Test helper: share real-SQLite sequential D1 batches

### DIFF
--- a/test/helpers/sqlite-d1.ts
+++ b/test/helpers/sqlite-d1.ts
@@ -1,0 +1,87 @@
+// Minimal D1 adapter backed by node:sqlite for tests whose correctness depends
+// on batch statements executing sequentially inside one transaction.
+//
+// A mock that returns canned batch success cannot expose changes(), guards that
+// read a preceding statement's post-state, or rollback of earlier statements.
+// Keep those semantics here so every state/event regression exercises the same
+// execution model.
+
+import { DatabaseSync } from "node:sqlite";
+import type { Env } from "../../src/society.ts";
+
+export class SqliteD1Statement {
+  private args: unknown[] = [];
+  private readonly db: DatabaseSync;
+  private readonly sql: string;
+
+  constructor(db: DatabaseSync, sql: string) {
+    this.db = db;
+    this.sql = sql;
+  }
+
+  bind(...args: unknown[]) {
+    this.args = args;
+    return this;
+  }
+
+  async first<T>(): Promise<T | null> {
+    return (this.db.prepare(this.sql).get(...(this.args as never[])) as T | undefined) ?? null;
+  }
+
+  async all<T>(): Promise<{ results: T[] }> {
+    return { results: this.db.prepare(this.sql).all(...(this.args as never[])) as T[] };
+  }
+
+  async run() {
+    const result = this.execute();
+    return { results: result.results, meta: result.meta };
+  }
+
+  execute(): { results: unknown[]; meta: { changes: number } } {
+    const statement = this.db.prepare(this.sql);
+    if (/^\s*SELECT\b/i.test(this.sql)) {
+      return { results: statement.all(...(this.args as never[])), meta: { changes: 0 } };
+    }
+    if (/\bRETURNING\b/i.test(this.sql)) {
+      const results = statement.all(...(this.args as never[]));
+      const changes = Number((this.db.prepare("SELECT changes() AS n").get() as { n: number }).n);
+      return { results, meta: { changes } };
+    }
+    const result = statement.run(...(this.args as never[]));
+    return { results: [], meta: { changes: Number(result.changes) } };
+  }
+}
+
+export class SqliteD1 {
+  private readonly db: DatabaseSync;
+
+  constructor(db: DatabaseSync) {
+    this.db = db;
+  }
+
+  prepare(sql: string) {
+    return new SqliteD1Statement(this.db, sql);
+  }
+
+  async batch(statements: SqliteD1Statement[]) {
+    this.db.exec("BEGIN");
+    try {
+      // Sequential order is load-bearing: SQLite's changes() and post-state
+      // guards in statement N observe statement N-1 before the transaction
+      // commits, matching the D1 batch contract these tests depend on.
+      const results = statements.map((statement) => statement.execute());
+      this.db.exec("COMMIT");
+      return results;
+    } catch (error) {
+      this.db.exec("ROLLBACK");
+      throw error;
+    }
+  }
+}
+
+export function sqliteTestEnv(schema: string): { env: Env; db: DatabaseSync; d1: SqliteD1 } {
+  const db = new DatabaseSync(":memory:");
+  db.exec(schema);
+  const d1 = new SqliteD1(db);
+  return { db, d1, env: { DB: d1 } as unknown as Env };
+}

--- a/test/key-revoke-race.test.ts
+++ b/test/key-revoke-race.test.ts
@@ -4,37 +4,11 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
-import { DatabaseSync } from "node:sqlite";
-import { revokeKey, SocietyError, type Env } from "../src/society.ts";
-
-class D1Statement {
-  private args: unknown[] = [];
-  private readonly db: DatabaseSync;
-  private readonly sql: string;
-  constructor(db: DatabaseSync, sql: string) {
-    this.db = db;
-    this.sql = sql;
-  }
-  bind(...args: unknown[]) { this.args = args; return this; }
-  async first<T>(): Promise<T | null> {
-    return (this.db.prepare(this.sql).get(...(this.args as never[])) as T | undefined) ?? null;
-  }
-  async all<T>(): Promise<{ results: T[] }> {
-    return { results: this.db.prepare(this.sql).all(...(this.args as never[])) as T[] };
-  }
-  async run() {
-    const result = this.db.prepare(this.sql).run(...(this.args as never[]));
-    return { meta: { changes: Number(result.changes) } };
-  }
-  _run() {
-    const result = this.db.prepare(this.sql).run(...(this.args as never[]));
-    return { results: [], meta: { changes: Number(result.changes) } };
-  }
-}
+import { revokeKey, SocietyError } from "../src/society.ts";
+import { SqliteD1Statement, sqliteTestEnv } from "./helpers/sqlite-d1.ts";
 
 function makeEnv() {
-  const db = new DatabaseSync(":memory:");
-  db.exec(`
+  return sqliteTestEnv(`
     CREATE TABLE keys (
       id INTEGER PRIMARY KEY, citizen_id INTEGER NOT NULL, public_key TEXT NOT NULL,
       thumbprint TEXT NOT NULL UNIQUE, status TEXT NOT NULL, ended_at INTEGER
@@ -44,23 +18,6 @@ function makeEnv() {
       created_at INTEGER, prev_hash TEXT, hash TEXT UNIQUE
     );
   `);
-  const env = {
-    DB: {
-      prepare: (sql: string) => new D1Statement(db, sql),
-      async batch(stmts: D1Statement[]) {
-        db.exec("BEGIN");
-        try {
-          const results = stmts.map((s) => s._run());
-          db.exec("COMMIT");
-          return results;
-        } catch (e) {
-          db.exec("ROLLBACK");
-          throw e;
-        }
-      },
-    },
-  } as unknown as Env;
-  return { env, db };
 }
 
 const citizen = { id: 7, handle: "race-witness", model: "test", karma: 0, created_at: 1, last_seen_at: 1 };
@@ -71,11 +28,11 @@ test("a losing concurrent key revocation appends no phantom identity event", asy
   db.prepare("INSERT INTO keys (id, citizen_id, public_key, thumbprint, status) VALUES (3, 7, 'unused', ?, 'active')").run(thumbprint);
 
   // Hold both initial SELECTs until both requests have observed the key active.
-  const originalPrepare = (env.DB as never as { prepare(sql: string): D1Statement }).prepare;
+  const originalPrepare = (env.DB as never as { prepare(sql: string): SqliteD1Statement }).prepare.bind(env.DB);
   let reads = 0;
   let release!: () => void;
   const bothRead = new Promise<void>((resolve) => { release = resolve; });
-  (env.DB as never as { prepare(sql: string): D1Statement }).prepare = (sql: string) => {
+  (env.DB as never as { prepare(sql: string): SqliteD1Statement }).prepare = (sql: string) => {
     const stmt = originalPrepare(sql);
     if (!sql.startsWith("SELECT id, public_key, status FROM keys")) return stmt;
     const first = stmt.first.bind(stmt);

--- a/test/rotate-log-row.test.ts
+++ b/test/rotate-log-row.test.ts
@@ -19,66 +19,19 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
-import { DatabaseSync } from "node:sqlite";
-import { rotateKey, type Env } from "../src/society.ts";
+import type { DatabaseSync } from "node:sqlite";
+import { rotateKey } from "../src/society.ts";
 import { sha256Hex } from "../src/chain.ts";
-
-class D1Statement {
-  private args: unknown[] = [];
-  private readonly db: DatabaseSync;
-  private readonly sql: string;
-  constructor(db: DatabaseSync, sql: string) {
-    this.db = db;
-    this.sql = sql;
-  }
-  bind(...args: unknown[]) {
-    this.args = args;
-    return this;
-  }
-  async first<T>(): Promise<T | null> {
-    return (this.db.prepare(this.sql).get(...(this.args as never[])) as T | undefined) ?? null;
-  }
-  async all<T>(): Promise<{ results: T[] }> {
-    return { results: this.db.prepare(this.sql).all(...(this.args as never[])) as T[] };
-  }
-  async run() {
-    const result = this.db.prepare(this.sql).run(...(this.args as never[]));
-    return { meta: { changes: Number(result.changes) } };
-  }
-  _run() {
-    const result = this.db.prepare(this.sql).run(...(this.args as never[]));
-    return { results: [], meta: { changes: Number(result.changes) } };
-  }
-}
+import { sqliteTestEnv } from "./helpers/sqlite-d1.ts";
 
 function makeEnv() {
-  const db = new DatabaseSync(":memory:");
-  db.exec(`
+  return sqliteTestEnv(`
     CREATE TABLE citizens (id INTEGER PRIMARY KEY, handle TEXT UNIQUE, secret_hash TEXT, model TEXT, karma INTEGER DEFAULT 0, created_at INTEGER DEFAULT 0);
     CREATE TABLE identity_events (
       id INTEGER PRIMARY KEY AUTOINCREMENT, citizen_id INTEGER, kind TEXT, detail TEXT,
       created_at INTEGER, prev_hash TEXT, hash TEXT UNIQUE
     );
   `);
-  const env = {
-    DB: {
-      prepare: (sql: string) => new D1Statement(db, sql),
-      // Sequential execution inside one transaction — D1's actual contract,
-      // and the detail the stub-based test abstracted away.
-      async batch(stmts: D1Statement[]) {
-        db.exec("BEGIN");
-        try {
-          const results = stmts.map((s) => s._run());
-          db.exec("COMMIT");
-          return results;
-        } catch (e) {
-          db.exec("ROLLBACK");
-          throw e;
-        }
-      },
-    },
-  } as unknown as Env;
-  return { env, db };
 }
 
 const SECRET = "1f916_sk_" + "ab".repeat(32);

--- a/test/vote-idempotency.test.ts
+++ b/test/vote-idempotency.test.ts
@@ -8,71 +8,8 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
-import { DatabaseSync } from "node:sqlite";
-import { castVote, SocietyError, type Env } from "../src/society.ts";
-
-class D1Statement {
-  private args: unknown[] = [];
-  private readonly db: DatabaseSync;
-  private readonly sql: string;
-
-  constructor(db: DatabaseSync, sql: string) {
-    this.db = db;
-    this.sql = sql;
-  }
-
-  bind(...args: unknown[]) {
-    this.args = args;
-    return this;
-  }
-
-  async first<T>(): Promise<T | null> {
-    return (this.db.prepare(this.sql).get(...this.args) as T | undefined) ?? null;
-  }
-
-  async all<T>(): Promise<{ results: T[] }> {
-    return { results: this.db.prepare(this.sql).all(...this.args) as T[] };
-  }
-
-  async run() {
-    const result = this.db.prepare(this.sql).run(...this.args);
-    return { meta: { changes: Number(result.changes) } };
-  }
-
-  execute() {
-    const statement = this.db.prepare(this.sql);
-    if (/\bRETURNING\b/i.test(this.sql)) {
-      const results = statement.all(...this.args);
-      return { results, meta: { changes: results.length } };
-    }
-    const result = statement.run(...this.args);
-    return { results: [], meta: { changes: Number(result.changes) } };
-  }
-}
-
-class LocalD1 {
-  private readonly db: DatabaseSync;
-
-  constructor(db: DatabaseSync) {
-    this.db = db;
-  }
-
-  prepare(sql: string) {
-    return new D1Statement(this.db, sql);
-  }
-
-  async batch(statements: D1Statement[]) {
-    this.db.exec("BEGIN");
-    try {
-      const results = statements.map((statement) => statement.execute());
-      this.db.exec("COMMIT");
-      return results;
-    } catch (error) {
-      this.db.exec("ROLLBACK");
-      throw error;
-    }
-  }
-}
+import { castVote, SocietyError } from "../src/society.ts";
+import { sqliteTestEnv } from "./helpers/sqlite-d1.ts";
 
 const VOTER = {
   id: 1,
@@ -84,8 +21,7 @@ const VOTER = {
 };
 
 test("a same-millisecond duplicate vote cannot mint duplicate karma", async () => {
-  const sqlite = new DatabaseSync(":memory:");
-  sqlite.exec(`
+  const { env, db: sqlite } = sqliteTestEnv(`
     CREATE TABLE citizens (id INTEGER PRIMARY KEY, karma INTEGER NOT NULL, created_at INTEGER NOT NULL);
     CREATE TABLE posts (id INTEGER PRIMARY KEY, citizen_id INTEGER NOT NULL);
     CREATE TABLE comments (id INTEGER PRIMARY KEY, citizen_id INTEGER NOT NULL);
@@ -99,7 +35,6 @@ test("a same-millisecond duplicate vote cannot mint duplicate karma", async () =
     INSERT INTO citizens VALUES (1, 0, 0), (2, 0, 0);
     INSERT INTO posts VALUES (99, 2);
   `);
-  const env = { DB: new LocalD1(sqlite) } as unknown as Env;
   const realNow = Date.now;
   Date.now = () => 1_786_400_000_123;
 


### PR DESCRIPTION
## Summary

Follow-up to the review note on #104: extract the real-SQLite, sequential-transaction D1 adapter into `test/helpers/sqlite-d1.ts` and use it from the unhooked batch regressions on main.

The helper preserves the semantics these tests are specifically meant to exercise:

- every batch statement runs in input order on the same SQLite connection;
- the batch is one `BEGIN`/`COMMIT` transaction and rolls back on any statement failure;
- `changes()` in statement N observes the completed write in statement N-1;
- one ordered result is returned per statement, with that statement's `meta.changes`;
- DML `RETURNING` rows are fully consumed before the next statement.

## Scope

Refactored:

- `test/rotate-log-row.test.ts`
- `test/key-revoke-race.test.ts`
- `test/vote-idempotency.test.ts`

The vote regression is the third unhooked duplicate already on main. The third file referenced in the #104 review is #103's `test/payouts.test.ts`, which is not on main yet; after this lands, that open branch can adopt the helper during its eventual rebase.

Deliberately not generalized:

- each test keeps its own schema and fixture data;
- cursor/row-commit tests keep their custom after-read injection adapters;
- the helper is a deliberately partial test double and does not claim to implement all of `D1Database`.

Net result: 167 lines of copied adapters removed, one 87-line shared implementation added, and no production code changed.

## Verification

- `npm test` — **424/424 passed, 0 skipped**
- focused three files — 5/5 passed
- helper smoke probe: DML `RETURNING`, per-statement `changes()`, and rollback all reproduced
- `npm run typecheck` — passed
- `npm audit --omit=dev` — 0 vulnerabilities
- `npx wrangler deploy --dry-run` — passed
- `git diff --check` — clean
