### PR TITLE
fix: enforce attestation cap atomically

### DIFF
--- a/src/society.ts
+++ b/src/society.ts
@@ -1754,9 +1754,17 @@ export async function issueAttestation(env: Env, issuer: Citizen, body: Attestat
   const v = await validateAttestation(env, issuer, body);
   const subject = await env.DB.prepare("SELECT id FROM citizens WHERE handle = ?").bind(v.subjectHandle).first<{ id: number }>();
   const now = Date.now();
+  const cutoff = now - 86_400_000;
+  // The budget belongs in the INSERT, not only in the fast-path count above.
+  // Two requests using the same credential can both read 19 before either one
+  // writes; SQLite serializes this statement so only the first can become row
+  // 20. The event carries the same changes() guard, or a refused row would
+  // still mint a chained claim that no attestation table row supports.
   const stateStmt = env.DB.prepare(
     `INSERT INTO attestations (class, issuer_id, subject_id, claim, evidence, payload, payload_hash, signature, key_thumbprint, target_attestation_id, withdraw_when, issued_at, payload_version)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id`,
+     SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+      WHERE (SELECT COUNT(*) FROM attestations WHERE issuer_id = ? AND issued_at >= ?) < ?
+     RETURNING id`,
   ).bind(
     v.cls,
     issuer.id,
@@ -1771,8 +1779,11 @@ export async function issueAttestation(env: Env, issuer: Citizen, body: Attestat
     v.withdrawWhen,
     now,
     ATTESTATION_PAYLOAD_VERSION,
+    issuer.id,
+    cutoff,
+    ATTESTATIONS_PER_DAY,
   );
-  let inserted: { state: { id: number } | null; hash: string };
+  let inserted: { state: { id: number } | null; changed: number; hash: string };
   try {
     inserted = await commitWithIdentityEvent<{ id: number }>(
       env,
@@ -1783,11 +1794,14 @@ export async function issueAttestation(env: Env, issuer: Citizen, body: Attestat
         detail: `${v.cls} about ${v.subjectHandle}, payload sha256=${v.payloadHash}${v.signature ? `, signed by ${v.thumbprint}` : ", unsigned (bearer-authenticated)"}`,
       },
       "attestation chain head moved four times running; refusing to record a claim without its anchor",
+      { sql: "changes() = 1", binds: [] },
     );
   } catch (e) {
     if (String(e).includes("UNIQUE")) throw new SocietyError(409, "an identical attestation (same class, subject, claim, evidence) already exists — the record is not a feed; issue a new claim or dispute the old one");
     throw e;
   }
+  if (inserted.changed === 0)
+    throw new SocietyError(429, `attestation budget spent (${ATTESTATIONS_PER_DAY}/rolling 24h) — scarcity is what keeps the record from becoming a feed`);
   return {
     attested: true,
     id: inserted.state?.id ?? null,

--- a/test/attestation-cap-race.test.ts
+++ b/test/attestation-cap-race.test.ts
@@ -1,0 +1,91 @@
+// The rolling attestation budget is a write invariant, not a hint. Two requests
+// using the same credential can pass a count performed before either INSERT;
+// the cap predicate therefore has to live in the chained write itself.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { ATTESTATIONS_PER_DAY, type AttestationInput } from "../src/attestations.ts";
+import { issueAttestation, SocietyError, type Citizen } from "../src/society.ts";
+import { sqliteTestEnv } from "./helpers/sqlite-d1.ts";
+
+const SCHEMA = `
+  CREATE TABLE citizens (
+    id INTEGER PRIMARY KEY,
+    handle TEXT NOT NULL UNIQUE
+  );
+  CREATE TABLE attestations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    class TEXT NOT NULL,
+    issuer_id INTEGER NOT NULL,
+    subject_id INTEGER NOT NULL,
+    claim TEXT NOT NULL,
+    evidence TEXT NOT NULL,
+    payload TEXT NOT NULL,
+    payload_hash TEXT NOT NULL UNIQUE,
+    signature TEXT,
+    key_thumbprint TEXT,
+    target_attestation_id INTEGER,
+    withdraw_when TEXT,
+    issued_at INTEGER NOT NULL,
+    payload_version INTEGER NOT NULL DEFAULT 1
+  );
+  CREATE TABLE identity_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    citizen_id INTEGER NOT NULL,
+    kind TEXT NOT NULL,
+    detail TEXT,
+    created_at INTEGER NOT NULL,
+    prev_hash TEXT,
+    hash TEXT
+  );
+  CREATE UNIQUE INDEX identity_events_prev ON identity_events(prev_hash);
+  CREATE UNIQUE INDEX identity_events_hash ON identity_events(hash);
+  INSERT INTO citizens (id, handle) VALUES (1, 'issuer'), (2, 'subject');
+`;
+
+const ISSUER: Citizen = {
+  id: 1,
+  handle: "issuer",
+  model: "test",
+  karma: 0,
+  created_at: 0,
+  last_seen_at: 0,
+  last_seen_comment_id: null,
+  last_seen_mention_id: null,
+};
+
+function attestation(claim: string): AttestationInput {
+  return { class: "code-merged", subject: "subject", claim, evidence: [] };
+}
+
+test("concurrent attestations cannot cross the rolling 24-hour cap or mint a phantom event", async () => {
+  const { env, db } = sqliteTestEnv(SCHEMA);
+  const now = Date.now();
+  const seed = db.prepare(
+    `INSERT INTO attestations
+       (class, issuer_id, subject_id, claim, evidence, payload, payload_hash, issued_at, payload_version)
+     VALUES ('code-merged', 1, 2, ?, '[]', ?, ?, ?, 2)`,
+  );
+  for (let i = 0; i < ATTESTATIONS_PER_DAY - 1; i++) {
+    seed.run(`seed ${i}`, `payload ${i}`, `hash ${i}`, now - i);
+  }
+
+  const settled = await Promise.allSettled([
+    issueAttestation(env, ISSUER, attestation("concurrent claim A")),
+    issueAttestation(env, ISSUER, attestation("concurrent claim B")),
+  ]);
+
+  const fulfilled = settled.filter((result) => result.status === "fulfilled");
+  const rejected = settled.filter((result) => result.status === "rejected");
+  assert.equal(fulfilled.length, 1, "only the twentieth attestation may commit");
+  assert.equal(rejected.length, 1);
+  assert.ok(
+    rejected[0].status === "rejected" && rejected[0].reason instanceof SocietyError && rejected[0].reason.status === 429,
+    "the concurrent loser receives the same budget-spent refusal as a sequential caller",
+  );
+
+  const count = db.prepare("SELECT COUNT(*) AS n FROM attestations WHERE issuer_id = 1").get() as { n: number };
+  assert.equal(count.n, ATTESTATIONS_PER_DAY);
+  const events = db.prepare("SELECT COUNT(*) AS n FROM identity_events WHERE kind = 'attestation'").get() as { n: number };
+  assert.equal(events.n, 1, "a refused attestation cannot append a chained event claiming it exists");
+});


### PR DESCRIPTION
## Bug

The rolling attestation budget was enforced by a `SELECT COUNT(*)` before validation and the chained write. Two requests using the same credential could both observe 19 recent rows, both pass, and both commit, leaving 21 attestations under a stated 20/rolling-24h cap.

Because each accepted attestation also appends an `identity_events(kind = 'attestation')` row, fixing only the response would still leave a false chained claim if the capped state insert changed zero rows.

## Fix

- keep the existing early count as a cheap fast-path refusal
- make the attestation `INSERT` authoritative with an atomic `INSERT ... SELECT ... WHERE COUNT(*) < 20`
- guard the chained identity-event insert with the immediately preceding statement's `changes() = 1`
- return the existing 429 budget response to the concurrent loser

SQLite/D1 serializes the guarded write, so the second writer evaluates the count after the first committed. The state row and event remain in the same atomic batch: both land or neither does.

## Regression coverage

The new real-SQLite D1 regression:

1. seeds 19 recent attestations for one issuer
2. issues two distinct attestations concurrently
3. asserts exactly one succeeds and one receives 429
4. asserts the final attestation count is 20
5. asserts exactly one new chained attestation event exists

Before the fix both promises fulfilled and the table ended at 21.

## Validation

- `npm test` — 546/546 passed
- `npm run typecheck`
- `npm audit --omit=dev` — 0 vulnerabilities
- `npx wrangler deploy --dry-run`
- `git diff --check`
