### PR TITLE
fix(test): use fileURLToPath for cross-platform src resolution and handle CRLF in migration split

### DIFF
--- a/test/ledger-tx-migration.test.ts
+++ b/test/ledger-tx-migration.test.ts
@@ -28,7 +28,7 @@ test("the migration only ever fills a NULL, and touches nothing else about a row
   assert.equal(proposed.size, 7, "seven rows, matching the docket row's count");
   // Every statement is guarded on tx IS NULL, so re-running it cannot
   // overwrite a value somebody else put there, and it is idempotent.
-  const statements = migration.split("\n").filter((l) => l.trim().startsWith("UPDATE") || l.trim().startsWith("INSERT") || l.trim().startsWith("DELETE"));
+  const statements = migration.split(/\r?\n/).map((l) => l.trim()).filter((l) => l.startsWith("UPDATE") || l.startsWith("INSERT") || l.startsWith("DELETE"));
   assert.equal(statements.length, 7, "no statement in this file does anything but the seven guarded updates");
   for (const s of statements) {
     assert.match(s, /^UPDATE ledger SET tx = '0x[0-9a-f]{64}' WHERE id = \d+ AND tx IS NULL;$/);

--- a/test/mcp-cors.test.ts
+++ b/test/mcp-cors.test.ts
@@ -114,7 +114,8 @@ test("every MCP response path is CORS-readable", async () => {
 test("no JSON response in the Worker is emitted without a declared charset", async () => {
   const { readFileSync } = await import("node:fs");
   const { join } = await import("node:path");
-  const srcDir = new URL("../src/", import.meta.url).pathname;
+  const { fileURLToPath } = await import("node:url");
+  const srcDir = fileURLToPath(new URL("../src/", import.meta.url));
   const files = ["index.ts", "mcp.ts", "x402.ts"];
   const offenders: string[] = [];
   for (const f of files) {


### PR DESCRIPTION
## Summary
Fixes two platform-specific test failures when running `npm test` on Windows environments:
1. `test/mcp-cors.test.ts`: Replaces `new URL("../src/", import.meta.url).pathname` with `fileURLToPath(new URL("../src/", import.meta.url))` to avoid leading slash / double drive letter resolution issues on Windows.
2. `test/ledger-tx-migration.test.ts`: Splits migration statements using `/\r?\n/` and trims lines to avoid trailing `\r` on systems checking out with CRLF.

## Verification
Ran full test suite on Node v24:
```
ℹ tests 560
ℹ suites 1
ℹ pass 560
ℹ fail 0
```
