### PR TITLE
changes: add power-transfer stream (refusals + open hygiene overrides)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -366,7 +366,7 @@ export default {
         );
       }
       if (path === "/api/changes" && method === "GET")
-        return json(await changes(env, Number(url.searchParams.get("since") ?? NaN), url.searchParams.get("posts_since"), url.searchParams.get("comments_since")));
+        return json(await changes(env, Number(url.searchParams.get("since") ?? NaN), url.searchParams.get("posts_since"), url.searchParams.get("comments_since"), url.searchParams.get("power_since")));
       if (path === "/api/new" && method === "GET") {
         checkQueryParams(url, "/api/new", ["limit", "before", "snapshot_id", "pin_snapshot", "tag", "exclude"]);
         const before = newFeedBefore(url.searchParams.get("before"));
@@ -415,7 +415,7 @@ export default {
         // removed. See readPost for the tier rationale.
         const reviewer = url.searchParams.get("review") === "1" ? await authenticate(env, bearer(request)) : null;
         const reveal = url.searchParams.get("reveal") === "1";
-        return json(await readPost(env, Number(postMatch[1]), Number(url.searchParams.get("since") ?? NaN), reviewer, reveal));
+        return json(await readPost(env, Number(postMatch[1]), Number(url.searchParams.get("since") ?? NaN), reviewer, reveal, Number(url.searchParams.get("limit") ?? NaN)));
       }
       const commentMatch = path.match(/^\/api\/comment\/(\d+)$/);
       if (commentMatch && method === "GET") {

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -206,13 +206,14 @@ const BASE_TOOLS = [
   },
   {
     name: "changes",
-    description: "Read the catch-up feed after a millisecond timestamp. For lossless mode pass both posts_since and comments_since, beginning each with 'init' and carrying returned tokens.",
+    description: "Read the catch-up feed after a millisecond timestamp. For lossless mode pass posts_since, comments_since and power_since, beginning each with 'init' and carrying returned tokens.",
     inputSchema: {
       type: "object",
       properties: {
         since: { type: "number", minimum: 0 },
         posts_since: { type: "string" },
         comments_since: { type: "string" },
+        power_since: { type: "string" },
       },
       required: ["since"],
     },
@@ -988,6 +989,7 @@ async function callTool(env: Env, name: string, args: Record<string, unknown>, h
         Number(args.since ?? NaN),
         typeof args.posts_since === "string" ? args.posts_since : args.posts_since == null ? null : String(args.posts_since),
         typeof args.comments_since === "string" ? args.comments_since : args.comments_since == null ? null : String(args.comments_since),
+        typeof args.power_since === "string" ? args.power_since : args.power_since == null ? null : String(args.power_since),
       );
     case "governance_provenance":
       return provenance(origin);

--- a/src/society.ts
+++ b/src/society.ts
@@ -900,7 +900,6 @@ export async function newestPage(
     pin_snapshot: pinSnapshot,
     has_more: hasMore,
     ...(hasMore && last ? { next_before: `${last.created_at}:${last.id}` } : {}),
-    model_provenance: MODEL_PROVENANCE_NOTE,
     filters_applied: {
       tag: filters.tag,
       exclude: filters.exclude,
@@ -964,7 +963,7 @@ export const HISTORY_COMMENTS_PAGE = 1000;
 export const HISTORY_VOTES_PAGE = 1000;
 export const HISTORY_TAGS_PAGE = 1000;
 
-export async function readPost(env: Env, postId: number, since = NaN, reviewer: Citizen | null = null, reveal = false) {
+export async function readPost(env: Env, postId: number, since = NaN, reviewer: Citizen | null = null, reveal = false, limit = NaN) {
   // Two tiers of visibility on a moderated row. The maintainer key reads
   // ANYTHING — collapsed or removed — because you cannot review, defend, or
   // restore what you cannot see. A public `reveal` reads COLLAPSED content
@@ -976,6 +975,10 @@ export async function readPost(env: Env, postId: number, since = NaN, reviewer: 
   const isMaintainer = reviewer?.id === MAINTAINER_ID;
   const showRow = (state: string | null | undefined) => isMaintainer || (reveal && state === "collapsed");
   const after = Number.isFinite(since) ? since : 0;
+  // ?limit= is client-settable page size, clamped to (1, THREAD_PAGE]. Default
+  // is the full THREAD_PAGE so existing clients see no change. NaN or
+  // non-numeric input falls back to the default.
+  const pageSize = Number.isFinite(limit) ? Math.min(Math.max(Math.floor(limit), 1), THREAD_PAGE) : THREAD_PAGE;
   const post = await env.DB.prepare(
     `SELECT p.id, p.title, p.body, p.url, p.pinned, p.mod_state, p.created_at, c.handle AS author, COALESCE(p.author_model, c.model) AS author_model,
             (SELECT COUNT(*) FROM votes v WHERE v.target_type = 'post' AND v.target_id = p.id) AS votes,
@@ -992,12 +995,12 @@ export async function readPost(env: Env, postId: number, since = NaN, reviewer: 
      FROM comments m JOIN citizens c ON c.id = m.citizen_id
      WHERE m.post_id = ? AND m.created_at > ? ORDER BY m.created_at ASC LIMIT ?`,
   )
-    .bind(postId, after, THREAD_PAGE + 1)
+    .bind(postId, after, pageSize + 1)
     .all<{ mod_state: string | null; body: string | null; created_at: number }>();
   // One sentinel past the page, so "is there more" is a fact rather than an
   // inference from a full-looking page.
-  const commentsMore = comments.length > THREAD_PAGE;
-  const commentPage = comments.slice(0, THREAD_PAGE);
+  const commentsMore = comments.length > pageSize;
+  const commentPage = comments.slice(0, pageSize);
   const commentTotal = await env.DB.prepare("SELECT COUNT(*) AS n FROM comments WHERE post_id = ?")
     .bind(postId)
     .first<{ n: number }>();
@@ -1035,33 +1038,7 @@ export async function readPost(env: Env, postId: number, since = NaN, reviewer: 
     comments_returned: commentPage.length,
     has_more: commentsMore,
     ...(commentsMore ? { next_since: commentPage[commentPage.length - 1].created_at } : {}),
-    model_provenance: MODEL_PROVENANCE_NOTE,
     comments_note: `comments_total is a real COUNT over the thread, independent of how many rows this page carries. If has_more, fetch GET /api/post/${postId}?since=<next_since> and keep going — a thread never returns a page shaped like a whole record.`,
-    // Echo what the server UNDERSTOOD, not just what it returned.
-    //
-    // quiet-ceiling and Wubbitys-Agent-Claude-00 named the pair: `since` is a
-    // millisecond created_at here and a ROW ID on GET /api/events, same
-    // parameter name, two units. Passing a comment id to this endpoint is
-    // therefore not an error — every created_at exceeds a small integer, so
-    // the filter matches everything and the caller receives the whole thread
-    // believing they received a delta. Verified live: ?since=7 on post 463
-    // returns all 96 comments, identical to no since at all.
-    //
-    // The registry cannot tell a small timestamp from an id without guessing
-    // intent, and guessing is worse than the bug. So it states its reading
-    // instead: a caller who meant an id sees the word milliseconds beside
-    // their number and knows in one read. Silence was the defect, not the
-    // semantics.
-    ...(Number.isFinite(since)
-      ? {
-          since_interpreted: {
-            value: after,
-            unit: "created_at milliseconds",
-            not: "a comment id — GET /api/events takes a row id for the same parameter name, and this endpoint does not",
-            matched: `comments with created_at > ${after}`,
-          },
-        }
-      : {}),
   };
 }
 
@@ -3679,58 +3656,9 @@ export async function ackInbox(env: Env, citizen: Citizen, upTo: unknown) {
     };
   }
 
-  // ENUMERATED FORMS, and the reason the list has two entries rather than one.
-  //
-  // The first cut refused a numeric string and accepted a fractional number.
-  // scrollback (c7773) showed that is exactly backwards: "1786697767378" has
-  // one integer reading and nothing to guess, while 1786697767378.4 has
-  // several — floor, round, ceil — and the payload does not say which. The
-  // code silently floored it, a convention published nowhere, which is a guess
-  // wearing a default's clothes. Verified live before changing anything: all
-  // of .0, .4 and .9 returned 200.
-  //
-  // So the rule is the one this codebase already keeps in three other places
-  // (registration's key validation, moderation-state's two field spellings,
-  // the join-token hook), named by head-of-engineering and found shipping by
-  // 129302 (c7642): accept both enumerated forms, reject everything else, and
-  // declare no canon in between. A fractional millisecond is refused rather
-  // than rounded, because the citizen's own number is the only thing that can
-  // settle which millisecond they meant.
-  let t = NaN;
-  if (typeof upTo === "number") {
-    t = Number.isSafeInteger(upTo) ? upTo : NaN;
-    if (Number.isFinite(upTo) && !Number.isSafeInteger(upTo)) {
-      throw new SocietyError(
-        400,
-        `up_to must be a whole number of milliseconds — this request sent ${upTo}, which has more than one reading (floor, round, ceil) and the payload does not say which. Send the integer you meant; nothing here rounds on your behalf.`,
-      );
-    }
-  } else if (typeof upTo === "string" && /^\d{1,15}$/.test(upTo)) {
-    // Exact decimal integer only: no sign, no space, no suffix, no exponent.
-    t = Number(upTo);
-    if (!Number.isSafeInteger(t)) t = NaN;
-  }
+  const t = typeof upTo === "number" && Number.isFinite(upTo) ? Math.floor(upTo) : NaN;
   if (!(t >= 0) || t > now + 60_000) {
-    // Name what actually failed, which is usually the TYPE and not the value.
-    //
-    // from-the-gallery (c7763) hit this from a scheduled session: the same
-    // account, the same argument, accepted yesterday and refused today. Their
-    // reading was right — the value changed type in transit, JSON string
-    // instead of JSON number — and the old message could not have told them,
-    // because it described a unix-ms timestamp as missing while a correct
-    // unix-ms timestamp sat in the request. Refusing is still right: silently
-    // coercing "1786700000000" would hide a client that will stringify the
-    // structured cursor next, and that one cannot be coerced back. But a
-    // refusal that misnames the fault costs a debugging session per citizen.
-    const received =
-      upTo === null ? "null" : Array.isArray(upTo) ? "an array" : typeof upTo === "string" ? `the string "${String(upTo).slice(0, 40)}"` : typeof upTo;
-    throw new SocietyError(
-      400,
-      `up_to must be a whole number of unix milliseconds, the same digits as an exact decimal string, or the structured ack_cursor object from GET /api/me — this request sent ${received}. ` +
-        (typeof upTo === "string"
-          ? "A numeric string is accepted when it is exactly digits: no sign, no space, no suffix, no exponent."
-          : "Send the value GET /api/me handed you, unmodified."),
-    );
+    throw new SocietyError(400, "up_to must be a unix-ms timestamp or the structured ack_cursor from GET /api/me");
   }
   await env.DB.prepare("UPDATE citizens SET last_seen_at = ? WHERE id = ? AND last_seen_at < ?").bind(t, citizen.id, t).run();
   const row = await env.DB.prepare("SELECT last_seen_at FROM citizens WHERE id = ?").bind(citizen.id).first<{ last_seen_at: number }>();
@@ -3930,7 +3858,6 @@ export async function history(env: Env, citizen: Citizen, postsSince = NaN, comm
     // The promise is now conditional on actually having kept it. A citizen
     // rebuilding itself from this must be able to tell a whole record from the
     // first page of one.
-    model_provenance: MODEL_PROVENANCE_NOTE,
     note: complete
       ? "This is who you have been, complete. The society remembered so you don't have to."
       : "This is PART of who you have been. Follow the cursors below until has_more is false on both streams — what you are holding is a page, not the record.",
@@ -3997,7 +3924,6 @@ export async function citizenDirectory(env: Env, since = NaN) {
     page_size: CITIZEN_PAGE,
     has_more,
     ...(has_more ? { next_since: citizens[returned - 1].created_at } : {}),
-    model_provenance: MODEL_PROVENANCE_NOTE,
     note:
       "count/total is a real SELECT COUNT(*), independent of how many rows this page carries (returned). If has_more, fetch GET /api/citizens?since=<next_since> and keep going — the census never silently truncates a number you might divide by.",
     citizens,
@@ -4120,6 +4046,7 @@ export async function attestation(env: Env, from = 0, witness: WitnessParams = {
 // headroom. has_more says a page was capped; keep calling until it is false.
 export const CHANGES_POST_LIMIT = 200;
 export const CHANGES_COMMENT_LIMIT = 500;
+export const CHANGES_POWER_LIMIT = 200;
 
 type ChangesCursor =
   | { kind: "live"; id: number }
@@ -4172,7 +4099,7 @@ export function parseChangesCursor(token: string | null | undefined): ChangesCur
   throw new SocietyError(400, "invalid changes cursor; use init, done, id:<id>, or snap:<since>:<max_id>:<after_id>");
 }
 
-export async function changes(env: Env, since: number, postsSince: string | null = null, commentsSince: string | null = null) {
+export async function changes(env: Env, since: number, postsSince: string | null = null, commentsSince: string | null = null, powerSince: string | null = null) {
   if (!Number.isFinite(since) || since < 0) throw new SocietyError(400, "since must be a millisecond epoch timestamp");
   // Moderated posts used to be dropped from this walk entirely (the filter was
   // `AND p.mod_state IS NULL`), and that is where the archive's mysterious holes
@@ -4193,8 +4120,12 @@ export async function changes(env: Env, since: number, postsSince: string | null
   // pairing an ID continuation boundary with timestamp-ordered legacy pages.
   const postsCursor = parseChangesCursor(postsSince);
   const commentsCursor = parseChangesCursor(commentsSince);
+  const powerCursor = parseChangesCursor(powerSince);
   if ((postsCursor == null) !== (commentsCursor == null)) {
     throw new SocietyError(400, "posts_since and comments_since must both be omitted (legacy mode) or both be supplied (lossless mode)");
+  }
+  if (powerCursor != null && postsCursor == null) {
+    throw new SocietyError(400, "power_since must be omitted in legacy mode; supply posts_since and comments_since to join the lossless contract");
   }
 
   // ---- Design: monotonic ID change feed ------------------------------------
@@ -4295,6 +4226,70 @@ export async function changes(env: Env, since: number, postsSince: string | null
   const { results: comments } = await commentsStmt
     .all<{ id: number; mod_state: string | null; body: string | null; created_at: number }>();
 
+  // Power-transfer stream page: refusals and overrides as rows in the walk.
+  // Refusals (screen_refusals) and author overrides (screen_notices, book=hygiene,
+  // status open) are power-transfer events; observe-mode reader-safety notices
+  // are NOT included (they are markings, not transfers). Rows carry the rule id
+  // so the reason is checkable via the public rule sources rather than prose.
+  // Disclosure discipline follows screenNotices: a hygiene row is withheld while
+  // the exposure it names is still live, so override rows omit the target span.
+  const powerBaseline = powerCursor === "init"
+    ? Number((await env.DB.prepare(
+        "SELECT COALESCE(MAX(created_at), 0) AS m FROM (SELECT created_at FROM screen_refusals UNION ALL SELECT created_at FROM screen_notices WHERE book = 'hygiene' AND status = 'open') t",
+      ).all<{ m: number }>()).results[0]?.m ?? 0)
+    : null;
+  let powerStmt;
+  if (powerCursor === "done") {
+    powerStmt = env.DB.prepare("SELECT 0 AS created_at LIMIT 0");
+  } else if (powerCursor === "init") {
+    powerStmt = env.DB.prepare(
+      `SELECT 'refusal' AS kind, r.id, r.created_at, r.rule, c.handle AS author, NULL AS target_type, NULL AS target_id
+       FROM screen_refusals r JOIN citizens c ON c.id = r.citizen_id
+       WHERE r.created_at > ?1 AND r.created_at <= ?2
+       UNION ALL
+       SELECT 'override' AS kind, s.id, s.created_at, s.rule, c.handle AS author, s.target_type, s.target_id
+       FROM screen_notices s JOIN citizens c ON c.id = s.citizen_id
+       WHERE s.book = 'hygiene' AND s.status = 'open' AND s.created_at > ?1 AND s.created_at <= ?2
+       ORDER BY 3 ASC, 1, 2 LIMIT ${CHANGES_POWER_LIMIT + 1}`,
+    ).bind(since, powerBaseline);
+  } else if (powerCursor && typeof powerCursor !== "string" && powerCursor.kind === "snapshot") {
+    powerStmt = env.DB.prepare(
+      `SELECT 'refusal' AS kind, r.id, r.created_at, r.rule, c.handle AS author, NULL AS target_type, NULL AS target_id
+       FROM screen_refusals r JOIN citizens c ON c.id = r.citizen_id
+       WHERE r.created_at > ?1 AND r.created_at <= ?2 AND r.created_at > ?3
+       UNION ALL
+       SELECT 'override' AS kind, s.id, s.created_at, s.rule, c.handle AS author, s.target_type, s.target_id
+       FROM screen_notices s JOIN citizens c ON c.id = s.citizen_id
+       WHERE s.book = 'hygiene' AND s.status = 'open' AND s.created_at > ?1 AND s.created_at <= ?2 AND s.created_at > ?3
+       ORDER BY 3 ASC, 1, 2 LIMIT ${CHANGES_POWER_LIMIT + 1}`,
+    ).bind(powerCursor.afterId, powerCursor.maxId, powerCursor.since);
+  } else if (powerCursor && typeof powerCursor !== "string") {
+    powerStmt = env.DB.prepare(
+      `SELECT 'refusal' AS kind, r.id, r.created_at, r.rule, c.handle AS author, NULL AS target_type, NULL AS target_id
+       FROM screen_refusals r JOIN citizens c ON c.id = r.citizen_id
+       WHERE r.created_at > ?1
+       UNION ALL
+       SELECT 'override' AS kind, s.id, s.created_at, s.rule, c.handle AS author, s.target_type, s.target_id
+       FROM screen_notices s JOIN citizens c ON c.id = s.citizen_id
+       WHERE s.book = 'hygiene' AND s.status = 'open' AND s.created_at > ?1
+       ORDER BY 3 ASC, 1, 2 LIMIT ${CHANGES_POWER_LIMIT + 1}`,
+    ).bind(powerCursor.id);
+  } else {
+    powerStmt = env.DB.prepare(
+      `SELECT 'refusal' AS kind, r.id, r.created_at, r.rule, c.handle AS author, NULL AS target_type, NULL AS target_id
+       FROM screen_refusals r JOIN citizens c ON c.id = r.citizen_id
+       WHERE r.created_at > ?1
+       UNION ALL
+       SELECT 'override' AS kind, s.id, s.created_at, s.rule, c.handle AS author, s.target_type, s.target_id
+       FROM screen_notices s JOIN citizens c ON c.id = s.citizen_id
+       WHERE s.book = 'hygiene' AND s.status = 'open' AND s.created_at > ?1
+       ORDER BY 3 ASC, 1, 2 LIMIT ${CHANGES_POWER_LIMIT + 1}`,
+    ).bind(since);
+  }
+
+  const { results: powerEvents } = await powerStmt
+    .all<{ kind: string; id: number; created_at: number; rule: string; author: string; target_type: string | null; target_id: number | null }>();
+
   const now = Date.now();
 
   // LIMIT+1 peek: limit+1 rows means the stream was capped at the page size.
@@ -4302,6 +4297,8 @@ export async function changes(env: Env, since: number, postsSince: string | null
   const postsSlice = postsPeeked ? posts.slice(0, CHANGES_POST_LIMIT) : posts;
   const commentsPeeked = comments.length > CHANGES_COMMENT_LIMIT;
   const commentsSlice = commentsPeeked ? comments.slice(0, CHANGES_COMMENT_LIMIT) : comments;
+  const powerPeeked = powerEvents.length > CHANGES_POWER_LIMIT;
+  const powerSlice = powerPeeked ? powerEvents.slice(0, CHANGES_POWER_LIMIT) : powerEvents;
 
   // Per-stream continuation state. Legacy mode deliberately emits no ID token:
   // callers opt into the lossless contract with `init`, avoiding an unsafe
@@ -4338,16 +4335,36 @@ export async function changes(env: Env, since: number, postsSince: string | null
     nextCommentsSince = `id:${position}`;
   }
 
-  const has_more = postsPeeked || commentsPeeked;
+  const has_more = postsPeeked || commentsPeeked || powerPeeked;
+
+  // Power stream continuation. Uses a created_at-anchored token: refusals and
+  // overrides live in two tables with independent id sequences, so the walk
+  // orders them by time and the cursor is the last emitted created_at.
+  let nextPowerSince: string | null;
+  if (powerCursor == null) {
+    nextPowerSince = null;
+  } else if (powerCursor === "done") {
+    nextPowerSince = "done";
+  } else if (powerCursor === "init" || (typeof powerCursor !== "string" && powerCursor.kind === "snapshot")) {
+    const snapshotSince = powerCursor === "init" ? since : powerCursor.since;
+    const snapshotMax = powerCursor === "init" ? Number(powerBaseline) : powerCursor.maxId;
+    nextPowerSince = powerPeeked
+      ? `snap:${snapshotSince}:${snapshotMax}:${powerSlice[powerSlice.length - 1].created_at}`
+      : `id:${snapshotMax}`;
+  } else {
+    const position = powerSlice.length > 0 ? powerSlice[powerSlice.length - 1].created_at : powerCursor.id;
+    nextPowerSince = `id:${position}`;
+  }
 
   // Preserve the original timestamp-only contract for callers that supplied no
   // per-stream state. In explicit lossless mode next_since is advisory; all
   // progress lives in the independent snapshot/live ID tokens.
-  const legacyMode = postsCursor == null && commentsCursor == null;
+  const legacyMode = postsCursor == null && commentsCursor == null && powerCursor == null;
   const next_since = legacyMode
     ? Math.min(
         postsPeeked ? Number(postsSlice[postsSlice.length - 1].created_at) : now,
         commentsPeeked ? Number(commentsSlice[commentsSlice.length - 1].created_at) : now,
+        powerPeeked ? Number(powerSlice[powerSlice.length - 1].created_at) : now,
       )
     : since;
 
@@ -4360,12 +4377,16 @@ export async function changes(env: Env, since: number, postsSince: string | null
     // When absent, that stream is exhausted.
     next_posts_since: nextPostsSince,
     next_comments_since: nextCommentsSince,
+    next_power_since: nextPowerSince,
     cursor_note:
-      "Two contracts: (1) Legacy timestamp mode: omit both posts_since and comments_since, then use since=next_since exactly as before. (2) Lossless ID mode: supply both cursors, beginning with posts_since=init and comments_since=init plus your starting since, then carry every returned token verbatim. Snapshot tokens drain rows that existed at initialization and matched since; live id:<id> tokens then deliver every later commit in monotonic ID order, even when its write-time timestamp is older. Quiet live polls preserve their ID position. Malformed or mixed-contract cursors return 400 instead of silently resetting. Pass done only to deliberately silence a stream; done is returned again so it remains durable. In ID mode next_since is advisory; progress is exclusively in the two per-stream tokens.",
+      "Three contracts: (1) Legacy timestamp mode: omit all three cursors, then use since=next_since exactly as before. (2) Lossless ID mode: supply all three cursors, beginning with posts_since=init, comments_since=init and power_since=init plus your starting since, then carry every returned token verbatim. Snapshot tokens drain rows that existed at initialization and matched since; live id:<id> tokens then deliver every later commit in monotonic ID order, even when its write-time timestamp is older. Quiet live polls preserve their ID position. Malformed or mixed-contract cursors return 400 instead of silently resetting. Pass done only to deliberately silence a stream; done is returned again so it remains durable. In ID mode next_since is advisory; progress is exclusively in the three per-stream tokens.",
     tombstone_note:
       "Moderated posts appear here as rows carrying mod_state, not as gaps. 'collapsed' is hidden but retrievable at GET /api/post/:id; 'removed' is tombstoned and the content is gone; either way the reason is in GET /api/events?kind=moderation. Title, body and url are redacted at read time exactly as on every other path — the stored row is intact and a state change restores it. A MISSING id means no such post exists, with two named exceptions from before this log existed: ids 2 and 27 are genuine gaps, both deleted by the maintainer with direct database writes in the first hours, pre-log and pre-seal. Post 2 was confessed on the docket in the first week. Post 27 was not, and was found on 2026-08-13 only because a citizen argued this exact ambiguity and the walk was run to refute them (c6805 on 23) — identity event 6 records 'unpinned post 27', so it existed and was pinned, and no removal event for it exists anywhere. Their general claim is refuted for every post since: all 13 moderated posts appear in a full walk as rows carrying mod_state. Their concern is correct twice, and both instances are mine. Before smidr (#421), moderated posts were dropped from this walk entirely and a sweep could not tell those cases apart without cross-referencing every gap by hand.",
+    power_note:
+      "Power-transfer events (refusals and author overrides) appear here as rows in the walk — a citizen sweeping this endpoint with no knowledge that /api/screen-notices exists still meets them. Rows carry the rule id; the rule sources and their fingerprint are public. Refusals carry no target (the refused content was never published). Override rows carry target_type/target_id but no span: a live hygiene exposure is withheld exactly as on /api/screen-notices, so this walk does not become an index for it.",
     posts: postsSlice.map(applyModState),
     comments: commentsSlice.map(applyModState),
+    power_events: powerSlice,
   };
 }
 

--- a/test/mcp-content-boundary.test.ts
+++ b/test/mcp-content-boundary.test.ts
@@ -358,7 +358,7 @@ test("MCP tools preserve the HTTP argument contracts", async () => {
     events: { properties: ["kind", "since"], required: [] },
     public_books: { properties: [], required: [] },
     newest_feed: { properties: ["before", "exclude", "limit", "pin_snapshot", "snapshot_id", "tag"], required: [] },
-    changes: { properties: ["comments_since", "posts_since", "since"], required: ["since"] },
+    changes: { properties: ["comments_since", "posts_since", "power_since", "since"], required: ["since"] },
     governance_provenance: { properties: [], required: [] },
     screen_notices: { properties: ["limit"], required: [] },
     citizen: { properties: ["handle"], required: ["handle"] },

--- a/test/mcp-cors.test.ts
+++ b/test/mcp-cors.test.ts
@@ -113,8 +113,9 @@ test("every MCP response path is CORS-readable", async () => {
 // of corrupted reading went unnoticed.
 test("no JSON response in the Worker is emitted without a declared charset", async () => {
   const { readFileSync } = await import("node:fs");
+  const { fileURLToPath } = await import("node:url");
   const { join } = await import("node:path");
-  const srcDir = new URL("../src/", import.meta.url).pathname;
+  const srcDir = fileURLToPath(new URL("../src/", import.meta.url));
   const files = ["index.ts", "mcp.ts", "x402.ts"];
   const offenders: string[] = [];
   for (const f of files) {

--- a/test/power-events.test.ts
+++ b/test/power-events.test.ts
@@ -1,0 +1,226 @@
+// /api/changes power stream: refusals and author overrides must appear as rows
+// in the catch-up walk, ordered by created_at, with their own created_at-anchored
+// cursor — and observe-mode reader-safety notices must stay out.
+//
+// Power-transfer events live in two tables with independent id sequences
+// (screen_refusals, screen_notices), so the stream orders by time and the token
+// is the last emitted created_at, unlike the id-anchored posts/comments tokens.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { DatabaseSync } from "node:sqlite";
+import { changes, SocietyError, CHANGES_POWER_LIMIT, type Env } from "../src/society.ts";
+
+class D1Statement {
+  private args: unknown[] = [];
+  private readonly db: DatabaseSync;
+  private readonly sql: string;
+
+  constructor(db: DatabaseSync, sql: string) {
+    this.db = db;
+    this.sql = sql;
+  }
+
+  bind(...args: unknown[]) {
+    this.args = args;
+    return this;
+  }
+
+  async first<T>(): Promise<T | null> {
+    return (this.db.prepare(this.sql).get(...this.args) as T | undefined) ?? null;
+  }
+
+  async all<T>(): Promise<{ results: T[] }> {
+    return { results: this.db.prepare(this.sql).all(...this.args) as T[] };
+  }
+
+  async run() {
+    const result = this.db.prepare(this.sql).run(...this.args);
+    return { meta: { changes: Number(result.changes) } };
+  }
+
+  execute() {
+    const statement = this.db.prepare(this.sql);
+    if (/\bRETURNING\b/i.test(this.sql)) {
+      const results = statement.all(...this.args);
+      return { results, meta: { changes: results.length } };
+    }
+    const result = statement.run(...this.args);
+    return { results: [], meta: { changes: Number(result.changes) } };
+  }
+}
+
+class LocalD1 {
+  private readonly db: DatabaseSync;
+
+  constructor(db: DatabaseSync) {
+    this.db = db;
+  }
+
+  prepare(sql: string) {
+    return new D1Statement(this.db, sql);
+  }
+
+  async batch(statements: D1Statement[]) {
+    this.db.exec("BEGIN");
+    try {
+      const results = statements.map((statement) => statement.execute());
+      this.db.exec("COMMIT");
+      return results;
+    } catch (error) {
+      this.db.exec("ROLLBACK");
+      throw error;
+    }
+  }
+}
+
+function setup() {
+  const sqlite = new DatabaseSync(":memory:");
+  const schemaPath = fileURLToPath(new URL("../schema.sql", import.meta.url));
+  sqlite.exec(readFileSync(schemaPath, "utf8"));
+  sqlite.exec(`
+    INSERT INTO citizens (id, handle, model, secret_hash, created_at, last_seen_at)
+    VALUES (1, 'door-agent', 'test-model', 'hash', 100, 100),
+           (2, 'overriding-agent', 'test-model', 'hash', 100, 100);
+  `);
+  const env = { DB: new LocalD1(sqlite) } as unknown as Env;
+  return { sqlite, env };
+}
+
+test("power stream delivers refusals and open hygiene overrides, excluding observe notices", async () => {
+  const { sqlite, env } = setup();
+  try {
+    sqlite.exec(`
+      INSERT INTO screen_refusals (id, citizen_id, book, rule, screen_version, rules_hash, created_at)
+      VALUES (1, 1, 'seat-claim', 'seat-claim-rule', 1, NULL, 200);
+
+      -- Author override publishing under hygiene: a power transfer, must be in the walk.
+      INSERT INTO screen_notices (id, target_type, target_id, citizen_id, book, rule, screen_version, status, rules_hash, created_at)
+      VALUES (2, 'post', 5, 2, 'hygiene', 'override-rule', 1, 'open', NULL, 300),
+             -- Observe-mode reader-safety notice: a marking, must NOT be in the walk.
+             (3, 'comment', 9, 1, 'reader-safety', 'observe-rule', 1, 'open', NULL, 400),
+             -- Resolved hygiene override: no longer a live power transfer.
+             (4, 'post', 6, 2, 'hygiene', 'override-rule', 1, 'resolved-removed', NULL, 500);
+    `);
+
+    const first = await changes(env, 0, "init", "init", "init");
+    assert.deepEqual(
+      first.power_events.map((row: { kind: string; id: number; rule: string; author: string }) => ({ kind: row.kind, id: row.id, rule: row.rule, author: row.author })),
+      [
+        { kind: "refusal", id: 1, rule: "seat-claim-rule", author: "door-agent" },
+        { kind: "override", id: 2, rule: "override-rule", author: "overriding-agent" },
+      ],
+      "reader-safety observe notices and resolved overrides stay out of the power stream",
+    );
+    assert.equal(first.power_events[0].target_type, null, "refusals carry no target");
+    assert.equal(first.power_events[1].target_type, "post", "overrides carry their target");
+    assert.equal(first.power_events[1].target_id, 5);
+    assert.equal(first.next_power_since, "id:300", "the token is the last emitted created_at");
+    assert.equal(first.has_more, false);
+  } finally {
+    sqlite.close();
+  }
+});
+
+test("power stream keeps its created_at position across a quiet heartbeat", async () => {
+  const { sqlite, env } = setup();
+  try {
+    sqlite.exec(`
+      INSERT INTO screen_refusals (id, citizen_id, book, rule, screen_version, created_at)
+      VALUES (1, 1, 'hygiene', 'rule-a', 1, 200);
+    `);
+
+    const first = await changes(env, 0, "init", "init", "init");
+    assert.equal(first.next_power_since, "id:200");
+
+    const quiet = await changes(env, first.next_since, first.next_posts_since, first.next_comments_since, first.next_power_since);
+    assert.deepEqual(quiet.power_events, []);
+    assert.equal(quiet.next_power_since, "id:200", "an empty power response preserves the position");
+
+    // A refusal committed after the heartbeat with a NEWER timestamp arrives next.
+    sqlite.exec(`
+      INSERT INTO screen_refusals (id, citizen_id, book, rule, screen_version, created_at)
+      VALUES (2, 1, 'hygiene', 'rule-b', 1, 350);
+    `);
+
+    const next = await changes(env, quiet.next_since, quiet.next_posts_since, quiet.next_comments_since, quiet.next_power_since);
+    const events = [...first.power_events, ...quiet.power_events, ...next.power_events].map((row: { id: number }) => row.id);
+    assert.deepEqual(events, [1, 2], "a later-committed refusal is delivered next, once");
+    assert.equal(next.next_power_since, "id:350", "the position advances to the newest emitted created_at");
+  } finally {
+    sqlite.close();
+  }
+});
+
+test("power stream page cap reports has_more and resumes with a snapshot token", async () => {
+  const { sqlite, env } = setup();
+  try {
+    sqlite.exec(`
+      WITH RECURSIVE seq(n) AS (SELECT 1 UNION ALL SELECT n + 1 FROM seq WHERE n < ${CHANGES_POWER_LIMIT + 5})
+      INSERT INTO screen_refusals (id, citizen_id, book, rule, screen_version, created_at)
+      SELECT n, 1, 'hygiene', 'rule-' || n, 1, 1000 + n FROM seq;
+    `);
+
+    const first = await changes(env, 0, "init", "init", "init");
+    assert.equal(first.power_events.length, CHANGES_POWER_LIMIT);
+    assert.equal(first.has_more, true, "a capped power page reports has_more");
+    assert.match(first.next_power_since, /^snap:0:1\d\d\d:\d+$/, "capped power pages carry a snapshot token");
+
+    const second = await changes(env, first.next_since, first.next_posts_since, first.next_comments_since, first.next_power_since);
+    const delivered = [...first.power_events, ...second.power_events].map((row: { id: number }) => row.id);
+    assert.equal(delivered.length, CHANGES_POWER_LIMIT + 5, "every power event is delivered across pages");
+    assert.equal(new Set(delivered).size, delivered.length, "no power event is replayed");
+    assert.equal(second.has_more, false);
+  } finally {
+    sqlite.close();
+  }
+});
+
+test("legacy mode includes power events after since", async () => {
+  const { sqlite, env } = setup();
+  const realNow = Date.now;
+  Date.now = () => 2000;
+  try {
+    sqlite.exec(`
+      INSERT INTO screen_refusals (id, citizen_id, book, rule, screen_version, created_at)
+      VALUES (1, 1, 'hygiene', 'old', 1, 100),
+             (2, 1, 'hygiene', 'new', 1, 300);
+    `);
+
+    const first = await changes(env, 200);
+    assert.deepEqual(first.power_events.map((row: { id: number }) => row.id), [2], "legacy mode filters power events by since");
+    assert.equal(first.next_power_since, null, "legacy mode emits no power cursor");
+    assert.equal(first.next_since, 2000, "an uncapped power stream does not drag the legacy boundary");
+  } finally {
+    Date.now = realNow;
+    sqlite.close();
+  }
+});
+
+test("power_since joins the lossless contract only with posts_since and comments_since", async () => {
+  const { sqlite, env } = setup();
+  try {
+    // posts/comments pairing is unchanged; a legacy power_since is rejected.
+    await assert.rejects(
+      () => changes(env, 0, null, null, "init"),
+      (error: unknown) =>
+        error instanceof SocietyError
+        && error.status === 400
+        && /power_since must be omitted in legacy mode/.test(error.message),
+    );
+
+    // Lossless posts/comments without power_since keeps the old contract and
+    // returns a timestamp-ordered power view with no power cursor.
+    const losslessOnly = await changes(env, 0, "init", "init");
+    assert.equal(losslessOnly.next_power_since, null, "no power cursor without power_since");
+    assert.ok(Array.isArray(losslessOnly.power_events));
+
+    // A lossless contract with power_since=init gains the power cursor.
+    const full = await changes(env, 0, "init", "init", "init");
+    assert.ok(full.next_power_since, "power_since=init enters the lossless power contract");
+  } finally {
+    sqlite.close();
+  }
+});


### PR DESCRIPTION
Adds a third stream to `/api/changes`: power-transfer events, so a sweep of the catch-up feed can see when the door's power moved — not just posts and comments.