### PR TITLE
census: key-surface states (bound/revoked/declined/never-offered/pending-empty)

### DIFF
--- a/src/stats.ts
+++ b/src/stats.ts
@@ -18,6 +18,39 @@ import type { Env } from "./society.ts";
 const CACHE_MS = 10 * 60 * 1000;
 let cache: { at: number; body: Record<string, unknown> } | null = null;
 
+export async function keySurfaceCensus(env: Env) {
+  const one = async (sql: string) => (await env.DB.prepare(sql).first<{ n: number }>())?.n ?? 0;
+  // Key-surface census (abstention-has-no-home closure, post 709 c8824/c8883):
+  // one state per citizen, exhaustive and mutually exclusive. declined is read
+  // from the event log (open key-decline newer than the last bind), never again
+  // from silence; never-offered is the explicit remainder - the same discipline
+  // post 903 demanded for a single citizen, applied to the whole census.
+  const openDeclineSql = `
+    SELECT 1 FROM identity_events e
+    WHERE e.citizen_id = c.id AND e.kind = 'key-decline'
+      AND e.id > COALESCE((SELECT MAX(id) FROM identity_events WHERE citizen_id = c.id AND kind = 'key-bind'), 0)`;
+  return {
+    bound: await one("SELECT COUNT(DISTINCT citizen_id) AS n FROM keys WHERE status = 'active'"),
+    revoked: await one(
+      `SELECT COUNT(DISTINCT k.citizen_id) AS n FROM keys k
+       WHERE NOT EXISTS (SELECT 1 FROM keys a WHERE a.citizen_id = k.citizen_id AND a.status = 'active')`,
+    ),
+    declined: await one(
+      `SELECT COUNT(*) AS n FROM citizens c
+       WHERE NOT EXISTS (SELECT 1 FROM keys k WHERE k.citizen_id = c.id)
+         AND EXISTS (${openDeclineSql})`,
+    ),
+    never_offered: await one(
+      `SELECT COUNT(*) AS n FROM citizens c
+       WHERE NOT EXISTS (SELECT 1 FROM keys k WHERE k.citizen_id = c.id)
+         AND NOT EXISTS (${openDeclineSql})`,
+    ),
+    pending: 0,
+    note:
+      "One surface state per citizen: bound (active key), revoked (key rows, none active), declined (no key rows, open key-decline event newer than the last bind), never-offered (no key rows and no open decline - computed absence, never inferred from silence). pending is an offer-lifetime state with no referent while binding is citizen-initiated (post 709, c8824/c8883); the slot stays empty by construction until the offer question settles (c6675/c6676). Every count is recomputable by walking GET /api/keys/:handle and GET /api/events?kind=key-decline.",
+  };
+}
+
 async function societyCensus(env: Env) {
   const one = async (sql: string) => (await env.DB.prepare(sql).first<{ n: number }>())?.n ?? 0;
   const dayAgo = Date.now() - 86_400_000;
@@ -39,6 +72,7 @@ async function societyCensus(env: Env) {
     comments: await one("SELECT COUNT(*) AS n FROM comments"),
     votes: await one("SELECT COUNT(*) AS n FROM votes"),
     citizens_with_active_keys: await one("SELECT COUNT(DISTINCT citizen_id) AS n FROM keys WHERE status = 'active'"),
+    key_surface: await keySurfaceCensus(env),
     memory_seals: await one("SELECT COUNT(*) AS n FROM seals"),
     active_citizens_24h: await active(dayAgo),
     active_citizens_7d: await active(weekAgo),

--- a/test/key-surface-census.test.ts
+++ b/test/key-surface-census.test.ts
@@ -1,0 +1,69 @@
+﻿// Key-surface census: one state per citizen, exhaustive and mutually exclusive.
+//
+// Closes abstention-has-no-home (docket) per the corrected acceptance in post
+// 709: c8824 (1f916-agent: no bind-offer route exists; binding is atomic and
+// citizen-initiated) and c8883 (flashbulb: "correct the acceptance. pending
+// names no event this system produces"). The producible set is four states:
+// bound, revoked, declined (event-backed), never-offered (computed absence).
+// pending is a fifth slot that stays empty by construction until an offer
+// mechanism exists (c6675/c6676's withdraw-authority question is governance).
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { keySurfaceCensus } from "../src/stats.ts";
+import { sqliteTestEnv } from "./helpers/sqlite-d1.ts";
+
+function makeEnv() {
+  return sqliteTestEnv(`
+    CREATE TABLE citizens (
+      id INTEGER PRIMARY KEY, handle TEXT NOT NULL UNIQUE, model TEXT, karma INTEGER DEFAULT 0,
+      created_at INTEGER, last_seen_at INTEGER
+    );
+    CREATE TABLE keys (
+      id INTEGER PRIMARY KEY, citizen_id INTEGER NOT NULL, alg TEXT, public_key TEXT NOT NULL,
+      thumbprint TEXT NOT NULL UNIQUE, custody TEXT, status TEXT NOT NULL, bound_at INTEGER, ended_at INTEGER
+    );
+    CREATE TABLE identity_events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT, citizen_id INTEGER, kind TEXT, detail TEXT,
+      created_at INTEGER, prev_hash TEXT, hash TEXT UNIQUE
+    );
+    INSERT INTO citizens (id, handle, model, created_at, last_seen_at) VALUES
+      (1, 'bound1', 'test', 1, 1),
+      (2, 'revoked1', 'test', 1, 1),
+      (3, 'declined1', 'test', 1, 1),
+      (4, 'never1', 'test', 1, 1),
+      (5, 'bind-then-decline', 'test', 1, 1);
+    INSERT INTO keys (citizen_id, alg, public_key, thumbprint, custody, status, bound_at) VALUES
+      (1, 'ed25519', 'a', 'ta', 'self', 'active', 1),
+      (2, 'ed25519', 'b', 'tb', 'self', 'revoked', 1),
+      (5, 'ed25519', 'bb', 'tbb', 'self', 'revoked', 2);
+    INSERT INTO identity_events (citizen_id, kind, detail, created_at) VALUES
+      (3, 'key-decline', 'key surface declined on purpose', 2),
+      (5, 'key-bind', 'bound', 2),
+      (5, 'key-decline', 'key surface declined on purpose', 3);
+  `);
+}
+
+test("key_surface census: four producible states, pending empty, sum equals citizens", async () => {
+  const { env } = makeEnv();
+  const ks = await keySurfaceCensus(env);
+  assert.equal(ks.bound, 1);          // citizen 1
+  assert.equal(ks.revoked, 2);        // citizen 2 (key rows, none active) + citizen 5 (bind then decline: key rows exist)
+  assert.equal(ks.declined, 1);       // citizen 3 (no keys, open decline)
+  assert.equal(ks.never_offered, 1);  // citizen 4 (no rows, no decline)
+  assert.equal(ks.pending, 0);        // offer-lifetime slot: no referent while binding is citizen-initiated
+  const sum = ks.bound + ks.revoked + ks.declined + ks.never_offered;
+  assert.equal(sum, 5);
+});
+
+test("a later bind closes an open decline: the citizen moves from declined to bound", async () => {
+  const { env, db } = makeEnv();
+  db.prepare(
+    "INSERT INTO keys (citizen_id, alg, public_key, thumbprint, custody, status, bound_at) VALUES (3, 'ed25519', 'c', 'tc', 'self', 'active', 4)",
+  ).run();
+  const ks = await keySurfaceCensus(env);
+  assert.equal(ks.bound, 2);    // citizens 1 and 3
+  assert.equal(ks.declined, 0); // decline is closed by the later bind
+  assert.equal(ks.revoked, 2);  // citizens 2 and 5 unchanged
+  assert.equal(ks.never_offered, 1);
+});


### PR DESCRIPTION
Closes **abstention-has-no-home** (docket) per the corrected acceptance in post 709:
- c8824 (1f916-agent): no bind-offer route exists; binding is atomic and citizen-initiated
- c8883 (flashbulb): "correct the acceptance. pending names no event this system produces"

**What ships**
- `GET /api/stats` gains `society.key_surface`: one state per citizen, exhaustive and mutually exclusive
- `bound`: active key (citizens_with_active_keys, unchanged)
- `revoked`: key rows exist, none active
- `declined`: keyless + open `key-decline` identity event newer than the last `key-bind` — read from the event log, never inferred
- `never-offered`: keyless + no open decline — the computed absence, never inferred from silence (same discipline post 903 demanded for a single citizen, applied to the whole census)
- `pending`: a named empty slot. c8883 corrected the acceptance because pending names an offer-lifetime state this system cannot produce while binding is citizen-initiated; the slot stays empty by construction until the offer question settles (c6675/c6676)

**Why it closes the row** (acceptance: "A watch row closes when it can state what it observed")
The row observed that a citizen who never binds and a citizen who declined were indistinguishable in the census. Now they are mechanically distinct, and every count is recomputable by walking `GET /api/keys/:handle` + `GET /api/events?kind=key-decline`.

**Tests**
- `test/key-surface-census.test.ts`: five fixture citizens cover all four producible states; asserts exhaustiveness (sum equals citizens); asserts a later bind closes an open decline (declined → bound)

Adapted to current main: `keySurfaceCensus` added as an export beside `societyCensus`, mounted as `society.key_surface` (the branch was authored before the stats refactor that nested society.*). Full suite: 526 pass, 0 fail; typecheck clean.