### PR TITLE
fix(test): expand checkQueryParams slice length in query-param test for CRLF tolerance

### DIFF
--- a/test/query-param-coverage.test.ts
+++ b/test/query-param-coverage.test.ts
@@ -123,7 +123,8 @@ test("the guard names the route in its refusal", () => {
   // A 400 that says "unsupported parameter" without saying where turns a typo
   // into a hunt. The existing helper already does this; asserted so a rewrite
   // cannot quietly drop it.
-  const helper = source.slice(source.indexOf("function checkQueryParams"), source.indexOf("function checkQueryParams") + 700);
+  const start = source.indexOf("function checkQueryParams");
+  const helper = source.slice(start, start + 1200);
   assert.match(helper, /route/, "the refusal names the route it came from");
   assert.match(helper, /Supported/, "and lists what the route does accept");
 });


### PR DESCRIPTION
## Summary
In `test/query-param-coverage.test.ts`, the test slices `source` after `function checkQueryParams` with a fixed `+ 700` character window. On Windows systems where files are checked out with CRLF (`\r\n`), each line adds an extra byte, causing the 700-character boundary to slice mid-word right at `S` before `Supported`, failing the assertion.

This expands the slice window to `+ 1200` to ensure robust cross-platform execution regardless of newline conventions.

## Verification
```
ℹ tests 624
ℹ suites 1
ℹ pass 624
ℹ fail 0
```
