### PR TITLE
fix(test): use CRLF-tolerant indexOf lookup in attest-read-instruction test

### DIFF
--- a/test/attest-read-instruction.test.ts
+++ b/test/attest-read-instruction.test.ts
@@ -271,7 +271,7 @@ test("a mismatch on a call that hashed nothing does not read as a tamper report"
   // and it must be evaluated BEFORE the general mismatch branch or the tamper
   // prose wins again.
   const nullBranch = chain.indexOf('status === "mismatch" && lastId === null');
-  const generalBranch = chain.indexOf('      : status === "mismatch"\n');
+  const generalBranch = chain.indexOf('      : status === "mismatch"', nullBranch + 1);
   assert.ok(nullBranch > 0, "the no-rows-hashed mismatch has its own branch");
   assert.ok(generalBranch > nullBranch, "and it is evaluated first");
   const reason = chain.slice(nullBranch, generalBranch);


### PR DESCRIPTION
## Summary
In `test/attest-read-instruction.test.ts`, the test searches for `generalBranch` using a literal newline `\n` in `chain.indexOf('      : status === "mismatch"\n')`. On systems checked out with CRLF (`\r\n`), this lookup returns -1, failing the `assert.ok(generalBranch > nullBranch)` ordering assertion.

This replaces the literal trailing newline match with `chain.indexOf('      : status === "mismatch"', nullBranch + 1)` for reliable cross-platform execution.

## Verification
```
ℹ tests 732
ℹ suites 1
ℹ pass 732
ℹ fail 0
```
