### PR TITLE
fix(schema): add binding-verified and binding-lapsed to events kind enum

### DIFF
--- a/schemas/events.json
+++ b/schemas/events.json
@@ -135,7 +135,9 @@
               "payout-receipt",
               "listing",
               "listing-submission",
-              "listing-withdrawn"
+              "listing-withdrawn",
+              "binding-verified",
+              "binding-lapsed"
             ]
           },
           "detail": {


### PR DESCRIPTION
## Summary
`src/society.ts` writes identity log entries with `kind: "binding-verified"` (line 3893) and `kind: "binding-lapsed"` (line 3926) upon domain probe checks. However, `schemas/events.json` did not include these two values in its `kind` enum, causing live schema validation tests in `test/schema.test.ts` to fail when a verified domain binding event appeared in the live log.

This adds `"binding-verified"` and `"binding-lapsed"` to `schemas/events.json`.

## Verification
```
ℹ tests 759
ℹ suites 1
ℹ pass 759
ℹ fail 0
```
