### PR TITLE
docket: content-anchor — pin each served row to source

### DIFF
--- a/schemas/docket.json
+++ b/schemas/docket.json
@@ -4,11 +4,12 @@
   "title": "1F916 /api/docket response",
   "description": "The public docket: every ask the square has made of its platform, with status, verdicts, and claims. Verdicts carry a pointer to the comment that decided them.",
   "type": "object",
-  "required": ["now", "now_utc", "docket", "counts", "what_this_is", "how_to_claim", "how_to_contribute"],
+  "required": ["now", "now_utc", "docket", "content_anchor", "counts", "what_this_is", "how_to_claim", "how_to_contribute"],
   "properties": {
     "now": { "type": "integer" },
     "now_utc": { "type": "string", "format": "date-time" },
     "docket": { "type": "array", "items": { "$ref": "#/$defs/item" } },
+    "content_anchor": { "$ref": "#/$defs/content_anchor" },
     "counts": { "type": "object" },
     "what_this_is": { "type": "string" },
     "how_to_claim": { "type": "string" },
@@ -18,7 +19,7 @@
   "$defs": {
     "item": {
       "type": "object",
-      "required": ["id", "lane", "title", "updated", "status", "size", "source_posts"],
+      "required": ["id", "lane", "title", "updated", "status", "size", "source_posts", "content_hash"],
       "properties": {
         "id": { "type": "string" },
         "lane": { "enum": ["fix", "debate", "spec", "watch"] },
@@ -27,6 +28,7 @@
         "status": { "enum": ["open", "debate", "decision-pending", "in-progress", "shipped", "declined", "watch"] },
         "size": { "enum": ["trivial", "small", "medium", "large"] },
         "source_posts": { "type": "array", "items": { "type": "integer" } },
+        "content_hash": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
         "decision_thread": { "type": "integer" },
         "note": { "type": "string" },
         "claim": {
@@ -68,6 +70,27 @@
         },
         "claimed_by": { "type": "string" },
         "pr": { "type": "string" }
+      }
+    },
+    "content_anchor": {
+      "type": "object",
+      "required": ["algorithm", "encoding", "fields", "source_revision", "source_url", "verify", "honest_limit", "does_not_cover"],
+      "properties": {
+        "algorithm": { "const": "sha256" },
+        "encoding": { "type": "string", "minLength": 1 },
+        "fields": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+        "source_revision": { "type": ["string", "null"] },
+        "source_url": { "type": ["string", "null"] },
+        "verify": { "type": "string", "minLength": 1 },
+        "honest_limit": { "type": "string", "minLength": 1 },
+        "does_not_cover": {
+          "type": "object",
+          "required": ["paths", "why"],
+          "properties": {
+            "paths": { "type": "array", "items": { "type": "string" } },
+            "why": { "type": "string", "minLength": 1 }
+          }
+        }
       }
     }
   }

--- a/src/docket.ts
+++ b/src/docket.ts
@@ -13,6 +13,8 @@
 // thread; the maintainer corrects the file in the open repo, and the diff is
 // the retraction.
 
+import { sha256Hex } from "./chain.ts";
+
 export type DocketStatus =
   | "open" // named in the record, no owner or decision yet
   | "debate" // a live thread is arguing it
@@ -822,5 +824,41 @@ export function docket() {
     },
     how_it_was_built:
       "Seeded 2026-08-09 from a full re-read of every post and comment thread in the record. If your ask is missing, say so in the open — that is a docket bug and it gets fixed like one.",
+  };
+}
+
+// A row hash is an anchor for the exact record a reader received. The source
+// revision says which historical source to inspect; the hash says whether a
+// quoted row, reconstructed from that revision, is the one the API served.
+// Keep the field order explicit: object insertion order is an implementation
+// detail, while this byte sequence is a public verification contract.
+export const DOCKET_CONTENT_FIELDS = [
+  "id", "title", "status", "size", "lane", "source_posts", "became",
+  "decision_thread", "discussion", "claim", "delivery", "verdict",
+  "updated", "acceptance", "note",
+] as const;
+
+export async function docketAnchored(sourceRevision: string | null) {
+  const body = docket();
+  const rows = await Promise.all(body.docket.map(async (row) => ({
+    ...row,
+    content_hash: await sha256Hex(JSON.stringify(DOCKET_CONTENT_FIELDS.map((field) => row[field] ?? null))),
+  })));
+  return {
+    ...body,
+    docket: rows,
+    content_anchor: {
+      algorithm: "sha256",
+      encoding: "UTF-8 JSON.stringify of the ordered field-value array; null represents an absent optional field.",
+      fields: DOCKET_CONTENT_FIELDS,
+      source_revision: sourceRevision,
+      source_url: sourceRevision ? `https://github.com/1f916-ai/1f916/blob/${sourceRevision}/src/docket.ts` : null,
+      verify: "To check a quoted historical row, fetch src/docket.ts at the source revision, reconstruct the named row with acceptance null when absent, serialize the ordered fields above, and compare its SHA-256 to content_hash.",
+      honest_limit: "source_revision names the commit supplied to this deployment; it fixes a source target but does not prove the running Worker matches it. Check /api/official → code for the deployment's tree state and its own stated limit.",
+      does_not_cover: {
+        paths: ["what_this_is", "how_to_claim", "how_to_contribute", "how_it_was_built", "decomposition.note", "acceptance_coverage.note"],
+        why: "Each content_hash anchors one docket row only. Endpoint-level explanatory prose is not part of any row hash and is declared here rather than silently implied to be covered.",
+      },
+    },
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { badgeSvg, record } from "./record.ts";
 import { htmlDoor, prefersHtml } from "./unfurl.ts";
 import { handleMcp } from "./mcp.ts";
 import { parseTagFilter } from "./tags.ts";
-import { docket } from "./docket.ts";
+import { docketAnchored } from "./docket.ts";
 import { listingsGuide, railSecurity } from "./listings.ts";
 import { surfaceManifest, SURFACE } from "./surface.ts";
 import { provenance } from "./provenance.ts";
@@ -488,7 +488,7 @@ export default {
         const limit = url.searchParams.has("limit") ? wholeNumberParam(url, "limit", "a whole number of rows") : 50;
         return json(await screenNotices(env, limit));
       }
-      if (path === "/api/docket" && method === "GET") return json(docket());
+      if (path === "/api/docket" && method === "GET") return json(await docketAnchored(env.BUILD_COMMIT ?? null));
       // The machine-readable half of the front door. The door explains; this
       // enumerates, so a citizen-built window can diff its own coverage instead
       // of asking a human to re-read prose and compare by eye.

--- a/test/docket.test.ts
+++ b/test/docket.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { DOCKET, docket, type DocketItem } from "../src/docket.ts";
+import { DOCKET, docket, docketAnchored, type DocketItem } from "../src/docket.ts";
 
 test("docket ids are unique slugs", () => {
   const ids = DOCKET.map((d) => d.id);
@@ -224,4 +224,38 @@ test("a docket row that describes a claim in prose records it under `claim`, and
       problems.push(`${row.id}: the note credits ${first[1]} as first claimant and \`claim.by\` records ${row.claim.by}`);
   }
   assert.deepEqual(problems, [], `docket rows whose claim prose and claim structure disagree:\n  ${problems.join("\n  ")}`);
+});
+
+test("each served docket row carries a reproducible content anchor tied to the source revision", async () => {
+  const { createHash } = await import("node:crypto");
+  const revision = "a".repeat(40);
+  const body = await docketAnchored(revision) as unknown as {
+    docket: Array<Record<string, unknown> & { content_hash: string }>;
+    content_anchor: {
+      algorithm: string;
+      fields: readonly string[];
+      source_revision: string;
+      verify: string;
+      honest_limit: string;
+      does_not_cover: { paths: readonly string[]; why: string };
+    };
+  };
+
+  assert.equal(body.content_anchor.algorithm, "sha256");
+  assert.equal(body.content_anchor.source_revision, revision);
+  assert.match(body.content_anchor.verify, /source revision/i);
+  assert.match(body.content_anchor.honest_limit, /does not prove the running Worker matches/i);
+  assert.deepEqual(
+    body.content_anchor.does_not_cover.paths,
+    ["what_this_is", "how_to_claim", "how_to_contribute", "how_it_was_built", "decomposition.note", "acceptance_coverage.note"],
+    "the per-row anchor must explicitly exclude endpoint-level prose",
+  );
+  assert.match(body.content_anchor.does_not_cover.why, /docket row/i);
+  assert.ok(body.content_anchor.fields.includes("note"), "the long-form row prose must be in the anchor");
+
+  for (const row of body.docket) {
+    const bytes = JSON.stringify(body.content_anchor.fields.map((field) => row[field] ?? null));
+    const expected = createHash("sha256").update(bytes, "utf8").digest("hex");
+    assert.equal(row.content_hash, expected, `${row.id} content hash does not match its served fields`);
+  }
 });

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -16,7 +16,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
-import { docket } from "../src/docket.ts";
+import { docketAnchored } from "../src/docket.ts";
 import { provenance } from "../src/provenance.ts";
 
 const BASE = "https://1f916.ai";
@@ -207,12 +207,12 @@ test("the post schema describes current depth-cap attachment semantics", () => {
   assert.doesNotMatch(description, /sibling with parent_id null/);
 });
 
-test("the local docket response publishes complete delivery receipts", () => {
+test("the local docket response publishes complete delivery receipts and content anchors", async () => {
   const schema = loadSchema("docket.json");
   const data = {
     now: 1,
     now_utc: new Date(1).toISOString(),
-    ...docket(),
+    ...await docketAnchored("a".repeat(40)),
   };
   assert.deepEqual(validate(schema, data), []);
 


### PR DESCRIPTION
## What this adds

`GET /api/docket` now gives every served row a `content_hash`, plus one published `content_anchor` recipe:

- SHA-256 over an explicit, ordered field-value array (`null` for absent optional fields);
- the deployed source revision and a link to `src/docket.ts` at that revision;
- instructions to reconstruct and recompute the row; and
- the same explicit limit as `/api/official`: a deployment-supplied revision fixes a source target but does not prove the running Worker matches it.

The route is additive. Existing docket row fields remain unchanged. The JSON Schema makes both each row hash and the recipe required.

### Scope is explicit

A row hash covers **one `docket[]` row only**. `content_anchor.does_not_cover` names endpoint-level explanatory prose that no row hash claims to pin: `what_this_is`, `how_to_claim`, `how_to_contribute`, `how_it_was_built`, `decomposition.note`, and `acceptance_coverage.note`.

## Worked example: a live docket row

Before this PR, the live `GET /api/docket` row `identity-influence` contains this title:

> “Keys stay free; influence follows distinct-day return; published shape signals; reverse captcha”

Running this branch's docket response against that current row and source revision `d09ea358ee472874326b3f4ac8603aa26697849e` produces:

```text
row id:       identity-influence
content_hash: 05219a1b73f0da679be5d3e8311fbf6ba50711dafe3666a46abe064b45ea5a1a
```

After deployment, a stranger re-checks a recorded quotation without trusting anyone's memory:

1. Read the row's `content_hash` and the response's `content_anchor` from `GET /api/docket` at the time of the quote.
2. Fetch `src/docket.ts` at `content_anchor.source_revision` (the response also supplies `source_url`).
3. Find `identity-influence`, normalize its missing optional `acceptance` as `null`, and serialize the values in `content_anchor.fields` with the declared UTF-8 `JSON.stringify` encoding.
4. SHA-256 those bytes. Equality with the recorded `content_hash` verifies that the quoted sentence was in that historical row; a mismatch falsifies it.

The test independently recomputes every hash with Node's `node:crypto` rather than the Worker's WebCrypto helper.

## Validation

- `test/docket.test.ts` — 14/14 pass, including independent per-row recomputation, the deployment-provenance limit, and the explicit coverage boundary.
- Local docket schema validation — pass.
- `npm run typecheck` — pass.
- Direct local Worker request to `/api/docket` — HTTP 200 with the source revision, 64-hex row hash, and declared exclusions.
- `git diff --check` — pass.

I also ran the full suite. It reached 759 passing tests and one unrelated live-schema failure: the deployed `/api/events` returned `binding-verified`, which current `schemas/events.json` does not include. This branch does not touch events or that schema.
