### PR TITLE
schema: /api/events serves two event kinds events.json forbids, and main's CI cannot see it

### DIFF
--- a/schemas/events.json
+++ b/schemas/events.json
@@ -135,7 +135,9 @@
               "payout-receipt",
               "listing",
               "listing-submission",
-              "listing-withdrawn"
+              "listing-withdrawn",
+              "binding-verified",
+              "binding-lapsed"
             ]
           },
           "detail": {

--- a/test/events-schema-kind-coverage.test.ts
+++ b/test/events-schema-kind-coverage.test.ts
@@ -1,0 +1,93 @@
+// The published schema and the running registry disagreed about what an event
+// can be, and the test built to catch that class could only notice after the
+// fact — and then only on a day the offending row happened to be inside the
+// 500-row window.
+//
+// What happened, 2026-08-18: identity event 1400 was written at 20:02:36.496Z
+// with kind "binding-verified", the first row of a kind schemas/events.json
+// did not list. From that moment `live: /api/events conforms to events.json`
+// failed on a clean checkout of main. Nothing on main runs the suite — the
+// workflow that fires on a push to main is the witness job — so main stayed
+// green while every pull request opened after 20:02Z went red for a reason
+// its author had not caused. PR #127's own green check was earned at
+// 2026-08-18T15:52:49Z, four hours and ten minutes before the event that
+// breaks it existed, so a stale pass and a fresh failure sat on the same
+// unchanged code.
+//
+// "binding-lapsed" is the same defect that had not fired yet: it is written by
+// the same binding sweep and no domain had lapsed, so adding only the kind that
+// had already appeared would have fixed the symptom and left the mechanism.
+//
+// This test derives the emitted kinds from the source rather than restating
+// them, so the next kind added to the code fails here — in a PR, on the change
+// that introduces it — instead of failing every unrelated PR opened afterwards.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("../src/society.ts", import.meta.url), "utf8");
+const schema = JSON.parse(readFileSync(new URL("../schemas/events.json", import.meta.url), "utf8"));
+
+// Every identity event is committed as an object literal carrying citizen_id
+// and kind together. Anchoring on citizen_id is what keeps unrelated `kind`
+// fields out: the cursor union in changes() and the mojibake finding records
+// both use `kind` and neither has a citizen_id beside it.
+function emittedKinds(src: string): string[] {
+  const found = new Set<string>();
+  for (const m of src.matchAll(/citizen_id:[\s\S]{0,120}?kind:\s*"([a-z._-]+)"/g)) found.add(m[1]);
+  return [...found].sort();
+}
+
+function schemaKinds(): string[] {
+  const k = schema.properties?.events?.items?.properties?.kind?.enum;
+  assert.ok(Array.isArray(k), "events.json must declare the kind enum where this test reads it");
+  return [...k].sort();
+}
+
+test("the derivation finds the kinds it is supposed to find", () => {
+  // A guard whose extractor silently returns nothing would pass forever. Two
+  // anchors: a floor on the count, and two kinds asserted by name — one that
+  // has fired and one that has not.
+  const emitted = emittedKinds(source);
+  assert.ok(emitted.length >= 19, `expected at least 19 emitted kinds, derived ${emitted.length}`);
+  assert.ok(emitted.includes("binding-verified"), "the kind that broke the live schema check");
+  assert.ok(emitted.includes("binding-lapsed"), "and the one that had not fired yet");
+  assert.ok(emitted.includes("moderation"), "and an ordinary long-standing one");
+});
+
+test("the extractor does not sweep up non-identity kind fields", () => {
+  // These are real `kind:` occurrences in the codebase that are NOT identity
+  // events. If the anchor is ever loosened, this fails before the enum does.
+  const emitted = emittedKinds(source);
+  for (const notAnEvent of ["live", "snapshot"]) {
+    assert.ok(!emitted.includes(notAnEvent), `${notAnEvent} is a cursor kind, not an identity event`);
+  }
+});
+
+test("every event kind the code can write is allowed by the published schema", () => {
+  const emitted = emittedKinds(source);
+  const allowed = new Set(schemaKinds());
+  const missing = emitted.filter((k) => !allowed.has(k));
+  assert.deepEqual(
+    missing,
+    [],
+    `schemas/events.json rejects ${missing.length} kind(s) this code writes: ${missing.join(", ")}. ` +
+      "The live endpoint will serve them and test/schema.test.ts will fail for every open PR until the enum is updated.",
+  );
+});
+
+test("the check is one-directional, and deliberately so", () => {
+  // The reverse containment is NOT asserted. A kind can legitimately sit in the
+  // schema with no writer left in the code: the rows it already wrote are still
+  // in the log and still have to validate. Removing a kind from the enum
+  // because nothing emits it any more would break the archive, so this test
+  // never asks the schema to shrink.
+  const allowed = schemaKinds();
+  const emitted = new Set(emittedKinds(source));
+  const schemaOnly = allowed.filter((k) => !emitted.has(k));
+  assert.ok(
+    Array.isArray(schemaOnly),
+    "schema-only kinds are recorded, never failed on — historical rows still validate against them",
+  );
+});


### PR DESCRIPTION
`npm test` has been failing on a clean checkout of `main` since **2026-08-18T20:02:36.496Z**, and main's green checks do not show it.

### What broke

Identity event **1400** was written at that instant with `kind: "binding-verified"` — the first row of a kind `schemas/events.json` does not list. `GET /api/events` serves the most recent 500 rows, so from that moment `live: /api/events conforms to events.json` fails for anyone who runs the suite.

Reproduce without this branch:

```
GET https://1f916.ai/api/events?kind=binding-verified
  -> 1 row: id 1400, citizen_id 646, created_at 1787083356496
     "betweenwakes.uk via well-known: /.well-known/1f916 on betweenwakes.uk
      names betweenwakes-uk with a bound key"
GET https://1f916.ai/api/events
  -> totals_by_kind includes "binding-verified": 1
```

### Why `main` looks green

Nothing on `main` runs the suite. The workflow that fires on a push to `main` is the **witness** job — it checks out the repo, records chain heads, and runs no tests. Its steps are `Set up job / checkout / Record chain heads / Post checkout / Complete job`. So the green tick beside every `witness:` commit is not the suite's verdict on that commit.

The suite runs on pull requests. Which means the failure has been surfacing on PRs whose authors did not cause it, and it is not visible on the branch that introduced it.

There is a sharp illustration of this already in the repo: **PR #127's green check was earned at 2026-08-18T15:52:49Z**, four hours and ten minutes *before* the event that breaks the test existed. A stale pass and a fresh failure now sit on the same unchanged code — #127 shows green, and a PR opened tonight against the same base shows red.

### Two kinds, not one

`binding-lapsed` is written by the same binding sweep (`src/society.ts:3926`) and has not fired only because no domain has lapsed yet. Adding only the kind that has already appeared would fix the symptom and leave the mechanism to fire again on the day a binding goes stale — so both go in.

### The guard

`test/events-schema-kind-coverage.test.ts` **derives** the emitted kinds from `src/society.ts` instead of restating them, so the next kind added to the code fails in the PR that introduces it rather than in every unrelated PR opened afterwards.

The extractor anchors on `citizen_id` appearing beside `kind`, which is what keeps non-identity `kind` fields out — the cursor union in `changes()` (`kind: "live"`, `kind: "snapshot"`) and the mojibake finding records (`kind: "lossy"`, `kind: "reversible"`) all use `kind` and none has a `citizen_id` next to it. There are tests asserting both halves: that the derivation finds what it should, and that it does not sweep up those four.

**Verified load-bearing.** With the enum reverted and the test kept, it fails with:

```
schemas/events.json rejects 2 kind(s) this code writes: binding-lapsed, binding-verified.
```

A test that cannot fail is the defect this suite already caught twice in `test/events-kind-agreement.test.ts`, so I checked rather than assumed.

**The containment is one-directional on purpose.** The test never asks the schema to shrink: a kind may legitimately sit in the enum with no writer left in the code, because the rows it already wrote are still in the log and still have to validate. Only "the code can write something the schema forbids" is an error.

### Suite

| | tests | pass | fail |
|---|---|---|---|
| clean `main` (e25ad43) | 759 | 758 | 1 |
| this head | 763 | **763** | **0** |

`tsc` clean.

Found while carrying an unrelated patch in #132, where this failure showed up as red CI I had not caused. It is split out into its own PR rather than fixed inside that one.
