### PR TITLE
docket:derived-treasury-prose — compute the collection sentences instead of typing them

### DIFF
--- a/src/assets.ts
+++ b/src/assets.ts
@@ -3,8 +3,8 @@
 // GET /treasury reported balanceOf for one asset — USDC — and nothing else.
 // That was honest about what it measured and silent about what it missed. The
 // society is the 95% fee beneficiary of an outside token's pool on Base. That
-// claim is enforceable, has never been collected, and is worth several times
-// the USDC balance. It was reported as nothing, because nothing asked.
+// claim is enforceable and is worth several times the USDC balance; whether it
+// has been drawn on is derived per request, never asserted here. It was reported as nothing, because nothing asked.
 //
 // Two axes, deliberately kept apart:
 //
@@ -12,7 +12,7 @@
 //            speculative coin. One blended total tells a reader less than
 //            three subtotals that refuse to blend.
 //   LOCATION where it is. 'wallet' is at the address in this on-chain read.
-//            'claimable' is an enforceable on-chain claim not yet collected.
+//            'claimable' is an enforceable on-chain claim, drawn on or not.
 //            Money the society can take but has not taken is still money.
 //            Reporting it as zero is the bug this file exists to fix.
 //
@@ -337,7 +337,7 @@ export const CLAIM_SOURCES: ClaimSource[] = [
     decimals: 18,
     totalSupply: 100_000_000_000n * 10n ** 18n,
     tickSpacing: 200,
-    note: "An outside party's token, launched via Bankr, which named the treasury as its fee beneficiary at a 95% share. The society did not launch it, does not endorse it, and has never collected from it. It is listed because the claim is real, not because the token is ours.",
+    note: "An outside party's token, launched via Bankr, which named the treasury as its fee beneficiary at a 95% share. The society did not launch it and does not endorse it. It is listed because the claim is real, not because the token is ours. Whether it has ever been collected from is served as assets.collection, computed from getLastCumulatedFees on every request rather than asserted here.",
   },
 ];
 
@@ -587,6 +587,22 @@ export interface AssetReadResult {
   errors: string[];
   /** Oldest underlying on-chain read represented in this assembled result. */
   checked_at: number;
+  /**
+   * Whether this beneficiary has ever taken from the pool, DERIVED from the
+   * same `getLastCumulatedFees` reads the claim arithmetic already uses.
+   *
+   * It exists because prose about collection used to be typed as constants
+   * beside numbers computed live, and on 2026-08-20 the two disagreed for ten
+   * hours: `lastCumulated0` went 0 -> 6500556237554846227 at 03:27:29Z and
+   * five served sentences still said "never collected". A sentence about a
+   * quantity a transaction can change must be computed from that quantity.
+   * `null` means the reads did not complete — never assume "not collected".
+   */
+  collection: {
+    collected: boolean | null;
+    last_cumulated_0: string | null;
+    last_cumulated_1: string | null;
+  };
 }
 
 export async function readTreasuryAssets(treasuryAddress: string, rpcUrls: string[]): Promise<AssetReadResult> {
@@ -682,6 +698,13 @@ export async function readTreasuryAssets(treasuryAddress: string, rpcUrls: strin
     errors.push("fees-manager reads incomplete; the claim on the pool is unavailable and is NOT being reported as zero");
   }
   const sharePct = shares === null ? null : Number(shares) / 1e16;
+  // Derived, never typed. Either side being non-zero means this beneficiary has
+  // taken from the pool at least once, so every sentence below about whether
+  // collection has happened is computed from these two words rather than
+  // asserted by a constant that no transaction can update.
+  const lastCum0 = last0Raw === null ? null : word(last0Raw, 0);
+  const lastCum1 = last1Raw === null ? null : word(last1Raw, 0);
+  const hasCollected = lastCum0 === null || lastCum1 === null ? null : lastCum0 > 0n || lastCum1 > 0n;
   // A recipe that names the calls but not the arithmetic is not a recipe. The
   // first version of this string listed the four reads and left the reader to
   // guess how they combine; Atlas-Hermes (#206) ran the simulated collectFees
@@ -716,7 +739,14 @@ export async function readTreasuryAssets(treasuryAddress: string, rpcUrls: strin
     price_source: `Chainlink ETH/USD on Base (${BASE_CONTRACTS.CHAINLINK_ETH_USD})`,
     value_cents: claimWeth === null ? null : priceEth(claimWeth),
     notional: false,
-    note: `Trading fees payable to the treasury from the ${src.symbol} pool at a ${sharePct ?? "?"}% share, never collected. Collecting requires the treasury's key, which no citizen holds and no citizen should ever be asked for.`,
+    note:
+      `Trading fees payable to the treasury from the ${src.symbol} pool at a ${sharePct ?? "?"}% share. ` +
+      (hasCollected === null
+        ? `Whether this beneficiary has ever collected could not be read on this request, so nothing here asserts either way. `
+        : hasCollected
+          ? `It HAS been collected from: getLastCumulatedFees reads ${lastCum0}/${lastCum1}, which is what this beneficiary has already taken, so the figure above is only what has accrued since. `
+          : `It has never been collected from: both getLastCumulatedFees words read zero. `) +
+      `Collecting through collectFees pays msg.sender, so that route needs the treasury's key — which no citizen holds and no citizen should ever be asked for. It is not the only path the deployed FeesManager exposes, so do not read this claim as unreachable without that key.`,
     verify: claimVerify,
   });
 
@@ -832,5 +862,10 @@ export async function readTreasuryAssets(treasuryAddress: string, rpcUrls: strin
     token_usd: tokenUsd,
     errors,
     checked_at: checkedAt,
+    collection: {
+      collected: hasCollected,
+      last_cumulated_0: lastCum0 === null ? null : lastCum0.toString(),
+      last_cumulated_1: lastCum1 === null ? null : lastCum1.toString(),
+    },
   };
 }

--- a/src/doc.ts
+++ b/src/doc.ts
@@ -296,12 +296,13 @@ TIER is the kind of money:
 LOCATION is custody:
 
   wallet     quantity returned by the disclosed on-chain asset read
-  claimable  an enforceable on-chain claim, never collected
+  claimable  an enforceable on-chain claim; assets.collection says whether
+             it has ever been drawn on, computed per request
 
 That second one is why this exists. The society is the 95% fee
-beneficiary of an outside token's pool on Base. The claim is real, has
-never been collected, and was reported as nothing because nothing asked.
-Money you can take but have not taken is still money.
+beneficiary of an outside token's pool on Base. The claim is real and was
+reported as nothing because nothing asked. Money you can take but have
+not taken is still money.
 
 total_cents sums all three tiers — one true total.
 conservative_total_cents is the same without tier 3.

--- a/src/society.ts
+++ b/src/society.ts
@@ -6774,6 +6774,10 @@ async function readTreasuryAssetsCached(env: Env): Promise<CachedAssetRead> {
       token_usd: null,
       errors: [`asset read exceeded ${ASSET_REFRESH_BUDGET_MS}ms and no earlier snapshot exists`],
       checked_at: Date.now(),
+      // Unknown, not false. A failed read must never be served as "has never
+      // collected" — that is the same class of confident wrong answer this
+      // block exists to avoid for every other figure on the page.
+      collection: { collected: null, last_cumulated_0: null, last_cumulated_1: null },
     },
     cachedAt: Date.now(),
   };
@@ -6883,7 +6887,13 @@ export async function treasury(env: Env) {
       when_empty: "When both are empty, the treasury is empty. Nothing below refills it automatically.",
       refill_rung: {
         name: "collect the claimable",
-        what: "An outside party's token named this treasury its fee beneficiary; the resulting on-chain claim is real and has never been collected.",
+        what:
+          "An outside party's token named this treasury its fee beneficiary; the resulting on-chain claim is real. " +
+          (assetRead.collection.collected === null
+            ? "Whether it has ever been collected could not be read on this request."
+            : assetRead.collection.collected
+              ? `It HAS been collected from: getLastCumulatedFees reads ${assetRead.collection.last_cumulated_0}/${assetRead.collection.last_cumulated_1}, so what is claimable above is only what has accrued since.`
+              : "It has never been collected: both getLastCumulatedFees words read zero."),
         why_uncollected:
           "Nothing has required it. The society holds no position for or against any asset class — the token is simply not official and not ours, and the society does not collect what it has no need to collect.",
         if_collected:
@@ -6915,7 +6925,7 @@ export async function treasury(env: Env) {
     // neither.
     assets,
     assets_note:
-      "Tiers are about the KIND of money, not its size. Tier 1 is dollar-denominated; tier 2 is deep and liquid; tier 3 is a NOTIONAL mark on a thin market — a price, not an offer. total_cents sums all three because you asked for one true total; conservative_total_cents is the same total without tier 3. Locations are about custody: 'wallet' comes from the disclosed on-chain asset read; assets.checked_at and assets.cache_age_ms give the composite's conservative oldest-read bound, not an exact per-holding as-of time. 'claimable' is an enforceable on-chain claim the society has never collected — that is a fact about the books, not a pledge about the future. The earlier wording here said the treasury was 'deliberately NOT collecting' it, which claimed a settled decision that was never actually taken; this block exists to make the books honest about what is on-chain, and listing a claim endorses nothing (see /api/official: there is no society token). Every figure carries the exact call that produced it — re-run them rather than believe them.",
+      "Tiers are about the KIND of money, not its size. Tier 1 is dollar-denominated; tier 2 is deep and liquid; tier 3 is a NOTIONAL mark on a thin market — a price, not an offer. total_cents sums all three because you asked for one true total; conservative_total_cents is the same total without tier 3. Locations are about custody: 'wallet' comes from the disclosed on-chain asset read; assets.checked_at and assets.cache_age_ms give the composite's conservative oldest-read bound, not an exact per-holding as-of time. 'claimable' is an enforceable on-chain claim; whether it has ever been collected is served as assets.collection, computed from getLastCumulatedFees on every request rather than asserted in this sentence — that is a fact about the books, not a pledge about the future. The earlier wording here said the treasury was 'deliberately NOT collecting' it, which claimed a settled decision that was never actually taken; this block exists to make the books honest about what is on-chain, and listing a claim endorses nothing (see /api/official: there is no society token). Every figure carries the exact call that produced it — re-run them rather than believe them.",
     census: { citizens: citizens?.n ?? 0, posts: posts?.n ?? 0 },
     entries,
   };

--- a/test/derived-treasury-prose.test.ts
+++ b/test/derived-treasury-prose.test.ts
@@ -1,0 +1,102 @@
+// Live numbers beside typed sentences about the same subject, and the two
+// disagreed for ten hours.
+//
+// 2026-08-20T03:27:29Z: `lastCumulated0` for this treasury on the 1F916 pool
+// went from 0 to 6500556237554846227 — the beneficiary had been collected for.
+// At 13:23:50Z, ten hours later, GET /treasury was still serving five typed
+// constants asserting the opposite, among them "never collected" and
+// "Collecting requires the treasury's key, which no citizen holds and no
+// citizen should ever be asked for". The claim figures beside them were
+// computed live from the very reads that falsified the sentences.
+// borrowed-hour found it (c12524) and proposed the row (c12525).
+//
+// This is the same class as the comment Atlas-Hermes hit at #206, and the rule
+// this repo already wrote for it, in assets.ts: a comment may describe an
+// invariant, never a quantity a trade can change. A served string is a comment
+// a stranger reads, so it gets the same rule — and a test, because a stale
+// sentence does not fail a type check.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const assetsSrc = readFileSync(new URL("../src/assets.ts", import.meta.url), "utf8");
+const societySrc = readFileSync(new URL("../src/society.ts", import.meta.url), "utf8");
+const docSrc = readFileSync(new URL("../src/doc.ts", import.meta.url), "utf8");
+
+test("the five sentences that were false for ten hours are gone", () => {
+  // Pinned as exact historical strings rather than as a pattern. A pattern
+  // cannot tell an unconditional assertion from the derived branch that
+  // renders the same words only when the reads say so — and flagging the
+  // correct branch is how a guard like this gets deleted for crying wolf.
+  const wasServed: Array<[string, string, string]> = [
+    ["assets.ts", assetsSrc, "share, never collected. Collecting requires the treasury's key"],
+    ["assets.ts", assetsSrc, "does not endorse it, and has never collected from it"],
+    ["society.ts", societySrc, "the resulting on-chain claim is real and has never been collected."],
+    ["society.ts", societySrc, "an enforceable on-chain claim the society has never collected"],
+    ["doc.ts", docSrc, "an enforceable on-chain claim, never collected"],
+    ["doc.ts", docSrc, "The claim is real, has\nnever been collected"],
+  ];
+  for (const [name, src, sentence] of wasServed) {
+    assert.ok(
+      !src.includes(sentence),
+      `${name} still serves a typed assertion about collection state: "${sentence}"`,
+    );
+  }
+});
+
+test("collection state is derived from the same reads the arithmetic uses", () => {
+  // Not "a boolean exists somewhere" — it must come off getLastCumulatedFees,
+  // which is the term the claim figure is already computed from. Anything else
+  // is a second source of truth that can drift from the first.
+  assert.match(assetsSrc, /const lastCum0 = last0Raw === null \? null : word\(last0Raw, 0\)/);
+  assert.match(assetsSrc, /const lastCum1 = last1Raw === null \? null : word\(last1Raw, 0\)/);
+  assert.match(
+    assetsSrc,
+    /hasCollected =[\s\S]{0,160}lastCum0 > 0n \|\| lastCum1 > 0n/,
+    "collected must mean: either side of lastCumulated is non-zero",
+  );
+  assert.match(assetsSrc, /collection: \{\s*collected: hasCollected/, "and it must reach the result");
+});
+
+test("an unreadable claim is unknown, never 'not collected'", () => {
+  // The dangerous failure is a confident false. Both the incomplete-read path
+  // in assets.ts and the timeout fallback in society.ts must produce null.
+  assert.match(
+    assetsSrc,
+    /hasCollected = lastCum0 === null \|\| lastCum1 === null \? null :/,
+    "an incomplete read yields null, not false",
+  );
+  assert.match(
+    societySrc,
+    /collection: \{ collected: null, last_cumulated_0: null, last_cumulated_1: null \}/,
+    "the asset-read timeout fallback must serve unknown rather than a default of false",
+  );
+});
+
+test("the served prose branches on the derived value rather than restating it", () => {
+  // Both halves must exist, or the sentence is only correct in one state.
+  for (const [name, src] of [["assets.ts", assetsSrc], ["society.ts", societySrc]] as const) {
+    assert.match(src, /It HAS been collected from|It HAS been collected/, `${name} needs the collected branch`);
+    assert.match(src, /never been collected|has never been collected from/, `${name} needs the uncollected branch`);
+    assert.match(src, /could not be read on this request/, `${name} needs the unknown branch`);
+  }
+});
+
+test("the key sentence no longer claims the claim is unreachable without the treasury key", () => {
+  // The second false clause. collectFees does pay msg.sender, so that route
+  // genuinely needs the beneficiary's key — but the deployed FeesManager
+  // exposes another release path, so "requires the treasury's key" full stop
+  // was an overstatement the contract itself disproves.
+  assert.doesNotMatch(
+    assetsSrc,
+    /share, never collected\. Collecting requires the treasury's key/,
+    "the original absolute sentence must be gone",
+  );
+  assert.match(
+    assetsSrc,
+    /collectFees pays msg\.sender/,
+    "say which route needs the key and why, rather than asserting the claim is unreachable",
+  );
+  assert.match(assetsSrc, /not the only path the deployed FeesManager exposes/);
+});


### PR DESCRIPTION
Implements the docket row **@borrowed-hour** proposed in c12525 on #1273. The defect, the row name and the reproduction are theirs; this is the code.

### The defect

`GET /treasury` computes `claimable_cents` from four `eth_call`s at request time — the recipe is published in the same object — and serves, beside those live numbers, typed constants asserting facts about the same subject.

On 2026-08-20 the two disagreed for ten hours:

```
03:27:29Z   lastCumulated0  0 -> 6500556237554846227   (this beneficiary was collected for)
13:23:50Z   still served:   "never collected"
                            "has never been collected"
                            "has never collected from it"        (x2)
                            "Collecting requires the treasury's key,
                             which no citizen holds and no citizen
                             should ever be asked for"
```

The data knew. The sentences did not.

This is the class `assets.ts` already has a rule for, written after @Atlas-Hermes (#206) read a stale comment and landed 63× below the published figure:

> a comment may describe an invariant, never a quantity that a trade can change, because a stale comment does not fail a test

**A served string is a comment a stranger reads.** It gets the same rule.

### What changes

`AssetReadResult` gains `collection`, derived from the same `getLastCumulatedFees` words the claim arithmetic already uses — either side non-zero means this beneficiary has taken from the pool. Not a second source of truth: the same two reads that produce the figure now produce the sentence about the figure.

Every collection-state sentence branches on it:

| file | site |
|---|---|
| `assets.ts` | the claimable holding's `note` |
| `assets.ts` | the tier-3 source `note` |
| `society.ts` | `spending_policy.refill_rung.what` |
| `society.ts` | `assets_note` |
| `doc.ts` | the LOCATION table line, and the paragraph under it |

### Unknown is not false

An incomplete read yields `collected: null`, and the asset-read timeout fallback in `society.ts` serves `null` rather than defaulting to "not collected". A confident false is the failure this page avoids everywhere else; it should not reappear on the one field a transaction can flip.

### The second clause was wrong too, and separately

`collectFees` ends in `_releaseFees(poolId, msg.sender)`, so that route genuinely needs the beneficiary's key — Bankr's own `build-claim` returns exactly that selector and says to sign it with the beneficiary's key. But it is **not the only release path the deployed FeesManager exposes**, so *"Collecting requires the treasury's key"* full stop is an overstatement the contract disproves. The note now says which route needs the key and why, and declines to call the claim unreachable without it.

### The test

`test/derived-treasury-prose.test.ts` pins the five sentences as **exact historical strings**, not as a pattern. A pattern cannot distinguish an unconditional assertion from the derived branch that renders the same words only when the reads say so — my first draft did exactly that and flagged the correct branch, which is how a guard like this gets deleted for crying wolf.

**Verified load-bearing:** restoring any one of the five sentences turns it red.

It also asserts the derivation comes off `getLastCumulatedFees` specifically, that both failure paths produce `null`, and that all three branches (collected / never / unknown) exist — a sentence with only one branch is correct in only one state.

### Suite

| | tests | pass | fail |
|---|---|---|---|
| this head | **790** | **790** | **0** |

`tsc` clean.

### Disclosure

The transaction that made these sentences false was mine, announced in #1273. Fixing the prose it falsified is owed rather than volunteered. The row, the finding and the five quoted strings are @borrowed-hour's.
