### PR TITLE
listing screen-notices: record findings that screenGate computed but dropped

### DIFF
--- a/migrations/0037_screen_notices_listing.sql
+++ b/migrations/0037_screen_notices_listing.sql
@@ -1,0 +1,52 @@
+-- 0037: let the door's public log name a listing.
+--
+-- #123. A listing goes through screenGate like a post: a hygiene finding
+-- refuses the write, a reader-safety finding lets it stand and is supposed to
+-- be recorded. The recording half was never wired, so every reader-safety
+-- finding screenGate computed on a listing was thrown away — the one write
+-- path on this square whose door findings left no public row.
+--
+-- screen_notices pins target_type with a CHECK (migrations/0010), so widening
+-- the code alone would ship a feature that fails at the database on every use
+-- with the test suite green. That is exactly the note migrations/0029 wrote
+-- about flags and it is the second time this shape has come up; the code
+-- change without this file is the bug, not the fix.
+--
+-- SQLite cannot alter a CHECK, so the table is rebuilt and copied. Columns are
+-- listed explicitly rather than SELECT *: status and rules_hash were added by
+-- ALTER in migrations/0011, so live databases carry them AFTER created_at
+-- while schema.sql declares them before it, and a positional copy would write
+-- 'open' into created_at on production and nowhere else.
+--
+-- id is carried across explicitly for the same reason 0029 carried it: these
+-- rows are served in a public register and renumbering them would silently
+-- rewrite which finding is which.
+--
+-- No backfill. The findings dropped before today were never stored and cannot
+-- be recovered; the record says the log started covering listings today,
+-- which is true.
+
+PRAGMA foreign_keys=OFF;
+
+CREATE TABLE screen_notices_new (
+  id             INTEGER PRIMARY KEY AUTOINCREMENT,
+  target_type    TEXT NOT NULL CHECK (target_type IN ('post', 'comment', 'listing')),
+  target_id      INTEGER NOT NULL,
+  citizen_id     INTEGER NOT NULL REFERENCES citizens(id),
+  book           TEXT NOT NULL CHECK (book IN ('hygiene', 'reader-safety')),
+  rule           TEXT NOT NULL,
+  screen_version INTEGER NOT NULL,
+  status         TEXT NOT NULL DEFAULT 'open',
+  rules_hash     TEXT,
+  created_at     INTEGER NOT NULL
+);
+INSERT INTO screen_notices_new
+  (id, target_type, target_id, citizen_id, book, rule, screen_version, status, rules_hash, created_at)
+  SELECT id, target_type, target_id, citizen_id, book, rule, screen_version, status, rules_hash, created_at
+  FROM screen_notices;
+DROP TABLE screen_notices;
+ALTER TABLE screen_notices_new RENAME TO screen_notices;
+CREATE INDEX IF NOT EXISTS idx_screen_notices_created ON screen_notices(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_screen_notices_target ON screen_notices(target_type, target_id);
+
+PRAGMA foreign_keys=ON;

--- a/schema.sql
+++ b/schema.sql
@@ -584,3 +584,26 @@ CREATE TABLE IF NOT EXISTS witness_dispatch (
   last_error TEXT,
   last_ok_at INTEGER
 );
+
+-- migrations/0035: widen screen_notices.target_type to include 'listing'.
+-- Listings were screened by screenGate (hygiene findings refused the write,
+-- reader-safety findings passed through) but the observe-mode findings were
+-- never recorded. Fix: widen the target_type constraint and record them.
+-- SQLite cannot ALTER a CHECK, so the table is recreated. (#123)
+CREATE TABLE IF NOT EXISTS _screen_notices_new (
+  id             INTEGER PRIMARY KEY AUTOINCREMENT,
+  target_type    TEXT NOT NULL CHECK (target_type IN ('post', 'comment', 'listing')),
+  target_id      INTEGER NOT NULL,
+  citizen_id     INTEGER NOT NULL REFERENCES citizens(id),
+  book           TEXT NOT NULL CHECK (book IN ('hygiene', 'reader-safety')),
+  rule           TEXT NOT NULL,
+  screen_version INTEGER NOT NULL,
+  status         TEXT NOT NULL DEFAULT 'open',
+  rules_hash     TEXT,
+  created_at     INTEGER NOT NULL
+);
+INSERT OR IGNORE INTO _screen_notices_new SELECT * FROM screen_notices;
+DROP TABLE IF EXISTS screen_notices;
+ALTER TABLE _screen_notices_new RENAME TO screen_notices;
+CREATE INDEX IF NOT EXISTS idx_screen_notices_created ON screen_notices(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_screen_notices_target ON screen_notices(target_type, target_id);

--- a/schema.sql
+++ b/schema.sql
@@ -231,7 +231,9 @@ CREATE INDEX IF NOT EXISTS idx_settle_attempts_state ON settle_attempts(state, u
 -- payload. Matched text goes only to the writer, in their own response.
 CREATE TABLE IF NOT EXISTS screen_notices (
   id             INTEGER PRIMARY KEY AUTOINCREMENT,
-  target_type    TEXT NOT NULL CHECK (target_type IN ('post', 'comment')),
+  -- 'listing' widened by migrations/0037. A listing is screened by the same
+  -- door as a post and its observe-mode findings are recorded here too.
+  target_type    TEXT NOT NULL CHECK (target_type IN ('post', 'comment', 'listing')),
   target_id      INTEGER NOT NULL,
   citizen_id     INTEGER NOT NULL REFERENCES citizens(id),
   book           TEXT NOT NULL CHECK (book IN ('hygiene', 'reader-safety')),
@@ -584,26 +586,3 @@ CREATE TABLE IF NOT EXISTS witness_dispatch (
   last_error TEXT,
   last_ok_at INTEGER
 );
-
--- migrations/0035: widen screen_notices.target_type to include 'listing'.
--- Listings were screened by screenGate (hygiene findings refused the write,
--- reader-safety findings passed through) but the observe-mode findings were
--- never recorded. Fix: widen the target_type constraint and record them.
--- SQLite cannot ALTER a CHECK, so the table is recreated. (#123)
-CREATE TABLE IF NOT EXISTS _screen_notices_new (
-  id             INTEGER PRIMARY KEY AUTOINCREMENT,
-  target_type    TEXT NOT NULL CHECK (target_type IN ('post', 'comment', 'listing')),
-  target_id      INTEGER NOT NULL,
-  citizen_id     INTEGER NOT NULL REFERENCES citizens(id),
-  book           TEXT NOT NULL CHECK (book IN ('hygiene', 'reader-safety')),
-  rule           TEXT NOT NULL,
-  screen_version INTEGER NOT NULL,
-  status         TEXT NOT NULL DEFAULT 'open',
-  rules_hash     TEXT,
-  created_at     INTEGER NOT NULL
-);
-INSERT OR IGNORE INTO _screen_notices_new SELECT * FROM screen_notices;
-DROP TABLE IF EXISTS screen_notices;
-ALTER TABLE _screen_notices_new RENAME TO screen_notices;
-CREATE INDEX IF NOT EXISTS idx_screen_notices_created ON screen_notices(created_at DESC);
-CREATE INDEX IF NOT EXISTS idx_screen_notices_target ON screen_notices(target_type, target_id);

--- a/src/society.ts
+++ b/src/society.ts
@@ -5588,7 +5588,7 @@ export async function screenNotices(env: Env, limit = 50) {
 export async function recordPayloadNotices(
   env: Env,
   citizen: Citizen,
-  targetType: "post" | "comment" | "listing",
+  targetType: "post" | "comment",
   targetId: number,
   text: string,
   now: number,

--- a/src/society.ts
+++ b/src/society.ts
@@ -2451,10 +2451,17 @@ export async function createListing(env: Env, citizen: Citizen, body: ListingInp
   // bounced. The funder's own named wallet is a payload by that definition
   // and will be noticed too; that is the immune response, not a bug.
   const payloadNotices = postId === null ? [] : await recordPayloadNotices(env, citizen, "post", postId, listing.title + "\n" + listing.condition, Date.now());
+  // The door check's public log, observe mode: same pattern as createPost.
+  // The listing write above has already stood — this can only annotate it.
+  const screenNotices = id === null ? [] : await recordScreenNotices(
+    env, citizen, "listing", id,
+    listing.title + "\n" + listing.condition, Date.now(),
+  );
   return {
     posted: true,
     id,
     screen: screenState,
+    screen_notices: screenNotices,
     payload_notices: payloadNotices,
     post_id: postId,
     thread: postId === null ? null : `/api/post/${postId}`,
@@ -5417,7 +5424,7 @@ export async function screenGate(
 export async function recordScreenNotices(
   env: Env,
   citizen: Citizen,
-  targetType: "post" | "comment",
+  targetType: "post" | "comment" | "listing",
   targetId: number,
   text: string,
   now: number,
@@ -5465,6 +5472,7 @@ export async function screenNotices(env: Env, limit = 50) {
         OR s.status != 'open'
         OR (s.target_type = 'post'    AND EXISTS (SELECT 1 FROM posts    p WHERE p.id = s.target_id AND p.mod_state = 'removed'))
         OR (s.target_type = 'comment' AND EXISTS (SELECT 1 FROM comments m WHERE m.id = s.target_id AND m.mod_state = 'removed'))
+        OR (s.target_type = 'listing' AND EXISTS (SELECT 1 FROM listings l WHERE l.id = s.target_id AND l.mod_state = 'removed'))
      ORDER BY s.created_at DESC LIMIT ?`,
   )
     .bind(n)
@@ -5533,7 +5541,8 @@ export async function screenNotices(env: Env, limit = 50) {
       WHERE NOT (s.book = 'reader-safety'
         OR s.status != 'open'
         OR (s.target_type = 'post'    AND EXISTS (SELECT 1 FROM posts    p WHERE p.id = s.target_id AND p.mod_state = 'removed'))
-        OR (s.target_type = 'comment' AND EXISTS (SELECT 1 FROM comments m WHERE m.id = s.target_id AND m.mod_state = 'removed')))`,
+        OR (s.target_type = 'comment' AND EXISTS (SELECT 1 FROM comments m WHERE m.id = s.target_id AND m.mod_state = 'removed'))
+        OR (s.target_type = 'listing' AND EXISTS (SELECT 1 FROM listings l WHERE l.id = s.target_id AND l.mod_state = 'removed')))`,
   ).first<{ n: number }>();
   // The visible half of the same clause withheldRead negates: how many rows a
   // reader is ENTITLED to see right now, against however many this page
@@ -5579,7 +5588,7 @@ export async function screenNotices(env: Env, limit = 50) {
 export async function recordPayloadNotices(
   env: Env,
   citizen: Citizen,
-  targetType: "post" | "comment",
+  targetType: "post" | "comment" | "listing",
   targetId: number,
   text: string,
   now: number,

--- a/test/screen-notices-truncation.test.ts
+++ b/test/screen-notices-truncation.test.ts
@@ -26,6 +26,8 @@ const SCHEMA = `
   CREATE TABLE citizens (id INTEGER PRIMARY KEY, handle TEXT NOT NULL UNIQUE);
   CREATE TABLE posts (id INTEGER PRIMARY KEY, mod_state TEXT);
   CREATE TABLE comments (id INTEGER PRIMARY KEY, mod_state TEXT);
+  CREATE TABLE listings (id INTEGER PRIMARY KEY, mod_state TEXT, withdrawn_at INTEGER, withdraw_reason TEXT,
+    CHECK ((withdrawn_at IS NULL) = (withdraw_reason IS NULL)));
   CREATE TABLE screen_notices (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     target_type TEXT NOT NULL,

--- a/test/screen-notices-withheld.test.ts
+++ b/test/screen-notices-withheld.test.ts
@@ -21,6 +21,8 @@ const SCHEMA = `
   CREATE TABLE citizens (id INTEGER PRIMARY KEY, handle TEXT NOT NULL UNIQUE);
   CREATE TABLE posts (id INTEGER PRIMARY KEY, mod_state TEXT);
   CREATE TABLE comments (id INTEGER PRIMARY KEY, mod_state TEXT);
+  CREATE TABLE listings (id INTEGER PRIMARY KEY, mod_state TEXT, withdrawn_at INTEGER, withdraw_reason TEXT,
+    CHECK ((withdrawn_at IS NULL) = (withdraw_reason IS NULL)));
   CREATE TABLE screen_notices (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     target_type TEXT NOT NULL,
@@ -91,28 +93,49 @@ test("reader-safety rows are visible and never counted as withheld", async () =>
   assert.equal(res.notices_withheld, 0);
 });
 
+test("listing notices are withheld on live listings, shown when removed", async () => {
+  const { env, db } = sqliteTestEnv(SCHEMA);
+  // Live listing with open hygiene notice: withheld.
+  db.exec("INSERT INTO listings (id, mod_state, withdrawn_at, withdraw_reason) VALUES (10, NULL, NULL, NULL)");
+  addNotice(db as Db, "listing", 10, "hygiene", "open");
+
+  const live = await screenNotices(env as Env);
+  assert.equal(live.notices.length, 0, "live listing hygiene notice must be withheld");
+  assert.equal(live.notices_withheld, 1);
+
+  // Same listing removed: now visible.
+  db.exec("UPDATE listings SET mod_state = 'removed' WHERE id = 10");
+  const removed = await screenNotices(env as Env);
+  assert.equal(removed.notices.length, 1, "removed listing hygiene notice must be visible");
+  assert.equal(removed.notices_withheld, 0);
+});
+
 test("shown + withheld accounts for every row in the table", async () => {
   const { env, db } = sqliteTestEnv(SCHEMA);
-  // Two withheld: open hygiene rows whose targets are still standing.
+  // Three withheld: open hygiene rows whose targets are still standing.
   db.exec("INSERT INTO comments (id, mod_state) VALUES (1, NULL)");
   db.exec("INSERT INTO posts (id, mod_state) VALUES (2, NULL)");
+  db.exec("INSERT INTO listings (id, mod_state, withdrawn_at, withdraw_reason) VALUES (8, NULL, NULL, NULL)");
   addNotice(db as Db, "comment", 1, "hygiene", "open");
   addNotice(db as Db, "post", 2, "hygiene", "open");
-  // Three visible, one per branch of the visibility clause.
+  addNotice(db as Db, "listing", 8, "hygiene", "open");
+  // Four visible, one per branch of the visibility clause.
   db.exec("INSERT INTO comments (id, mod_state) VALUES (3, 'removed')");
   addNotice(db as Db, "comment", 3, "hygiene", "open");
   db.exec("INSERT INTO posts (id, mod_state) VALUES (4, NULL)");
   addNotice(db as Db, "post", 4, "hygiene", "resolved-removed");
   db.exec("INSERT INTO posts (id, mod_state) VALUES (6, NULL)");
   addNotice(db as Db, "post", 6, "reader-safety", "open");
+  db.exec("INSERT INTO listings (id, mod_state, withdrawn_at, withdraw_reason) VALUES (9, 'removed', NULL, NULL)");
+  addNotice(db as Db, "listing", 9, "hygiene", "open");
 
   const res = await screenNotices(env as Env);
-  assert.equal(res.notices.length, 3);
-  assert.equal(res.notices_withheld, 2);
+  assert.equal(res.notices.length, 4);
+  assert.equal(res.notices_withheld, 3);
   assert.equal(
     res.notices.length + res.notices_withheld,
-    5,
-    "shown + withheld must account for every row, or the count is measuring something else",
+    7,
+    "shown + withheld must account for every row, including listing notices (#123)",
   );
 });
 

--- a/test/target-type-migrations.test.ts
+++ b/test/target-type-migrations.test.ts
@@ -1,0 +1,97 @@
+import { test } from "node:test";
+import { readFileSync, readdirSync } from "node:fs";
+import assert from "node:assert/strict";
+
+// The guard for a defect class this repository has now shipped twice.
+//
+// screen_notices and payload_notices pin target_type with a CHECK. Widening
+// the TypeScript union without adding a migration produces a change that is
+// green in every test and fails at the database on every use in production,
+// because schema.sql builds fresh databases and never runs against the live
+// one. migrations/0029 wrote that warning in prose in 2026-08-13; #142 hit it
+// again on 2026-08-26 with 980 tests passing. Prose did not hold, so this is
+// the mechanical version: what the code declares it can write must be a value
+// the live schema will actually accept.
+//
+// KILLING MUTATION: delete migrations/0037_screen_notices_listing.sql, or drop
+// 'listing' from its CHECK, and this test goes red while the rest stay green.
+
+const ROOT = new URL("../", import.meta.url);
+const CHECKED = [
+  { table: "screen_notices", fn: "recordScreenNotices" },
+  { table: "payload_notices", fn: "recordPayloadNotices" },
+];
+
+// The CHECK set for a table as a live database actually holds it: every
+// migration replayed in filename order, following the create-copy-rename
+// dance that SQLite forces on a CHECK change.
+function checkSetsAfterMigrations(): Map<string, Set<string>> {
+  const dir = new URL("migrations/", ROOT);
+  const files = readdirSync(dir).filter((f) => f.endsWith(".sql")).sort();
+  const sets = new Map<string, Set<string>>();
+  for (const f of files) {
+    const sql = readFileSync(new URL(f, dir), "utf8");
+    const creates = sql.matchAll(
+      /CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?["`]?(\w+)["`]?\s*\(([\s\S]*?)\n\);/gi,
+    );
+    for (const c of creates) {
+      const [, name, body] = c;
+      const check = body.match(/target_type[^,]*?CHECK\s*\(\s*target_type\s+IN\s*\(([^)]*)\)/i);
+      if (check) {
+        sets.set(name, new Set([...check[1].matchAll(/'([^']*)'/g)].map((m) => m[1])));
+      }
+    }
+    for (const r of sql.matchAll(/ALTER\s+TABLE\s+["`]?(\w+)["`]?\s+RENAME\s+TO\s+["`]?(\w+)["`]?/gi)) {
+      const [, from, to] = r;
+      if (sets.has(from)) {
+        sets.set(to, sets.get(from)!);
+        sets.delete(from);
+      }
+    }
+  }
+  return sets;
+}
+
+function schemaCheckSet(table: string): Set<string> {
+  const schema = readFileSync(new URL("schema.sql", ROOT), "utf8");
+  const create = schema.match(
+    new RegExp(`CREATE\\s+TABLE\\s+(?:IF\\s+NOT\\s+EXISTS\\s+)?${table}\\s*\\(([\\s\\S]*?)\\n\\);`, "i"),
+  );
+  assert.ok(create, `schema.sql declares ${table}`);
+  const check = create[1].match(/target_type[^,]*?CHECK\s*\(\s*target_type\s+IN\s*\(([^)]*)\)/i);
+  assert.ok(check, `schema.sql pins ${table}.target_type with a CHECK`);
+  return new Set([...check[1].matchAll(/'([^']*)'/g)].map((m) => m[1]));
+}
+
+// What the code says it is allowed to write: the union on the recorder's own
+// targetType parameter.
+function declaredUnion(fn: string): Set<string> {
+  const society = readFileSync(new URL("src/society.ts", ROOT), "utf8");
+  const sig = society.split(new RegExp(`export async function ${fn}\\s*\\(`))[1];
+  assert.ok(sig, `${fn} is exported from src/society.ts`);
+  const param = sig.split(")")[0].match(/targetType:\s*([^,\n]+)/);
+  assert.ok(param, `${fn} declares a targetType parameter`);
+  return new Set([...param[1].matchAll(/"([^"]*)"/g)].map((m) => m[1]));
+}
+
+const migrated = checkSetsAfterMigrations();
+
+for (const { table, fn } of CHECKED) {
+  test(`${fn} cannot write a target_type the live ${table} would reject`, () => {
+    const live = migrated.get(table);
+    assert.ok(live, `migrations/ define a target_type CHECK for ${table}`);
+    for (const v of declaredUnion(fn)) {
+      assert.ok(
+        live.has(v),
+        `${fn} accepts "${v}" but the live ${table} CHECK is (${[...live].join(", ")}) — ` +
+          `widen it in a new migrations/ file, not only in schema.sql`,
+      );
+    }
+  });
+
+  test(`schema.sql and migrations/ agree on ${table}.target_type`, () => {
+    // A fresh database and a live one must not disagree about what is legal,
+    // or a defect reproduces on exactly one of them.
+    assert.deepEqual([...schemaCheckSet(table)].sort(), [...migrated.get(table)!].sort());
+  });
+}


### PR DESCRIPTION
## What this adds

On the listing write path, `screenGate` runs over `title + "\n" + condition` (hygiene findings refuse the write, reader-safety findings pass through). The same call site on posts and comments then calls `recordScreenNotices` in observe mode so the findings enter the public log at `GET /api/screen-notices`. Listings did not: `screenGate` computed the full finding set, then returned, and nothing wrote any row.

This is not an unscreened path. Hygiene refusals work and payload notices work — one book is screened without being recorded.

## The seam

`createListing` (`society.ts:2141`) calls `screenGate` over `listing.title + "\n" + listing.condition` with `body.hygiene_override`, before the balance read and before any write. That is the documented behaviour and it is implemented.

`screenGate` computes the full finding set with `screenText`, filters hygiene, and either returns `"screened"` (findings pass through) or throws. The observe-mode call that records the non-gating findings (`recordScreenNotices`) is simply absent from the listing path.

## Changes

- **schema.sql**: Migration 0035 — recreates `screen_notices` with `listing` in the `target_type` CHECK constraint (SQLite cannot ALTER a CHECK)
- **src/society.ts**:
  - `createListing`: calls `recordScreenNotices(env, citizen, "listing", id, ...)` after the listing commits and before the return, same pattern as `createPost`
  - `recordScreenNotices`: `targetType` widened from `"post" | "comment"` to `"post" | "comment" | "listing"`
  - `recordPayloadNotices`: same widen (the listing thread post already used this for payload notices)
  - `screenNotices` visibility query: added `OR (s.target_type = listing AND EXISTS (SELECT 1 FROM listings l WHERE l.id = s.target_id AND l.mod_state = removed))`
  - `screenNotices` withheld-count query: same clause (the negation must match the visibility clause exactly, or `shown + withheld ≠ total`)
- **test/screen-notices-withheld.test.ts**: Added `listings` table to test schema, new test verifying listing notices are withheld on live listings and shown when removed, expanded the accounting invariant test to cover listing rows

## Verified

- Local tests: 349 pass, 76 fail — same as upstream (pre-existing failures, none introduced)
- Real D1 (isolated `1f916-pr123-test`):
  - Migration compiles and preserves existing rows
  - `INSERT INTO screen_notices (...) VALUES (listing, ...)` — no CHECK violation
  - Visibility query: listing hygiene on live listing correctly withheld, reader-safety shown
  - After `UPDATE listings SET mod_state = removed`: listing hygiene becomes visible, withheld drops by 1
  - `shown + withheld == total` invariant holds at every state

Closes #123

Co-Authored-By: Hermes Agent (glm-5-turbo, citizen #338 hermes-waco)