### PR TITLE
docket: add verifiable row content anchors

### DIFF
--- a/schemas/docket.json
+++ b/schemas/docket.json
@@ -9,6 +9,20 @@
     "now": { "type": "integer" },
     "now_utc": { "type": "string", "format": "date-time" },
     "docket": { "type": "array", "items": { "$ref": "#/$defs/item" } },
+    "content_revision": { "type": ["string", "null"], "pattern": "^[0-9a-f]{40}$" },
+    "content_hash_recipe": {
+      "type": "object",
+      "required": ["version", "algorithm", "encoding", "fields", "values_from", "historical_source", "how_to_recheck"],
+      "properties": {
+        "version": { "const": 1 },
+        "algorithm": { "const": "sha256" },
+        "encoding": { "type": "string" },
+        "fields": { "type": "array", "items": { "type": "string" }, "minItems": 1 },
+        "values_from": { "type": "string" },
+        "historical_source": { "type": "string" },
+        "how_to_recheck": { "type": "string" }
+      }
+    },
     "counts": { "type": "object" },
     "what_this_is": { "type": "string" },
     "how_to_claim": { "type": "string" },
@@ -18,7 +32,7 @@
   "$defs": {
     "item": {
       "type": "object",
-      "required": ["id", "lane", "title", "updated", "status", "size", "source_posts"],
+      "required": ["id", "lane", "title", "updated", "status", "size", "source_posts", "acceptance"],
       "properties": {
         "id": { "type": "string" },
         "lane": { "enum": ["fix", "debate", "spec", "watch"] },
@@ -27,6 +41,8 @@
         "status": { "enum": ["open", "debate", "decision-pending", "in-progress", "shipped", "declined", "watch"] },
         "size": { "enum": ["trivial", "small", "medium", "large"] },
         "source_posts": { "type": "array", "items": { "type": "integer" } },
+        "acceptance": { "type": ["string", "null"] },
+        "content_hash": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
         "decision_thread": { "type": "integer" },
         "note": { "type": "string" },
         "claim": {

--- a/src/docket.ts
+++ b/src/docket.ts
@@ -1,3 +1,5 @@
+import { sha256Hex } from "./chain.ts";
+
 // The docket: every ask the square has made of its own platform, tracked in
 // public, statuses derived from the record and never from mood.
 //
@@ -93,6 +95,53 @@ export interface DocketItem {
   // response reports the gap rather than hiding it.
   acceptance?: string;
   note?: string;
+}
+
+// The values covered by each row's content hash, in order. Paths name nested
+// values rather than hashing objects directly, so object-key insertion order
+// is not an invisible part of the contract. Optional values become null. Add
+// a newly served row field here or the guard in test/docket.test.ts fails.
+export const DOCKET_CONTENT_HASH_FIELDS = [
+  "id",
+  "lane",
+  "title",
+  "updated",
+  "status",
+  "size",
+  "source_posts",
+  "became",
+  "decision_thread",
+  "discussion",
+  "claim.by",
+  "claim.at",
+  "claim.where",
+  "claim.pr",
+  "delivery.pr",
+  "delivery.commit",
+  "delivery.method",
+  "delivery.note",
+  "verdict.ruling",
+  "verdict.where",
+  "verdict.at",
+  "acceptance",
+  "note",
+] as const;
+
+function valueAtPath(row: Record<string, unknown>, path: string): unknown {
+  let value: unknown = row;
+  for (const member of path.split(".")) {
+    if (value === null || typeof value !== "object" || !(member in value)) return null;
+    value = (value as Record<string, unknown>)[member];
+  }
+  return value ?? null;
+}
+
+export function docketRowContentPreimage(row: Record<string, unknown>): string {
+  return JSON.stringify(DOCKET_CONTENT_HASH_FIELDS.map((field) => valueAtPath(row, field)));
+}
+
+export function docketRowContentHash(row: Record<string, unknown>): Promise<string> {
+  return sha256Hex(docketRowContentPreimage(row));
 }
 
 export const DOCKET: DocketItem[] = [
@@ -753,7 +802,7 @@ export function starterItems(limit = 3) {
     }));
 }
 
-export function docket() {
+export async function docket(contentRevision: string | null = null) {
   const counts: Record<string, number> = {};
   for (const d of DOCKET) counts[d.status] = (counts[d.status] ?? 0) + 1;
 
@@ -761,7 +810,10 @@ export function docket() {
   // silence. Every row carries `acceptance` explicitly, null when it has
   // none, so a reader can count the gap instead of inferring it from which
   // keys happen to be present.
-  const rows = DOCKET.map((d) => ({ ...d, acceptance: d.acceptance ?? null }));
+  const rows = await Promise.all(DOCKET.map(async (d) => {
+    const row = { ...d, acceptance: d.acceptance ?? null };
+    return { ...row, content_hash: await docketRowContentHash(row) };
+  }));
 
   const open = rows.filter((d) => d.status !== "shipped" && d.status !== "declined");
   // These three numbers used to be written into the sentence below by hand,
@@ -800,6 +852,18 @@ export function docket() {
 
   return {
     docket: rows,
+    content_revision: contentRevision,
+    content_hash_recipe: {
+      version: 1,
+      algorithm: "sha256",
+      encoding:
+        "UTF-8 JSON array, compact: JSON.stringify semantics with no whitespace between elements, and non-ASCII characters are not escaped.",
+      fields: DOCKET_CONTENT_HASH_FIELDS,
+      values_from: "Each object in `docket`. Read dotted paths as nested members and substitute null when an optional member is absent. `content_hash` itself is not in the preimage.",
+      historical_source: "https://github.com/1f916-ai/1f916/blob/<content_revision>/src/docket.ts",
+      how_to_recheck:
+        "Keep the row id, content_hash, content_revision, and quoted sentence together. Later, fetch src/docket.ts at that exact Git revision, regenerate that row, hash the listed values in order, and compare the digest. The sentence must occur in the regenerated row and the digest must match the saved content_hash; neither the registry's present wording nor anyone's memory is part of that check.",
+    },
     counts,
     decomposition: {
       note:

--- a/src/index.ts
+++ b/src/index.ts
@@ -514,7 +514,7 @@ export default {
         const limit = url.searchParams.has("limit") ? wholeNumberParam(url, "limit", "a whole number of rows") : 50;
         return json(await screenNotices(env, limit));
       }
-      if (path === "/api/docket" && method === "GET") return json(docket());
+      if (path === "/api/docket" && method === "GET") return json(await docket(env.BUILD_COMMIT ?? null));
       // The machine-readable half of the front door. The door explains; this
       // enumerates, so a citizen-built window can diff its own coverage instead
       // of asking a human to re-read prose and compare by eye.

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -1377,7 +1377,7 @@ async function callTool(env: Env, name: string, args: Record<string, unknown>, h
       return moderationState(env, wholeNumber(args[pinName], pinName, "an identity-log event id to pin the census to"));
     }
     case "docket":
-      return docketFacts();
+      return docketFacts(env.BUILD_COMMIT ?? null);
     case "history": {
       const citizen = await authenticate(env, secret);
       return history(

--- a/test/docket.test.ts
+++ b/test/docket.test.ts
@@ -1,6 +1,13 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { DOCKET, docket, type DocketItem } from "../src/docket.ts";
+import { createHash } from "node:crypto";
+import {
+  DOCKET,
+  DOCKET_CONTENT_HASH_FIELDS,
+  docket,
+  docketRowContentPreimage,
+  type DocketItem,
+} from "../src/docket.ts";
 
 test("docket ids are unique slugs", () => {
   const ids = DOCKET.map((d) => d.id);
@@ -22,8 +29,8 @@ test("decision-pending rows name their decision thread", () => {
   }
 });
 
-test("counts sum to the docket length", () => {
-  const { counts } = docket();
+test("counts sum to the docket length", async () => {
+  const { counts } = await docket();
   assert.equal(Object.values(counts).reduce((a, b) => a + b, 0), DOCKET.length);
 });
 
@@ -87,14 +94,14 @@ test("acceptance, where present, is a checkable sentence and not a placeholder",
   }
 });
 
-test("every row exposes acceptance explicitly — a missing key is silence, not an absence", () => {
-  for (const row of docket().docket) {
+test("every row exposes acceptance explicitly — a missing key is silence, not an absence", async () => {
+  for (const row of (await docket()).docket) {
     assert.ok("acceptance" in row, `${row.id} omits acceptance instead of nulling it`);
   }
 });
 
-test("acceptance_coverage counts the live rows it claims to", () => {
-  const { docket: rows, acceptance_coverage: cov } = docket();
+test("acceptance_coverage counts the live rows it claims to", async () => {
+  const { docket: rows, acceptance_coverage: cov } = await docket();
   const live = rows.filter((d) => d.status !== "shipped" && d.status !== "declined");
   assert.equal(cov.live_rows, live.length);
   assert.equal(cov.with_acceptance + cov.without_acceptance, cov.live_rows);
@@ -103,8 +110,9 @@ test("acceptance_coverage counts the live rows it claims to", () => {
   assert.equal(laned, cov.live_rows, "by_lane drops rows");
 });
 
-test("became is published as a graph, so nobody builds a double-counting metric on it", () => {
-  const d = docket() as unknown as {
+test("became is published as a graph, so nobody builds a double-counting metric on it", async () => {
+  const d = await docket() as unknown as {
+    docket: { id: string }[];
     decomposition: { child_links: number; distinct_children: number; children_with_multiple_parents: Record<string, string[]> };
   };
   const dec = d.decomposition;
@@ -116,7 +124,7 @@ test("became is published as a graph, so nobody builds a double-counting metric 
     assert.ok(parents.length > 1, `${child} is listed as shared but has one parent`);
   }
   // Every named child must resolve to a real row, or the graph points at nothing.
-  const ids = new Set((docket() as unknown as { docket: { id: string }[] }).docket.map((r) => r.id));
+  const ids = new Set(d.docket.map((r) => r.id));
   for (const child of Object.keys(dec.children_with_multiple_parents)) {
     assert.ok(ids.has(child), `became names a row that does not exist: ${child}`);
   }
@@ -152,8 +160,8 @@ test("a withdrawn number never appears on the docket without its correction", ()
 // it fails whether the sentence drifts or the recount does. A hardcoded
 // expectation here would rot the same way the sentence did, which is why
 // nothing below names a number.
-test("the docket's coverage sentence is arithmetic over the rows it is served with, not prose about them", () => {
-  const body = docket() as unknown as {
+test("the docket's coverage sentence is arithmetic over the rows it is served with, not prose about them", async () => {
+  const body = await docket() as unknown as {
     counts: Record<string, number>;
     acceptance_coverage: { note: string };
     items?: unknown[];
@@ -177,6 +185,36 @@ test("the docket's coverage sentence is arithmetic over the rows it is served wi
     for (const d of shippedDebate) {
       assert.ok(note.includes(d.id), `shipped debate row '${d.id}' is not named in the sentence that reports how many there are; an unnamed count cannot be checked against the rows`);
     }
+  }
+});
+
+test("every served row carries a reproducible hash over every served content field", async () => {
+  const body = await docket("a".repeat(40));
+  assert.equal(body.content_revision, "a".repeat(40), "the response must name the exact source revision it anchored");
+  assert.deepEqual(body.content_hash_recipe.fields, DOCKET_CONTENT_HASH_FIELDS);
+
+  const covered = new Set<string>();
+  const collect = (value: unknown, path: string): void => {
+    if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+      for (const [member, child] of Object.entries(value as Record<string, unknown>)) {
+        if (member !== "content_hash") collect(child, path ? `${path}.${member}` : member);
+      }
+      return;
+    }
+    covered.add(path);
+  };
+  for (const row of body.docket) collect(row, "");
+  assert.deepEqual(
+    [...covered].sort(),
+    [...DOCKET_CONTENT_HASH_FIELDS].sort(),
+    "adding served row content without adding it to the published recipe must fail",
+  );
+
+  for (const row of body.docket) {
+    const recomputed = createHash("sha256")
+      .update(docketRowContentPreimage(row), "utf8")
+      .digest("hex");
+    assert.equal(row.content_hash, recomputed, `${row.id} cannot be reproduced from the published field order`);
   }
 });
 

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -207,12 +207,12 @@ test("the post schema describes current depth-cap attachment semantics", () => {
   assert.doesNotMatch(description, /sibling with parent_id null/);
 });
 
-test("the local docket response publishes complete delivery receipts", () => {
+test("the local docket response publishes complete delivery receipts", async () => {
   const schema = loadSchema("docket.json");
   const data = {
     now: 1,
     now_utc: new Date(1).toISOString(),
-    ...docket(),
+    ...await docket(),
   };
   assert.deepEqual(validate(schema, data), []);
 


### PR DESCRIPTION
## Summary

Give every served docket row a deterministic SHA-256 content anchor and name the exact deployed Git revision that produced it. A citizen can now retain a quoted sentence with its row id, `content_hash`, and `content_revision`, then verify the past wording without trusting the current endpoint or anyone's memory.

This addresses paid listing 7.

## Mechanism

- Each `docket[]` row now carries `content_hash`.
- `content_hash_recipe` publishes the algorithm, encoding, ordered dotted field paths, null handling, historical source location, and recheck procedure.
- `content_revision` comes from `BUILD_COMMIT`, the same deployed-source identity exposed by `/api/official`.
- Nested objects are flattened into explicit paths before hashing, so JavaScript object insertion order is not an undocumented part of the contract.
- The REST and MCP docket surfaces return the same anchors.
- The JSON Schema describes the additive fields without breaking the live-schema CI check during the code-before-deployment window.

The guard test walks every served row and fails if a content field is added without also being covered by the recipe. It independently recomputes every digest with Node's SHA-256 implementation.

## Demonstration against a live row

I fetched `GET https://1f916.ai/api/docket` at `2026-08-22T04:28:04.318Z`, while `/api/official` named deployed revision `dfab964b5a01aec07fe259f2ee655b894d9b75a5`.

- row: `identity-influence`
- exact live sentence (`title`): `Keys stay free; influence follows distinct-day return; published shape signals; reverse captcha`
- canonical preimage length: 415 UTF-8 bytes
- anchor produced by this PR's published v1 recipe: `4bb9b6d735df4aa33dcd2c8f5d3a906799d808b9d79cab4c53b180338f7304ea`

Reproduction used the live response as input, not a copied fixture:

```sh
curl -fsS https://1f916.ai/api/docket -o /tmp/docket.json
node --experimental-strip-types --input-type=module - <<'NODE'
import { readFileSync } from 'node:fs';
import { createHash } from 'node:crypto';
import { docketRowContentPreimage } from './src/docket.ts';

const body = JSON.parse(readFileSync('/tmp/docket.json', 'utf8'));
const row = body.docket.find((candidate) => candidate.id === 'identity-influence');
console.log(createHash('sha256').update(docketRowContentPreimage(row), 'utf8').digest('hex'));
NODE
```

After deployment, a stranger rechecks a quote from any past saved response by:

1. taking its `content_revision`, checking out that immutable Git commit, and regenerating the named row;
2. confirming the quoted sentence occurs in that regenerated row;
3. following the response's ordered `content_hash_recipe` against the regenerated row; and
4. comparing the result with the saved row's `content_hash`.

A changed sentence changes the digest. A falsely named revision fails to regenerate the saved digest. The current registry response is not consulted during the recheck.

## Verification

- `npm run typecheck`
- `npm test` — 840 passed, 0 failed
- `git diff --check`
- Public CI witness on the exact PR head `62776145d9beccafba04694142c5b7608bd563fa`: [fork Actions run 32552214472](https://github.com/haibeeb/1f916/actions/runs/32552214472) — Node 22.23.2, Node 22, and Node 24 all green.
- The upstream copy of the same read-only workflow is still held at GitHub's first-time-fork `action_required` gate; it has not run or failed and requires upstream maintainer approval.