### PR TITLE
treasury: an empty read is unknown, not a complete book worth zero

### DIFF
--- a/src/assets.ts
+++ b/src/assets.ts
@@ -231,8 +231,35 @@ export interface AssetSummary {
 // balanceOf. A treasury that under-reports without saying so is precisely the
 // failure this file was written to correct, and it would be absurd to
 // reintroduce it here.
-export function summarizeAssets(holdings: Holding[]): AssetSummary {
-  const complete = holdings.every((h) => h.value_cents !== null);
+export function summarizeAssets(holdings: Holding[], errors: string[] = []): AssetSummary {
+  // An empty holdings array means two different things and this function used
+  // to be unable to tell them apart, because it only ever received the array.
+  //
+  //   "the society holds nothing"     -> genuinely complete, genuinely zero
+  //   "this read reached nothing"     -> unknown, and NOT zero
+  //
+  // Array.prototype.every returns TRUE for an empty array, so both collapsed
+  // into the first. Every sum below is sum([]) === 0, so GET /treasury served
+  // `complete: true, total_cents: 0`, every tier zero, `holdings: []` — a
+  // confident, fully-formed claim that the society owns nothing, with the error
+  // sitting in a field beside it that the completeness flag contradicted.
+  //
+  // That path is live, not theoretical: readTreasuryAssetsCached returns exactly
+  // `holdings: []` plus one error string when the asset composite exceeds its
+  // refresh budget and no earlier snapshot exists. Observed on the wire
+  // 2026-08-22T15:0xZ — consecutive unauthenticated reads returned
+  // total_cents 2317119 and then total_cents 0 with an empty holdings array,
+  // seconds apart. Demummon reported the zeroed shape on 2026-08-20 (#1263) and
+  // it was read as ordinary cache lag at the time.
+  //
+  // The errors the read already collected are what separate the two cases, so
+  // they are passed in rather than inferred. A caller that omits them keeps the
+  // old meaning, which is the honest default for a hand-built summary: an empty
+  // book that nobody failed to read IS complete and IS zero.
+  //
+  // The rule is already written twelve lines below, about chains: "zero is a
+  // claim and absence is not." This makes it true of the whole book.
+  const complete = errors.length === 0 && holdings.every((h) => h.value_cents !== null);
   const sum = (rows: Holding[]) => rows.reduce((n, h) => n + (h.value_cents ?? 0), 0);
   return {
     // One true total: every asset the society holds or can claim, at one

--- a/src/society.ts
+++ b/src/society.ts
@@ -7186,7 +7186,7 @@ export async function treasury(env: Env) {
   const onchainAgeMs = onchainCheckedAt === null ? null : Math.max(0, Date.now() - onchainCheckedAt);
   const assetRead = assetSnapshot.value;
   const assets = {
-    ...summarizeAssets(assetRead.holdings),
+    ...summarizeAssets(assetRead.holdings, assetRead.errors),
     // Three served sentences — assets.ts, doc.ts and assets_note below — tell a
     // reader to look here for whether the claim has been drawn on. Until this
     // line they pointed at a field that was computed, used internally by

--- a/test/empty-holdings-not-complete.test.ts
+++ b/test/empty-holdings-not-complete.test.ts
@@ -1,0 +1,115 @@
+// An empty holdings array meant two different things and summarizeAssets could
+// not tell them apart, because it only ever received the array:
+//
+//   "the society holds nothing"   -> genuinely complete, genuinely zero
+//   "this read reached nothing"   -> unknown, and NOT zero
+//
+// `Array.prototype.every` returns true for an empty array, so both collapsed
+// into the first. Every sum is sum([]) === 0, so GET /treasury served
+// `complete: true, total_cents: 0`, every tier zero, `holdings: []` — a
+// confident, fully-formed claim that the society owns nothing, with the error
+// sitting in a field beside it that the completeness flag contradicted.
+//
+// Reachable in production, not theoretical. readTreasuryAssetsCached returns
+// exactly `holdings: []` plus one error string when the asset composite exceeds
+// its refresh budget and no earlier snapshot exists. Observed live on the wire
+// 2026-08-22T15:0xZ: consecutive unauthenticated GET /treasury reads returned
+// total_cents 2317119 and then total_cents 0 with holdings [], seconds apart.
+// Demummon reported the zeroed shape on 2026-08-20 in #1263 and it was read as
+// ordinary cache lag at the time, which is why these name the mechanism.
+//
+// The fix passes the errors the read already collected rather than inferring
+// them, so the pre-existing contract is preserved exactly: an empty book that
+// nobody failed to read is still complete and still zero.
+//
+// The rule was already written in src/assets.ts, about chains: "zero is a claim
+// and absence is not." These assert it for the book as a whole.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { summarizeAssets, TIERS, type Holding } from "../src/assets.ts";
+
+function holding(over: Partial<Holding> = {}): Holding {
+  return {
+    asset: "USDC",
+    address: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+    chain: "base",
+    tier: 1,
+    tier_label: TIERS[1].label,
+    location: "wallet",
+    quantity: "1",
+    decimals: 6,
+    price_usd: 1,
+    price_source: "face value",
+    value_cents: 100,
+    notional: false,
+    verify: "eth_call balanceOf",
+    ...over,
+  } as Holding;
+}
+
+test("a FAILED read that produced no holdings is NOT a complete book", () => {
+  const s = summarizeAssets([], ["asset read exceeded 2500ms and no earlier snapshot exists"]);
+  assert.equal(s.complete, false, "every() is vacuously true on []; completeness must not be");
+  assert.equal(s.total_cents, null, "an unreachable book is unknown, never zero");
+  assert.equal(s.conservative_total_cents, null);
+  assert.equal(s.by_location.wallet_cents, null);
+  assert.equal(s.by_location.claimable_cents, null);
+  for (const tier of s.by_tier) {
+    assert.equal(tier.cents, null, `tier ${tier.tier} must be unknown, not zero`);
+  }
+});
+
+test("the zeroed shape that was served is now unreachable", () => {
+  // The exact response body observed on the wire: complete true, total zero,
+  // every tier zero, holdings empty. If any future refactor can produce that
+  // combination again, this fails.
+  const s = summarizeAssets([], ["asset read exceeded 2500ms and no earlier snapshot exists"]);
+  const servedAsComplete = s.complete === true && s.total_cents === 0;
+  assert.equal(servedAsComplete, false, "complete:true with total_cents:0 from an empty read is the defect");
+});
+
+test("an empty book nobody failed to read is still complete and zero", () => {
+  // The existing contract, preserved deliberately: summarizeAssets([]) with no
+  // errors keeps its old meaning. The defect was never that [] is zero — it was
+  // that [] plus a failed read was ALSO zero.
+  const s = summarizeAssets([]);
+  assert.equal(s.complete, true);
+  assert.equal(s.total_cents, 0);
+  assert.deepEqual(s.by_tier.map((t) => t.cents), [0, 0, 0]);
+});
+
+test("a genuine zero balance is still reportable, and is different from an unreachable one", () => {
+  // The fix must not make a real zero unrepresentable. A wallet that truly holds
+  // nothing has a holding row whose value_cents is 0 — present at zero, which is
+  // a claim the read actually supports.
+  const s = summarizeAssets([holding({ quantity: "0", value_cents: 0 })]);
+  assert.equal(s.complete, true, "one row that was read successfully is a complete book");
+  assert.equal(s.total_cents, 0, "and it may legitimately total zero");
+  assert.equal(s.by_tier.find((t) => t.tier === 1)?.cents, 0);
+});
+
+test("one unpriced holding still makes the book incomplete", () => {
+  // The original guard, unchanged: a row the read could not price poisons the
+  // total rather than being summed as zero.
+  const s = summarizeAssets([holding(), holding({ asset: "WETH", tier: 2, value_cents: null })]);
+  assert.equal(s.complete, false);
+  assert.equal(s.total_cents, null);
+});
+
+test("completeness and the totals never disagree", () => {
+  // The invariant a consumer actually relies on: if complete is false every
+  // aggregate is null, and if it is true none of them are. A window that trusts
+  // `complete` and renders the totals cannot then be handed a zero.
+  const cases: Array<[Holding[], string[]]> = [
+    [[], []], [[], ["read failed"]], [[holding()], []],
+    [[holding(), holding({ value_cents: null })], []], [[holding({ value_cents: 0 })], []],
+    [[holding()], ["a partial failure still poisons the book"]],
+  ];
+  for (const [rows, errs] of cases) {
+    const s = summarizeAssets(rows, errs);
+    const aggregates = [s.total_cents, s.conservative_total_cents, s.by_location.wallet_cents, s.by_location.claimable_cents, ...s.by_tier.map((t) => t.cents)];
+    if (s.complete) assert.ok(aggregates.every((v) => v !== null), "complete book must price every aggregate");
+    else assert.ok(aggregates.every((v) => v === null), "incomplete book must price none of them");
+  }
+});


### PR DESCRIPTION
`GET /treasury` intermittently serves a confident claim that the society owns nothing.

```
complete:      true
total_cents:   0
by_tier:       [0, 0, 0]
holdings:      []
```

…while the wallet holds ~$22k and the error explaining the failure sits in a field beside it that `complete` contradicts.

### The mechanism

`Array.prototype.every` returns **true** for an empty array, and that was the completeness test:

```js
const complete = holdings.every((h) => h.value_cents !== null);
```

So an empty holdings array became a complete book, and every `sum([])` is `0`. The array means two different things and the function could not tell them apart, because the array is all it received:

| | |
|---|---|
| "the society holds nothing" | genuinely complete, genuinely zero |
| "this read reached nothing" | unknown, and **not** zero |

### Reachable, not theoretical

`readTreasuryAssetsCached` returns exactly `holdings: []` plus one error string when the asset composite exceeds its refresh budget and no earlier snapshot exists.

Observed on the wire, unauthenticated, **2026-08-22T15:0xZ** — consecutive reads seconds apart:

```
1  complete=true   total_cents=2317119   holdings=6
5  complete=true   total_cents=0         holdings=0     <-- this
6  complete=false  total_cents=null      holdings=6     <-- honest degradation
```

Poll 6 is the endpoint behaving correctly: five RPC reads failed, `complete: false`, values `null`. Poll 5 is the defect. It is currently rendering as **$0** in at least one citizen-built window, and @Demummon reported the zeroed shape on 2026-08-20 in #1263 — it was read as ordinary cache lag at the time, including by me.

### The fix passes the errors the read already collected

`summarizeAssets(holdings, errors = [])`, and completeness requires an error-free read.

**This preserves the existing contract exactly.** `test/assets.test.ts` → *"no holdings is complete and zero, not incomplete"* passes **unchanged**, because an empty book that nobody *failed* to read is still complete and still zero. The defect was never that `[]` is zero — it was that `[]` **plus a failed read** was also zero. That distinction is why this is a two-argument change rather than a flipped assertion.

It also strictly tightens the partial case: a read returning priced holdings *and* errors is now incomplete, where before the errors were invisible to the summary.

### The rule was already written, twelve lines below the bug

```
// Derived from the holdings actually present, never from the CHAINS table:
// a chain this read could not reach must be absent here rather than
// present at zero, because zero is a claim and absence is not.
```

That is exactly right and it was true of chains but not of the book.

### Tests

Six new, in `test/empty-holdings-not-complete.test.ts`, including the invariant a consumer actually relies on: **if `complete` is false every aggregate is null, and if it is true none of them are** — so a window that trusts the flag and renders the totals can never be handed a zero.

**Verified load-bearing:** reverting the guard turns two of them red.

| | tests | pass | fail |
|---|---|---|---|
| this head | **845** | **845** | **0** |

`tsc` clean.
