### PR TITLE
Accept ui_locales OAuth parameter

### DIFF
--- a/src/connect.ts
+++ b/src/connect.ts
@@ -95,7 +95,7 @@ ${writes.join("\n")}
 // summary. The router's checkQueryParams allowlists are the enforcement;
 // test/connect.test.ts asserts this table matches them, so it cannot drift.
 export const QUERY_PARAMS: Readonly<Record<string, readonly string[]>> = {
-  "/oauth/authorize": ["response_type", "client_id", "redirect_uri", "state", "code_challenge", "code_challenge_method", "scope", "resource", "prompt", "nonce", "login_hint", "access_type", "audience"],
+  "/oauth/authorize": ["response_type", "client_id", "redirect_uri", "state", "code_challenge", "code_challenge_method", "scope", "resource", "prompt", "nonce", "login_hint", "access_type", "audience", "ui_locales"],
   "/treasury": [],
   "/api/attest": ["from", "identity_from", "identity_expect", "ledger_from", "ledger_expect"],
   "/api/search": ["q", "limit"],

--- a/src/index.ts
+++ b/src/index.ts
@@ -386,7 +386,7 @@ export default {
         // The OAuth 2.1 / OIDC request vocabulary hosts are known to send. An
         // unknown key is refused like everywhere else; a host sending one will
         // see the name in the 400 rather than a page that ignored it.
-        checkQueryParams(url, "/oauth/authorize", ["response_type", "client_id", "redirect_uri", "state", "code_challenge", "code_challenge_method", "scope", "resource", "prompt", "nonce", "login_hint", "access_type", "audience"]);
+        checkQueryParams(url, "/oauth/authorize", ["response_type", "client_id", "redirect_uri", "state", "code_challenge", "code_challenge_method", "scope", "resource", "prompt", "nonce", "login_hint", "access_type", "audience", "ui_locales"]);
         const p = await authorizeParams(env, url.searchParams);
         return authorizeHtml(authorizePage(url.origin, p, null));
       }

--- a/test/connect.test.ts
+++ b/test/connect.test.ts
@@ -202,6 +202,23 @@ test("OAuth can register a new citizen for the assistant, and a wrong secret sta
   assert.equal((await exchange(env, { grant_type: "authorization_code", code: clientId, client_id: clientId, code_verifier: verifier })).status, 400);
 });
 
+test("authorize accepts ChatGPT's ui_locales hint", async () => {
+  const env = await makeEnv();
+  const redirect = "https://chatgpt.com/connector_platform_oauth_redirect";
+  const clientId = await registerClient(env, redirect);
+  const { challenge } = await pkce();
+  const q = new URLSearchParams({
+    response_type: "code",
+    client_id: clientId,
+    redirect_uri: redirect,
+    code_challenge: challenge,
+    code_challenge_method: "S256",
+    ui_locales: "zh-CN en",
+  });
+  const page = await worker.fetch(req(`/oauth/authorize?${q}`), env);
+  assert.equal(page.status, 200);
+});
+
 test("authorize refuses an unregistered redirect_uri without redirecting, and codes expire", async () => {
   const env = await makeEnv();
   const clientId = await registerClient(env, "https://host.example/cb");


### PR DESCRIPTION
Summary

ChatGPT includes the optional ui_locales parameter when starting the OAuth authorization flow. The current strict allowlist rejects that request before displaying the authorization page.

This PR:

* accepts ui_locales on GET /oauth/authorize
* keeps QUERY_PARAMS and the router allowlist synchronized
* adds a regression test for a ChatGPT-style authorization request

ui_locales is only a UI-language hint, so its value does not need to be consumed by the authorization logic.