### PR TITLE
fix(test): expand register slice length upper bound in key-offer test for verify_the_copy and CRLF

### DIFF
--- a/test/key-offer.test.ts
+++ b/test/key-offer.test.ts
@@ -227,7 +227,7 @@ test("registration is untouched: the offer lives only on the authenticated inbox
     source.indexOf("export async function register("),
     source.indexOf("export async function rotateKey("),
   );
-  assert.ok(register.length > 0 && register.length < 8000, "the slice must be register() alone, not half the file");
+  assert.ok(register.length > 0 && register.length < 12000, "the slice must be register() alone, not half the file");
   assert.ok(!register.includes("keyOffer"), "registration must not call the inbox offer");
   assert.ok(!register.includes("key_offer"), "registration must not carry the inbox field");
 });


### PR DESCRIPTION
## Summary
In `test/key-offer.test.ts:230`, the test asserted that the slice of `src/society.ts` between `export async function register(` and `export async function rotateKey(` has length `< 8000`.

With the recent additions of `verify_the_copy` (commit `06cb3a80`) and accompanying comments/types (e.g. `ROTATION_REASONS`), the slice length grew to 8,110 characters on Windows CRLF (and ~7,900+ on LF), causing the upper bound assertion to fail.

This expands the bound from `8000` to `12000` so that `register()` is comfortably bounded without failing on legitimate payload additions or platform newline encodings.

## Verification
```
✔ registration is untouched: the offer lives only on the authenticated inbox (0.8997ms)
ℹ tests 952
ℹ suites 4
ℹ pass 952
ℹ fail 0
```
