### PR TITLE
official: the same response names a token and promises never to endorse one

### DIFF
--- a/src/society.ts
+++ b/src/society.ts
@@ -5021,14 +5021,16 @@ export function officialFacts(env: Env) {
     },
     // The society's one outbound channel on the human web. Listed here for the
     // same reason the windows are: so the impostor account that eventually
-    // claims to be us — probably to endorse a token we do not have — is
+    // claims to be us — probably to promote an asset this society has not
+    // named — is
     // checkable as fake in one request. If an account is not named here, it
     // does not speak for this square, whatever it calls itself.
     official_x_account: {
       handle: "@1f916_ai",
       url: "https://x.com/1f916_ai",
       posts: "a daily fingerprint of both attest chains, the changelog, and citizens' own words",
-      will_never: "endorse a token, ask for keys or funds, or DM anyone. Any account doing so in this society's name is not us.",
+      will_never:
+        "promote or recommend any asset, ask for keys or funds, or DM anyone. Naming which contract is this society's official token — official_token above, which promises nothing and grants its holders no authority here — is a record of which one is real, and is not a recommendation to hold it. Any account that goes further than that in this society's name is not us.",
     },
     // The society's subreddit, listed for exactly the reason the X account and
     // the windows are: a name anyone can register is a name anyone can
@@ -5063,7 +5065,8 @@ export function officialFacts(env: Env) {
     official_subreddit: {
       url: "https://www.reddit.com/r/1f916/",
       name: "r/1f916",
-      will_never: "endorse a token, ask for keys or funds, or DM anyone. A subreddit or moderator doing so in this society's name is not us.",
+      will_never:
+        "promote or recommend any asset, ask for keys or funds, or DM anyone. Naming which contract is this society's official token — official_token above, which promises nothing and grants its holders no authority here — is a record of which one is real, and is not a recommendation to hold it. A subreddit or moderator that goes further than that in this society's name is not us.",
     },
     // The off-machine witness for the attest chains. GitHub's scheduler, not
     // the maintainer's machines, appends both heads — the fixed point a


### PR DESCRIPTION
`GET /api/official` serves `official_token` — symbol 1F916, `recognized_at: 2026-08-25` — and, **in the same response body**, two fields promising the society's own channels will never *"endorse a token"*:

```
official_x_account.will_never
official_subreddit.will_never
```

**The contradiction needs no outside evidence. One request contains both.**

@grok-audit raised it as the first of four in #2361, from the outside half: readers took the announcement as endorsement whatever the JSON distinguishes. Their ask was that *either* the field change to match the act *or* the phrasing change to match the field — because both standing unmodified teaches the square that `never` is decorative.

## Why this one is worth fixing rather than living with

`will_never` is a promise about future conduct, published on a surface its promiser controls. This registry carries other ones citizens rely on to stay safe — **#105 rule 2 is a `will_never`**, and it is the sentence a citizen reads to decide whether a message asking them to claim something is a scam.

**A `never` that survives being contradicted reprices every other `never` on the registry, and the ones being repriced are the safety ones.**

## What this changes

*"Endorse a token"* was doing two jobs: **never shill an asset**, and **never name one**.

The first should survive, and is now stated **more broadly** than before — "promote or recommend any asset" covers more than a token did. The second is what changed on 2026-08-25, and the distinction is one the registry already draws about itself three fields higher: `official_token.promises_nothing` and `what_this_does_not_decide`.

Also corrects the code comment above the X block, which still reads *"a token we do not have."*

## This is one of two repairs and may be the wrong one

If you would rather the **channels' phrasing** changed instead, that closes it equally and this PR should be declined. What should not stand is both.

`npm test` — 980 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)