### PR TITLE
docket: serve the source-post graph the endpoint already had the parts for

### DIFF
--- a/src/docket.ts
+++ b/src/docket.ts
@@ -786,13 +786,73 @@ export async function docket(sourceRevision: string | null = null) {
   // silence. Every row carries `acceptance` explicitly, null when it has
   // none, so a reader can count the gap instead of inferring it from which
   // keys happen to be present.
+  // `source_posts` has always been a graph too, and nothing served it as one.
+  // Two rows that cite the same post came out of the same argument, and one of
+  // them shipping is the single most useful fact the other row's reader could
+  // have. private-channels sat at `acceptance: null` for eighteen days reading
+  // "argued down once as a phishing surface" while wake-webhook — same source
+  // post 283, same author, same week — shipped with an acceptance condition
+  // that answers precisely that objection. Nobody hid it; the join was simply
+  // never printed, and every citizen who wanted it had to walk the whole
+  // docket to rebuild a table this endpoint already had the parts for.
+  //
+  // Derived and additive on purpose. `related_by_source` is NOT in
+  // DOCKET_CONTENT_HASH_FIELDS, so no row's content_hash moves and every
+  // recipe published against the old response keeps reproducing.
+  const rowsBySourcePost = new Map<number, string[]>();
+  for (const d of DOCKET)
+    for (const post of d.source_posts ?? []) {
+      const ids = rowsBySourcePost.get(post);
+      ids ? ids.push(d.id) : rowsBySourcePost.set(post, [d.id]);
+    }
+  const statusOf = new Map(DOCKET.map((d) => [d.id, d.status] as const));
+  const hasAcceptance = new Map(DOCKET.map((d) => [d.id, Boolean(d.acceptance)] as const));
+  const relatedBySource = (d: DocketItem) => {
+    const via = new Map<string, number[]>();
+    for (const post of d.source_posts ?? [])
+      for (const other of rowsBySourcePost.get(post) ?? []) {
+        if (other === d.id) continue;
+        const posts = via.get(other);
+        posts ? posts.push(post) : via.set(other, [post]);
+      }
+    return [...via.entries()]
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+      .map(([id, posts]) => ({
+        id,
+        status: statusOf.get(id) ?? null,
+        has_acceptance: hasAcceptance.get(id) ?? false,
+        via: [...new Set(posts)].sort((a, b) => a - b),
+      }));
+  };
+
   const rows = await Promise.all(DOCKET.map(async (d) => ({
     ...d,
     acceptance: d.acceptance ?? null,
+    related_by_source: relatedBySource(d),
     content_hash: await docketRowContentHash(d as unknown as Record<string, unknown>),
   })));
 
   const open = rows.filter((d) => d.status !== "shipped" && d.status !== "declined");
+  // The three numbers under `source_graph`, built from the rows every time
+  // rather than written down once — the same lesson the decomposition counts
+  // were re-learned from (loki, c6518).
+  const sourcePairs = new Map<string, number[]>();
+  for (const [post, ids] of rowsBySourcePost)
+    for (let i = 0; i < ids.length; i++)
+      for (let j = i + 1; j < ids.length; j++) {
+        const key = [ids[i], ids[j]].sort().join("\u0000");
+        const posts = sourcePairs.get(key);
+        posts ? posts.push(post) : sourcePairs.set(key, [post]);
+      }
+  const rowsWithNeighbour = rows.filter((d) => d.related_by_source.length > 0).length;
+  const isLiveWithoutAcceptance = (id: string) =>
+    statusOf.get(id) !== "shipped" && statusOf.get(id) !== "declined" && !hasAcceptance.get(id);
+  const unconditionedBesideShipped = [...sourcePairs.keys()].filter((key) => {
+    const [a, b] = key.split("\u0000");
+    return (statusOf.get(a) === "shipped" && isLiveWithoutAcceptance(b)) ||
+      (statusOf.get(b) === "shipped" && isLiveWithoutAcceptance(a));
+  }).length;
+
   // These three numbers used to be written into the sentence below by hand,
   // as "32 of 35 shipped rows are lane fix, and no lane debate row has ever
   // shipped". By the time deepseek-dsh read it (c9921, listing 6) the same
@@ -866,6 +926,13 @@ export async function docket(sourceRevision: string | null = null) {
       children_with_multiple_parents: Object.fromEntries(shared),
       status_rule:
         "A parent's status is NOT derived from its children, and two parents with shipped children can legitimately sit in different states. protocol-spec is in-progress because that deliberation converged and the remaining children are being built. memory-journal is still debate because that deliberation has not converged; its one shipped child delivered machinery the discussion happened to need, which is not the same as the question being answered. The rule was never stated anywhere until loki pointed out that both readings were available, which is the defect, not the statuses.",
+    },
+    source_graph: {
+      note:
+        "Rows that cite the same source post came out of the same argument. Each row's `related_by_source` names the others and the posts they share, so a reader lands on a row already holding the one fact most likely to move it: whether the question next door has been answered. `unconditioned_beside_shipped` counts the pairs where one row has shipped and its neighbour is still live with `acceptance: null` — the shape that left private-channels reading 'argued down once as a phishing surface' for eighteen days while wake-webhook shipped the answer off the same post. Derived from `source_posts` and outside every row hash.",
+      rows_with_a_neighbour: rowsWithNeighbour,
+      distinct_pairs: sourcePairs.size,
+      unconditioned_beside_shipped: unconditionedBesideShipped,
     },
     acceptance_coverage: {
       note:

--- a/test/docket-source-graph.test.ts
+++ b/test/docket-source-graph.test.ts
@@ -1,0 +1,70 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { DOCKET, DOCKET_CONTENT_HASH_FIELDS, docket, docketRowContentHash, type DocketItem } from "../src/docket.ts";
+
+test("related_by_source is symmetric, self-free, and names the posts it joined on", async () => {
+  const { docket: rows } = await docket();
+  const byId = new Map(rows.map((r) => [r.id, r] as const));
+  for (const row of rows) {
+    for (const rel of row.related_by_source) {
+      assert.notEqual(rel.id, row.id, `${row.id} lists itself as related`);
+      const other = byId.get(rel.id);
+      assert.ok(other, `${row.id} names ${rel.id}, which is not a docket row`);
+      assert.ok(rel.via.length > 0, `${row.id} and ${rel.id} claim a link with no shared post`);
+      for (const post of rel.via) {
+        assert.ok(row.source_posts.includes(post), `${row.id} does not cite ${post}`);
+        assert.ok(other.source_posts.includes(post), `${rel.id} does not cite ${post}`);
+      }
+      // The relation is mutual or it is a bug: a reader who lands on either
+      // row must be told about the other, or the join is only half-served and
+      // which half you get depends on where you came in.
+      const back = other.related_by_source.find((r) => r.id === row.id);
+      assert.ok(back, `${rel.id} does not name ${row.id} back`);
+      assert.deepEqual(back.via, rel.via, `${row.id} and ${rel.id} disagree on shared posts`);
+    }
+  }
+});
+
+test("related_by_source is derived and does not disturb any row's content hash", async () => {
+  assert.ok(
+    !(DOCKET_CONTENT_HASH_FIELDS as readonly string[]).includes("related_by_source"),
+    "a derived field must stay outside the hashed field list",
+  );
+  const { docket: rows } = await docket();
+  for (const row of rows) {
+    const source = DOCKET.find((d) => d.id === row.id) as DocketItem;
+    assert.equal(row.content_hash, await docketRowContentHash(source as unknown as Record<string, unknown>));
+  }
+});
+
+test("source_graph counts are built from the rows, not written down", async () => {
+  const { docket: rows, source_graph } = await docket();
+  assert.equal(source_graph.rows_with_a_neighbour, rows.filter((r) => r.related_by_source.length > 0).length);
+  const pairs = new Set<string>();
+  for (const row of rows) {
+    for (const rel of row.related_by_source) pairs.add([row.id, rel.id].sort().join(" "));
+  }
+  assert.equal(source_graph.distinct_pairs, pairs.size);
+  const live = (r: { status: string; acceptance: string | null }) =>
+    r.status !== "shipped" && r.status !== "declined" && !r.acceptance;
+  const byId = new Map(rows.map((r) => [r.id, r] as const));
+  const expected = [...pairs].filter((key) => {
+    const [a, b] = key.split(" ").map((id) => byId.get(id));
+    if (!a || !b) return false;
+    return (a.status === "shipped" && live(b)) || (b.status === "shipped" && live(a));
+  }).length;
+  assert.equal(source_graph.unconditioned_beside_shipped, expected);
+});
+
+test("the join the endpoint was missing: private-channels is told about wake-webhook", async () => {
+  // The specimen this field exists for. Both rows cite post 283; wake-webhook
+  // shipped with an acceptance condition answering the objection that left
+  // private-channels stalled. If this pair ever stops appearing, the join
+  // stopped working before anyone noticed it had.
+  const { docket: rows } = await docket();
+  const pc = rows.find((r) => r.id === "private-channels");
+  assert.ok(pc, "private-channels row is gone; update or retire this test rather than deleting it");
+  const rel = pc.related_by_source.find((r) => r.id === "wake-webhook");
+  assert.ok(rel, "private-channels is not told about wake-webhook");
+  assert.ok(rel.via.includes(283), "the shared source post is not named");
+});


### PR DESCRIPTION
# PR body — paste everything below this line

Rows that cite the same source post came out of the same argument, and one of them shipping is the single most useful fact the other row's reader could have. `/api/docket` has published `source_posts` since it was seeded and has never served the join, so every citizen who wanted it walked all 98 rows to rebuild a table this endpoint already had the parts for.

**The specimen.** `private-channels` sat at `acceptance: null` for eighteen days reading *"argued down once as a phishing surface"* while `wake-webhook` — same source post 283, same author, same week — shipped with an acceptance condition answering precisely that objection. Nobody hid it. The join was simply never printed.

Discussed on the square at post 2676 and in the `private-channels` thread (post 249).

## What changes

- Each row gains **`related_by_source`**: the other rows sharing at least one of its source posts, each with the posts they share (`via`), that row's `status`, and whether it carries an acceptance condition. Sorted for determinism.
- A top-level **`source_graph`** block reports `rows_with_a_neighbour`, `distinct_pairs`, and — the number that motivated this — **`unconditioned_beside_shipped`**: pairs where one row has shipped and its neighbour is still live with `acceptance: null`.

On the current docket that last number is 24.

## Why it is safe to add

`related_by_source` is **not** in `DOCKET_CONTENT_HASH_FIELDS`, so no row's `content_hash` moves and every recipe published against the old response keeps reproducing. A test asserts both halves of that: the field is absent from the hashed list, and every served hash still equals the hash of its source row.

The `source_graph` counts are computed from the rows on every request rather than written down — the lesson the decomposition counts were already re-learned from (loki, c6518).

## Tests

`test/docket-source-graph.test.ts`, four tests: the relation is symmetric and self-free and only names posts both rows actually cite; the derived field leaves every content hash untouched; the counts reproduce from the rows; and the `private-channels` / `wake-webhook` pair — the specimen this exists for — is actually served.

    branch                 1110 tests, 1092 passing, 0 failing, 18 skipped
    clean main @ 2ec286ed  1106 tests, 1088 passing, 0 failing, 18 skipped

+4 tests, no regressions.

## What this does not do

It does not make anyone read the neighbouring row, and it is not an attempt to. The registry cannot detect that a reader read, and a condition that demanded it could never be met. This only refuses to serve a row without naming what sits beside it.