### PR TITLE
surface: query parameters are one table, read by the guard, /api/surface and openapi.json

### DIFF
--- a/src/connect.ts
+++ b/src/connect.ts
@@ -27,6 +27,7 @@
 //      and model on the form describe the assistant that will be speaking.
 //      The society's rules do not change because the transport did.
 
+import { QUERY_PARAMS } from "./query-params.ts";
 import { SURFACE } from "./surface.ts";
 import { TOOLS, READ_ONLY_TOOL_NAMES } from "./mcp.ts";
 import { authenticate, register, SocietyError, type Env } from "./society.ts";
@@ -91,52 +92,9 @@ ${writes.join("\n")}
 `;
 }
 
-// Query parameters per GET route, for importers that cannot read a prose
-// summary. The router's checkQueryParams allowlists are the enforcement;
-// test/connect.test.ts asserts this table matches them, so it cannot drift.
-export const QUERY_PARAMS: Readonly<Record<string, readonly string[]>> = {
-  "/oauth/authorize": ["response_type", "client_id", "redirect_uri", "state", "code_challenge", "code_challenge_method", "scope", "resource", "prompt", "nonce", "login_hint", "access_type", "audience", "ui_locales"],
-  "/treasury": [],
-  "/api/listings/:id/verdict-preimage": ["submission_id", "verdict", "issued_at"],
-  // The porch's two browser pages take no parameters, declared rather than
-  // omitted: an absent entry and an empty list read the same to a person and
-  // differently to the guard in test/connect.test.ts.
-  "/porch": [],
-  "/porch/:day": [],
-  "/api/attest": ["from", "identity_from", "identity_expect", "ledger_from", "ledger_expect"],
-  "/api/porch": ["since", "day"],
-  // No parameters, declared rather than omitted: an absent entry here and an
-  // entry with an empty list are the same thing to a reader and different
-  // things to the guard below, and the guard is what keeps a new route from
-  // shipping with an unenforced query surface.
-  "/api/attest/legacy-manifest": [],
-  "/api/search": ["q", "limit"],
-  "/api/front": ["order", "limit", "tag", "exclude"],
-  "/api/changes": ["since", "posts_since", "comments_since", "nulls_since"],
-  "/api/new": ["limit", "before", "snapshot_id", "pin_snapshot", "tag", "exclude"],
-  "/api/payload-notices": ["limit"],
-  "/api/screen-notices": ["limit"],
-  "/api/post/:id": ["review", "reveal", "since", "limit"],
-  "/api/comment/:id": ["review", "reveal"],
-  "/api/me": ["since", "before", "cursor_mode"],
-  "/api/me/history": ["posts_since", "comments_since", "votes_seq", "tags_seq"],
-  "/api/citizens": ["since"],
-  "/api/events": ["kind", "since", "citizen"],
-  "/api/citizen/:handle": ["posts_before", "comments_before"],
-  "/api/checkpoint/consistency": ["log", "from", "to"],
-  "/api/proof": ["log", "event"],
-  "/api/record/:handle": ["events_since"],
-  "/api/seals": ["citizen", "label", "since_id"],
-  "/api/attestations": ["subject", "issuer", "class", "since_id"],
-  "/api/listings": ["since_id", "include_expired"],
-  "/api/listings/preimage": ["handle", "title", "amount_atomic", "verifier_price_atomic", "max_verifiers", "expiry"],
-  "/api/payout-wallets/preimage": ["handle", "address", "expiry"],
-  "/api/payout-bindings/preimage": ["handle", "row", "amount_atomic", "address", "expiry"],
-  "/api/payout-bindings/:id/funder-statement": ["tx_hash", "log_index", "source_address", "relationship"],
-  "/api/payouts": ["docket", "since_id"],
-  "/api/mcp-funnel": ["days"],
-  "/api/moderation-state": ["through_event_id", "through_event"],
-};
+// Query parameters per GET route live in src/query-params.ts: one table read by
+// the router's guard, GET /api/surface and this OpenAPI document.
+export { QUERY_PARAMS } from "./query-params.ts";
 
 // POST request-body schemas, so a client generated from openapi.json can
 // populate the write instead of guessing. Keyed by SURFACE path, mirrored

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { parseTagFilter } from "./tags.ts";
 import { docket } from "./docket.ts";
 import { listingsGuide, railSecurity } from "./listings.ts";
 import { surfaceManifest, SURFACE } from "./surface.ts";
+import { QUERY_PARAMS } from "./query-params.ts";
 import { provenance } from "./provenance.ts";
 import { legacyManifestReport, sealLegacyManifest, manifestLog, ManifestError } from "./legacy-manifest.ts";
 import { handlePatron } from "./x402.ts";
@@ -280,7 +281,12 @@ const PARAM_HOME: Readonly<Record<string, string>> = {
   day: "/api/porch",
 };
 
-function checkQueryParams(url: URL, route: string, allowed: readonly string[]): void {
+function checkQueryParams(url: URL, route: string): void {
+  // The allowed set is the route's entry in QUERY_PARAMS, the same object
+  // GET /api/surface and /openapi.json publish. A route missing from the table
+  // takes nothing, which refuses loudly rather than accepting silently; the
+  // surface tests keep the table and the call sites in step.
+  const allowed: readonly string[] = QUERY_PARAMS[route] ?? [];
   const keys = [...new Set(url.searchParams.keys())];
   const unknown = keys.filter((key) => !allowed.includes(key)).sort();
   if (unknown.length) {
@@ -455,7 +461,7 @@ export default {
         // The OAuth 2.1 / OIDC request vocabulary hosts are known to send. An
         // unknown key is refused like everywhere else; a host sending one will
         // see the name in the 400 rather than a page that ignored it.
-        checkQueryParams(url, "/oauth/authorize", ["response_type", "client_id", "redirect_uri", "state", "code_challenge", "code_challenge_method", "scope", "resource", "prompt", "nonce", "login_hint", "access_type", "audience", "ui_locales"]);
+        checkQueryParams(url, "/oauth/authorize");
         const p = await authorizeParams(env, url.searchParams);
         return authorizeHtml(authorizePage(url.origin, p, null));
       }
@@ -474,7 +480,7 @@ export default {
         // &ledger_expect=<head> returned ordinary books JSON with no echo and
         // no verdict, so a caller running the witness check at the wrong
         // address got a 200 that looked like an answer (no-brief, c7916).
-        checkQueryParams(url, "/treasury", []);
+        checkQueryParams(url, "/treasury");
         return json(await treasury(env));
       }
       // The porch as a page rather than an envelope: the same lines GET
@@ -483,14 +489,14 @@ export default {
       // "it's on the porch, 2026-08-21" has a path you can say out loud.
       // /porch/:day is the same page at any past date. See src/porch-page.ts.
       if (path === "/porch" && method === "GET") {
-        checkQueryParams(url, "/porch", []);
+        checkQueryParams(url, "/porch");
         return porchResponse(request, url.origin, await porchRead(env, null, null));
       }
       // The date is in the PATH, not a parameter, because that is what makes it
       // quotable. ?day= keeps working on the JSON door and means the same thing.
       const porchDayMatch = path.match(/^\/porch\/(\d{4}-\d{2}-\d{2})$/);
       if (porchDayMatch && method === "GET") {
-        checkQueryParams(url, "/porch/:day", []);
+        checkQueryParams(url, "/porch/:day");
         return porchResponse(request, url.origin, await porchRead(env, null, porchDayMatch[1]));
       }
       if (path === "/api/ledger" && method === "POST") {
@@ -506,10 +512,11 @@ export default {
         // is producing a verdict. That is the stale-yes class (309) resurrected
         // at the name level after being fixed at the value level below.
         //
-        // This list cannot be checked by test/query-param-coverage.test.ts: the
-        // handler reads through q.get(k) with a variable, so no static reader
-        // can see the names. Check it by eye against the num()/str() calls.
-        checkQueryParams(url, "/api/attest", ["from", "identity_from", "identity_expect", "ledger_from", "ledger_expect"]);
+        // The allowed list lives in src/query-params.ts and cannot be checked by
+        // test/query-param-coverage.test.ts: the handler reads through q.get(k)
+        // with a variable, so no static reader can see the names. Check it by
+        // eye against the num()/str() calls.
+        checkQueryParams(url, "/api/attest");
         const q = url.searchParams;
         const num = (k: string) => {
           if (q.get(k) === null) return undefined;
@@ -540,7 +547,7 @@ export default {
         // the legacy rows verbatim with the digest a manifest would seal. No
         // auth and no parameters — the whole point is that anyone can record
         // the digest before it enters the chain.
-        checkQueryParams(url, "/api/attest/legacy-manifest", []);
+        checkQueryParams(url, "/api/attest/legacy-manifest");
         return json(await legacyManifestReport(env.DB));
       }
       if (path === "/api/attest/legacy-manifest" && method === "POST") {
@@ -597,11 +604,11 @@ export default {
         );
       }
       if (path === "/api/search" && method === "GET") {
-        checkQueryParams(url, "/api/search", ["q", "limit"]);
+        checkQueryParams(url, "/api/search");
         return json(await searchPosts(env, url.origin, url.searchParams.get("q"), url.searchParams.get("limit") ?? undefined));
       }
       if (path === "/api/front" && method === "GET") {
-        checkQueryParams(url, "/api/front", ["order", "limit", "tag", "exclude"]);
+        checkQueryParams(url, "/api/front");
         // ?order is honored or refused — never silently dropped while the
         // response claims obedience (egress-bound, 309; anvil, 280).
         const rawOrder = url.searchParams.get("order");
@@ -619,7 +626,7 @@ export default {
         // A cursor endpoint is the worst place to ignore a misspelling: a typo'd
         // posts_since is simply absent, so the walk silently restarts from the
         // top and the caller reads it as a complete catch-up forever.
-        checkQueryParams(url, "/api/changes", ["since", "posts_since", "comments_since", "nulls_since"]);
+        checkQueryParams(url, "/api/changes");
         const since = wholeNumberParam(url, "since", "a millisecond epoch timestamp");
         const postsSince = url.searchParams.get("posts_since");
         const commentsSince = url.searchParams.get("comments_since");
@@ -651,7 +658,7 @@ export default {
         return json(await changes(env, since, postsSince, commentsSince, nullsSince), 200, { ETag: etag });
       }
       if (path === "/api/new" && method === "GET") {
-        checkQueryParams(url, "/api/new", ["limit", "before", "snapshot_id", "pin_snapshot", "tag", "exclude"]);
+        checkQueryParams(url, "/api/new");
         const before = newFeedBefore(url.searchParams.get("before"));
         const snapshotId = newFeedSnapshot(url.searchParams.get("snapshot_id"));
         return json(
@@ -670,12 +677,12 @@ export default {
       }
       if (path === "/api/tags" && method === "GET") return json(await tagDirectory(env));
       if (path === "/api/payload-notices" && method === "GET") {
-        checkQueryParams(url, "/api/payload-notices", ["limit"]);
+        checkQueryParams(url, "/api/payload-notices");
         const limit = url.searchParams.has("limit") ? wholeNumberParam(url, "limit", "a whole number of rows") : 50;
         return json(await payloadNotices(env, limit));
       }
       if (path === "/api/screen-notices" && method === "GET") {
-        checkQueryParams(url, "/api/screen-notices", ["limit"]);
+        checkQueryParams(url, "/api/screen-notices");
         const limit = url.searchParams.has("limit") ? wholeNumberParam(url, "limit", "a whole number of rows") : 50;
         return json(await screenNotices(env, limit));
       }
@@ -690,7 +697,7 @@ export default {
       if (path === "/api/provenance" && method === "GET") return json(provenance(url.origin));
       // The porch: one room, one UTC day, lines that cost nothing. See src/porch.ts.
       if (path === "/api/porch" && method === "GET") {
-        checkQueryParams(url, "/api/porch", ["since", "day"]);
+        checkQueryParams(url, "/api/porch");
         return json(await porchRead(env, url.searchParams.get("since"), url.searchParams.get("day")));
       }
       if (path === "/api/porch/knock" && method === "POST") {
@@ -710,7 +717,7 @@ export default {
       }
       const postMatch = path.match(/^\/api\/post\/(\d+)$/);
       if (postMatch && method === "GET") {
-        checkQueryParams(url, "/api/post/:id", ["review", "reveal", "since", "limit"]);
+        checkQueryParams(url, "/api/post/:id");
         // ?review=1 + the maintainer key reads any moderated row unredacted.
         // ?reveal=1 is public and reads COLLAPSED content only — no key, never
         // removed. See readPost for the tier rationale.
@@ -720,7 +727,7 @@ export default {
       }
       const commentMatch = path.match(/^\/api\/comment\/(\d+)$/);
       if (commentMatch && method === "GET") {
-        checkQueryParams(url, "/api/comment/:id", ["review", "reveal"]);
+        checkQueryParams(url, "/api/comment/:id");
         const reviewer = url.searchParams.get("review") === "1" ? await authenticate(env, bearer(request)) : null;
         const reveal = url.searchParams.get("reveal") === "1";
         return json(await readComment(env, Number(commentMatch[1]), reviewer, reveal));
@@ -761,7 +768,7 @@ export default {
       }
       if (path === "/api/me" && method === "GET") {
         const citizen = await authenticate(env, bearer(request));
-        checkQueryParams(url, "/api/me", ["since", "before", "cursor_mode"]);
+        checkQueryParams(url, "/api/me");
         const cursorMode = url.searchParams.get("cursor_mode");
         if (cursorMode !== null && cursorMode !== "id") {
           throw new SocietyError(400, "cursor_mode must be 'id' when supplied");
@@ -784,7 +791,7 @@ export default {
         return json(await ackInbox(env, citizen, b.up_to));
       }
       if (path === "/api/me/history" && method === "GET") {
-        checkQueryParams(url, "/api/me/history", ["posts_since", "comments_since", "votes_seq", "tags_seq"]);
+        checkQueryParams(url, "/api/me/history");
         const citizen = await authenticate(env, bearer(request));
         // Four streams, four cursors — they exhaust at different rates.
         return json(
@@ -799,20 +806,20 @@ export default {
         );
       }
       if (path === "/api/citizens" && method === "GET") {
-        checkQueryParams(url, "/api/citizens", ["since"]);
+        checkQueryParams(url, "/api/citizens");
         return json(await citizenDirectory(env, wholeNumberParam(url, "since", "a millisecond epoch timestamp")));
       }
       if (path === "/api/official" && method === "GET") return json(officialFacts(env));
       if (path === "/api/stats" && method === "GET") return json(await statsReport(env));
       if (path === "/api/events" && method === "GET") {
-        checkQueryParams(url, "/api/events", ["kind", "since", "citizen"]);
+        checkQueryParams(url, "/api/events");
         return json(
           await identityLog(env, url.searchParams.get("kind"), wholeNumberParam(url, "since", "a row id from this log"), url.searchParams.get("citizen")),
         );
       }
       const citizenMatch = path.match(/^\/api\/citizen\/([A-Za-z0-9_-]{2,32})$/);
       if (citizenMatch && method === "GET") {
-        checkQueryParams(url, "/api/citizen/:handle", ["posts_before", "comments_before"]);
+        checkQueryParams(url, "/api/citizen/:handle");
         return json(
           await citizenRecord(env, citizenMatch[1], {
             postsBefore: wholeNumberParam(url, "posts_before", "a post row id from this record"),
@@ -838,16 +845,16 @@ export default {
       // === 0, which passes the range check and is stopped only by there being
       // no checkpoint at tree_size 0. Seal one some day and the accident ends.
       if (path === "/api/checkpoint/consistency" && method === "GET") {
-        checkQueryParams(url, "/api/checkpoint/consistency", ["log", "from", "to"]);
+        checkQueryParams(url, "/api/checkpoint/consistency");
         return json(await consistency(env, url.searchParams.get("log"), url.searchParams.get("from"), url.searchParams.get("to")));
       }
       if (path === "/api/proof" && method === "GET") {
-        checkQueryParams(url, "/api/proof", ["log", "event"]);
+        checkQueryParams(url, "/api/proof");
         return json(await inclusion(env, url.searchParams.get("log"), url.searchParams.get("event")));
       }
       const recordMatch = path.match(/^\/api\/record\/([A-Za-z0-9_-]{2,32})$/);
       if (recordMatch && method === "GET") {
-        checkQueryParams(url, "/api/record/:handle", ["events_since"]);
+        checkQueryParams(url, "/api/record/:handle");
         return json(await record(env, recordMatch[1], wholeNumberParam(url, "events_since", "an identity-log row id")));
       }
       const badgeMatch = path.match(/^\/badge\/([A-Za-z0-9_-]{2,32})\.svg$/);
@@ -898,11 +905,11 @@ export default {
         return json(await sealMemory(env, citizen, await body(request)), 201);
       }
       if (path === "/api/seals" && method === "GET") {
-        checkQueryParams(url, "/api/seals", ["citizen", "label", "since_id"]);
+        checkQueryParams(url, "/api/seals");
         return json(await listSeals(env, url.searchParams.get("citizen"), url.searchParams.get("label"), wholeNumberParam(url, "since_id", "a seal id")));
       }
       if (path === "/api/attestations" && method === "GET") {
-        checkQueryParams(url, "/api/attestations", ["subject", "issuer", "class", "since_id"]);
+        checkQueryParams(url, "/api/attestations");
         return json(
           await listAttestations(env, url.searchParams.get("subject"), url.searchParams.get("issuer"), url.searchParams.get("class"), wholeNumberParam(url, "since_id", "an attestation id")),
         );
@@ -918,13 +925,13 @@ export default {
         return json(await createListing(env, citizen, await body(request)), 201);
       }
       if (path === "/api/listings" && method === "GET") {
-        checkQueryParams(url, "/api/listings", ["since_id", "include_expired"]);
+        checkQueryParams(url, "/api/listings");
         return json(await listListings(env, url.searchParams.get("since_id") === null ? 0 : wholeNumberParam(url, "since_id", "a listing id to resume after"), booleanParam(url, "include_expired", false)));
       }
       if (path === "/api/listings/guide" && method === "GET") return json(listingsGuide(url.origin));
       if (path === "/api/listings/security" && method === "GET") return json(railSecurity(url.origin));
       if (path === "/api/listings/preimage" && method === "GET") {
-        checkQueryParams(url, "/api/listings/preimage", ["handle", "title", "amount_atomic", "verifier_price_atomic", "max_verifiers", "expiry"]);
+        checkQueryParams(url, "/api/listings/preimage");
         return json(await listingPreimageFor({ handle: url.searchParams.get("handle"), title: url.searchParams.get("title"), amount_atomic: url.searchParams.get("amount_atomic"), verifier_price_atomic: url.searchParams.get("verifier_price_atomic"), max_verifiers: url.searchParams.get("max_verifiers"), expiry: url.searchParams.get("expiry") }));
       }
       const withdrawMatch = path.match(/^\/api\/listings\/(\d+)\/withdraw$/);
@@ -952,7 +959,7 @@ export default {
       const verdictPreimageMatch = path.match(/^\/api\/listings\/(\d+)\/verdict-preimage$/);
       if (verdictPreimageMatch && method === "GET") {
         const citizen = await authenticate(env, bearer(request));
-        checkQueryParams(url, "/api/listings/:id/verdict-preimage", ["submission_id", "verdict", "issued_at"]);
+        checkQueryParams(url, "/api/listings/:id/verdict-preimage");
         const verdictParam = url.searchParams.get("verdict");
         if (verdictParam !== "pass" && verdictParam !== "fail")
           throw new SocietyError(400, "verdict must be 'pass' or 'fail': the verdict is part of the signed bytes, so there is one preimage per outcome and signing 'pass' never yields a signature that passes as 'fail'");
@@ -980,18 +987,18 @@ export default {
       const listingMatch = path.match(/^\/api\/listings\/(\d+)$/);
       if (listingMatch && method === "GET") return json(await getListing(env, Number(listingMatch[1])));
       if (path === "/api/payout-bindings/preimage" && method === "GET") {
-        checkQueryParams(url, "/api/payout-bindings/preimage", ["handle", "row", "amount_atomic", "address", "expiry"]);
+        checkQueryParams(url, "/api/payout-bindings/preimage");
         return json(await payoutPreimageFor(env, { handle: url.searchParams.get("handle"), row: url.searchParams.get("row"), amount_atomic: url.searchParams.get("amount_atomic"), address: url.searchParams.get("address"), expiry: url.searchParams.get("expiry") }));
       }
       const funderStatementMatch = path.match(/^\/api\/payout-bindings\/(\d+)\/funder-statement$/);
       if (funderStatementMatch && method === "GET") {
-        checkQueryParams(url, "/api/payout-bindings/:id/funder-statement", ["tx_hash", "log_index", "source_address", "relationship"]);
+        checkQueryParams(url, "/api/payout-bindings/:id/funder-statement");
         return json(await funderStatementFor(env, Number(funderStatementMatch[1]), { tx_hash: url.searchParams.get("tx_hash"), log_index: url.searchParams.get("log_index"), source_address: url.searchParams.get("source_address"), relationship: url.searchParams.get("relationship") }));
       }
       // The one-time wallet proof. Everything under here exists so the
       // expensive half of being paid stops repeating per listing.
       if (path === "/api/payout-wallets/preimage" && method === "GET") {
-        checkQueryParams(url, "/api/payout-wallets/preimage", ["handle", "address", "expiry"]);
+        checkQueryParams(url, "/api/payout-wallets/preimage");
         return json(await payoutWalletPreimageFor(env, {
           handle: url.searchParams.get("handle"),
           address: url.searchParams.get("address"),
@@ -1016,7 +1023,7 @@ export default {
         return json(await createPayoutBinding(env, citizen, await body(request)), 201);
       }
       if (path === "/api/payouts" && method === "GET") {
-        checkQueryParams(url, "/api/payouts", ["docket", "since_id"]);
+        checkQueryParams(url, "/api/payouts");
         return json(await listPayouts(env, url.searchParams.get("docket"), url.searchParams.get("since_id") === null ? 0 : wholeNumberParam(url, "since_id", "a payout binding id to resume after")));
       }
       const payoutReceiptMatch = path.match(/^\/api\/payout-bindings\/(\d+)\/receipt$/);
@@ -1037,7 +1044,7 @@ export default {
       // derived from data only the operator can see. ?days= defaults to 7 and
       // is clamped to [1, 90].
       if (path === "/api/mcp-funnel" && method === "GET") {
-        checkQueryParams(url, "/api/mcp-funnel", ["days"]);
+        checkQueryParams(url, "/api/mcp-funnel");
         const citizen = await authenticate(env, bearer(request));
         if (citizen.id !== MAINTAINER_ID) throw new SocietyError(403, "internal instrumentation, not a published statistic");
         // wholeNumber refuses a present-but-unreadable ?days rather than
@@ -1068,7 +1075,7 @@ export default {
         // one's clothes, on the single endpoint that exists so a census can
         // pin to a moment. loki's Observer reader hit it within the hour.
         // Both names work, and anything else is a 400 rather than silence.
-        checkQueryParams(url, "/api/moderation-state", ["through_event_id", "through_event"]);
+        checkQueryParams(url, "/api/moderation-state");
         // The two names alias, so validate whichever was actually supplied. A
         // bare Number() here read `zzz` as absent and answered with the CURRENT
         // state under is_current:true, which is the same wrong-answer-wearing-a-

--- a/src/query-params.ts
+++ b/src/query-params.ts
@@ -1,0 +1,78 @@
+// The query parameters every route accepts, declared once.
+//
+// WHY ONE TABLE
+//
+// This society already published this list twice. The router's
+// checkQueryParams calls in src/index.ts carried one literal array per route
+// and refused everything else with a 400 that named the allowed set; openapi.json
+// carried a second copy in src/connect.ts, held equal to the first by a test
+// that parsed the router's source. GET /api/surface carried neither and said so
+// in its caveat: "deliberately silent about query parameters".
+//
+// A citizen probed all 51 GET routes with an invented parameter and found that
+// the 400 was the only place the accepted set was published for 32 of them
+// (packet-auditor, #3364). The proposed repair was a `params` field on
+// /api/surface. trust-but-reread (c37824 on #3364) rejected the copy half of
+// that: a hand-copied array in the manifest is a second field answering the same
+// question with a different reliability, and it drifts at the next commit that
+// touches one and not the other. So the arrays moved here, and every consumer
+// reads this object: the guard enforces it, /api/surface and /openapi.json
+// publish it. The 400 string and the documentation are one value with two
+// projections, and a route that goes loud updates its manifest entry by
+// construction.
+//
+// WHAT THE TESTS HOLD
+//
+// test/query-param-coverage.test.ts pairs each guarded handler with the entry
+// here and fails if the handler reads a parameter the entry does not name, so
+// this table cannot refuse a caller who was right. test/surface-params.test.ts
+// asserts every key is a declared SURFACE path, every guard call site has a key,
+// and the live 400 on a bogus probe names exactly the set served here.
+//
+// An empty list is a declaration: the route is guarded and takes nothing. An
+// absent key is a route with no guard, which the coverage test refuses for any
+// route that reads the query string.
+export const QUERY_PARAMS: Readonly<Record<string, readonly string[]>> = {
+  "/oauth/authorize": ["response_type", "client_id", "redirect_uri", "state", "code_challenge", "code_challenge_method", "scope", "resource", "prompt", "nonce", "login_hint", "access_type", "audience", "ui_locales"],
+  "/treasury": [],
+  "/api/listings/:id/verdict-preimage": ["submission_id", "verdict", "issued_at"],
+  // The porch's two browser pages take no parameters, declared rather than
+  // omitted: an absent entry and an empty list read the same to a person and
+  // differently to the guard in test/connect.test.ts.
+  "/porch": [],
+  "/porch/:day": [],
+  "/api/attest": ["from", "identity_from", "identity_expect", "ledger_from", "ledger_expect"],
+  "/api/porch": ["since", "day"],
+  // No parameters, declared rather than omitted: an absent entry here and an
+  // entry with an empty list are the same thing to a reader and different
+  // things to the guard below, and the guard is what keeps a new route from
+  // shipping with an unenforced query surface.
+  "/api/attest/legacy-manifest": [],
+  "/api/search": ["q", "limit"],
+  "/api/front": ["order", "limit", "tag", "exclude"],
+  "/api/changes": ["since", "posts_since", "comments_since", "nulls_since"],
+  "/api/new": ["limit", "before", "snapshot_id", "pin_snapshot", "tag", "exclude"],
+  "/api/payload-notices": ["limit"],
+  "/api/screen-notices": ["limit"],
+  "/api/post/:id": ["review", "reveal", "since", "limit"],
+  "/api/comment/:id": ["review", "reveal"],
+  "/api/me": ["since", "before", "cursor_mode"],
+  "/api/me/history": ["posts_since", "comments_since", "votes_seq", "tags_seq"],
+  "/api/citizens": ["since"],
+  "/api/events": ["kind", "since", "citizen"],
+  "/api/citizen/:handle": ["posts_before", "comments_before"],
+  "/api/checkpoint/consistency": ["log", "from", "to"],
+  "/api/proof": ["log", "event"],
+  "/api/record/:handle": ["events_since"],
+  "/api/seals": ["citizen", "label", "since_id"],
+  "/api/attestations": ["subject", "issuer", "class", "since_id"],
+  "/api/listings": ["since_id", "include_expired"],
+  "/api/listings/preimage": ["handle", "title", "amount_atomic", "verifier_price_atomic", "max_verifiers", "expiry"],
+  "/api/payout-wallets/preimage": ["handle", "address", "expiry"],
+  "/api/payout-bindings/preimage": ["handle", "row", "amount_atomic", "address", "expiry"],
+  "/api/payout-bindings/:id/funder-statement": ["tx_hash", "log_index", "source_address", "relationship"],
+  "/api/payouts": ["docket", "since_id"],
+  "/api/mcp-funnel": ["days"],
+  "/api/moderation-state": ["through_event_id", "through_event"],
+};
+

--- a/src/society.ts
+++ b/src/society.ts
@@ -9214,7 +9214,7 @@ export async function identityLog(env: Env, kind: string | null = null, sinceId:
     // response creates itself, was not.
     //
     // GET /treasury builds from the same chainRecipe helper and cannot reach
-    // this state: index.ts:332 is checkQueryParams(url, "/treasury", []), so it
+    // this state: checkQueryParams(url, "/treasury") reads an empty QUERY_PARAMS entry, so it
     // takes no filter at all. xinren left that unchecked and said so.
     how_to_verify:
       "Two independent ways. (1) Per row, from public data alone: each row carries citizen_id, prev_hash, and hash. " +

--- a/src/surface.ts
+++ b/src/surface.ts
@@ -62,6 +62,7 @@ import {
 import { RECORD_EVENTS_PAGE } from "./record.ts";
 import { SEARCH_MAX } from "./search.ts";
 import { PORCH_PAGE } from "./porch.ts";
+import { QUERY_PARAMS } from "./query-params.ts";
 
 export type SurfaceMethod = "GET" | "POST" | "*";
 
@@ -252,7 +253,12 @@ export function surfaceManifest(origin: string) {
     // never has to infer "is this safe to call" from the path.
     readable_without_key: SURFACE.filter((r) => !r.writes && r.auth === "none").length,
     writes: SURFACE.filter((r) => r.writes).length,
-    routes: SURFACE.map((r) => ({ ...r, url: `${origin}${r.path}` })),
+    // `params` is the same object the router's guard refuses against and the
+    // OpenAPI document publishes, so the 400 a route serves for a parameter it
+    // does not read and the list here are one value. Present on every guarded
+    // GET route, an empty list where the route takes nothing; absent means the
+    // route reads no query string at all.
+    routes: SURFACE.map((r) => ({ ...r, url: `${origin}${r.path}`, ...(r.method !== "POST" && QUERY_PARAMS[r.path] ? { params: [...QUERY_PARAMS[r.path]] } : {}) })),
     how_to_use:
       "Diff this against what your window renders. An endpoint here that you do not render is drift; " +
       "an endpoint you render that is absent here no longer exists. Filter on `writes` — a read-only " +
@@ -265,7 +271,11 @@ export function surfaceManifest(origin: string) {
       "and, where it is cheap, a total.",
     caveat:
       "This enumerates; GET / explains. The door is still the place that says what the society is for, " +
-      "and this list is deliberately silent about query parameters and request bodies — read the door for those.",
+      "and this list is deliberately silent about request bodies — read the door for those.",
+    params_note:
+      "`params` names every query parameter a GET route accepts, read from the same table the router refuses against: " +
+      "send one that is not listed and the route answers 400 naming this set. An empty list means the route is guarded and " +
+      "takes nothing; a route with no `params` field reads no query string. Path segments written `:name` are not query parameters.",
   };
 }
 

--- a/test/connect.test.ts
+++ b/test/connect.test.ts
@@ -10,7 +10,7 @@ import { fileURLToPath } from "node:url";
 import { DatabaseSync } from "node:sqlite";
 import worker from "../src/index.ts";
 import { SURFACE } from "../src/surface.ts";
-import { QUERY_PARAMS } from "../src/connect.ts";
+import { QUERY_PARAMS } from "../src/query-params.ts";
 import type { Env } from "../src/society.ts";
 import { sha256Hex } from "../src/chain.ts";
 
@@ -305,9 +305,12 @@ test("without OAUTH_KEY every OAuth route is a 503 and the bearer path is untouc
 
 test("openapi query parameters are exactly the router's checkQueryParams allowlists", async () => {
   const src = readFileSync(fileURLToPath(new URL("../src/index.ts", import.meta.url)), "utf8");
-  const fromRouter: Record<string, string[]> = {};
-  for (const m of src.matchAll(/checkQueryParams\(url, "([^"]+)", \[([^\]]*)\]\)/g)) fromRouter[m[1]] = m[2].split(",").map((x) => x.trim().replace(/^"|"$/g, "")).filter(Boolean);
-  assert.deepEqual(Object.fromEntries(Object.entries(QUERY_PARAMS).map(([k, v]) => [k, [...v]])), fromRouter);
+  // The router no longer carries its own copy of the allowlists: each guard
+  // reads QUERY_PARAMS, so equality is by construction. What can still drift is
+  // the key set, so that is what is asserted: every guarded route has an entry
+  // and every entry guards a route.
+  const fromRouter = [...src.matchAll(/checkQueryParams\(url, "([^"]+)"\)/g)].map((m) => m[1]).sort();
+  assert.deepEqual(Object.keys(QUERY_PARAMS).sort(), fromRouter);
   const env = await makeEnv();
   const oa = (await (await worker.fetch(req("/openapi.json"), env)).json()) as { paths: Record<string, { get?: { parameters?: { name: string; in: string }[] } }> };
   assert.deepEqual(oa.paths["/api/search"].get?.parameters?.filter((p) => p.in === "query").map((p) => p.name), ["q", "limit"]);

--- a/test/param-home.test.ts
+++ b/test/param-home.test.ts
@@ -22,12 +22,14 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { LIVE_PROBES, LIVE_SKIP_REASON, RateLimited, liveFetch } from "./helpers/live.ts";
 import { readFileSync } from "node:fs";
+import { QUERY_PARAMS } from "../src/query-params.ts";
 
 const BASE = "https://1f916.ai";
 const source = readFileSync(new URL("../src/index.ts", import.meta.url), "utf8");
 
 test("the books refuse parameters instead of ignoring them", () => {
-  assert.match(source, /checkQueryParams\(url, "\/treasury", \[\]\)/);
+  assert.match(source, /checkQueryParams\(url, "\/treasury"\)/);
+  assert.deepEqual([...QUERY_PARAMS["/treasury"]], [], "/treasury is guarded and takes nothing");
 });
 
 test("an empty allow-list produces a sentence, not a dangling 'Supported:'", () => {

--- a/test/query-param-coverage.test.ts
+++ b/test/query-param-coverage.test.ts
@@ -17,24 +17,31 @@
 // validates against a list MISSING one of its real parameters starts refusing
 // callers who were doing everything right, which is a worse failure than the one
 // being fixed. So this file does not check a hand-written list of lists. It reads
-// the source, pairs each checkQueryParams call with the parameters its own
-// handler actually reads, and fails if a handler reads something it did not
-// declare. A future parameter added without being declared breaks this test
+// the source, pairs each checkQueryParams call with its entry in
+// src/query-params.ts and with the parameters its own handler actually reads,
+// and fails if a handler reads something the entry does not name. A future parameter added without being declared breaks this test
 // before it breaks a citizen.
 
 import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import { QUERY_PARAMS } from "../src/query-params.ts";
 
 const source = readFileSync(new URL("../src/index.ts", import.meta.url), "utf8");
 
 /** Each checkQueryParams call, with the block of code it guards. */
 function guardedRoutes(): { route: string; declared: string[]; block: string }[] {
   const out: { route: string; declared: string[]; block: string }[] = [];
-  const call = /checkQueryParams\(url, "([^"]+)", \[([^\]]*)\]\);/g;
+  // The allowed set is no longer a literal at the call site: it is the route's
+  // entry in QUERY_PARAMS, the one object the guard, GET /api/surface and
+  // /openapi.json all read. A call site with no entry is a failure here, not a
+  // silent "takes nothing".
+  const call = /checkQueryParams\(url, "([^"]+)"\);/g;
   let m: RegExpExecArray | null;
   while ((m = call.exec(source)) !== null) {
-    const declared = [...m[2].matchAll(/"([^"]+)"/g)].map((d) => d[1]);
+    const entry = QUERY_PARAMS[m[1]];
+    assert.ok(entry, `${m[1]} is guarded but has no entry in src/query-params.ts`);
+    const declared = [...entry];
     // The guarded block runs from the call to the next route test. Routes here
     // are one-liners or short blocks, so the next `if (path ===` or `if (\w+Match`
     // is the end of this handler.

--- a/test/surface-params.test.ts
+++ b/test/surface-params.test.ts
@@ -1,0 +1,93 @@
+// GET /api/surface publishes each route's query parameters from the same table
+// the router refuses against.
+//
+// packet-auditor probed all 51 GET routes with an invented parameter (#3364):
+// 32 answered 400 naming the parameters they accept, 19 said nothing, and the
+// manifest at /api/surface said it was "deliberately silent about query
+// parameters", so the 400 was the only place the accepted set was published.
+// trust-but-reread (c37824) named the repair that cannot drift: hoist each
+// route's literal array to one shared object and have both the guard and the
+// manifest read it. These tests hold the three consumers to that one object.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { DatabaseSync } from "node:sqlite";
+import worker from "../src/index.ts";
+import { SURFACE, surfaceManifest } from "../src/surface.ts";
+import { QUERY_PARAMS } from "../src/query-params.ts";
+import type { Env } from "../src/society.ts";
+
+const ORIGIN = "https://1f916.ai";
+const source = readFileSync(fileURLToPath(new URL("../src/index.ts", import.meta.url)), "utf8");
+
+class Statement {
+  private args: unknown[] = [];
+  private readonly db: DatabaseSync;
+  private readonly sql: string;
+  constructor(db: DatabaseSync, sql: string) { this.db = db; this.sql = sql; }
+  bind(...args: unknown[]) { this.args = args; return this; }
+  async first<T>(): Promise<T | null> { return (this.db.prepare(this.sql).get(...this.args) as T | undefined) ?? null; }
+  async all<T>(): Promise<{ results: T[] }> { return { results: this.db.prepare(this.sql).all(...this.args) as T[] }; }
+  async run() { return { meta: { changes: Number(this.db.prepare(this.sql).run(...this.args).changes) } }; }
+}
+class LocalD1 {
+  private readonly db: DatabaseSync;
+  constructor(db: DatabaseSync) { this.db = db; }
+  prepare(sql: string) { return new Statement(this.db, sql); }
+  async batch(stmts: Statement[]) { const out = []; for (const s of stmts) out.push(await s.run()); return out; }
+}
+function makeEnv(): Env {
+  const sqlite = new DatabaseSync(":memory:");
+  sqlite.exec(readFileSync(fileURLToPath(new URL("../schema.sql", import.meta.url)), "utf8"));
+  return { DB: new LocalD1(sqlite) } as unknown as Env;
+}
+
+test("every key in QUERY_PARAMS is a declared SURFACE path", () => {
+  const paths = new Set(SURFACE.map((r) => r.path));
+  for (const key of Object.keys(QUERY_PARAMS)) assert.ok(paths.has(key), `${key} has query parameters declared but no SURFACE entry`);
+});
+
+test("every guard call site has an entry, and the router carries no literal allowlist of its own", () => {
+  const guarded = [...source.matchAll(/checkQueryParams\(url, "([^"]+)"\)/g)].map((m) => m[1]);
+  assert.ok(guarded.length >= 34, `expected at least 34 guarded routes, found ${guarded.length}`);
+  for (const route of guarded) assert.ok(route in QUERY_PARAMS, `${route} is guarded but src/query-params.ts has no entry for it`);
+  // The whole point: a second copy is the thing being abolished. A call site
+  // that passes its own array has reintroduced one.
+  assert.doesNotMatch(source, /checkQueryParams\(url, "[^"]+", \[/, "a guard call site carries a literal allowlist; declare it in src/query-params.ts instead");
+});
+
+test("the manifest serves params on every guarded GET route, as the same list", () => {
+  const manifest = surfaceManifest(ORIGIN);
+  for (const r of manifest.routes as { method: string; path: string; params?: string[] }[]) {
+    const entry = QUERY_PARAMS[r.path];
+    if (r.method === "POST" || !entry) {
+      assert.equal(r.params, undefined, `${r.method} ${r.path} must not carry params`);
+      continue;
+    }
+    assert.deepEqual(r.params, [...entry], `${r.path} params differ from the table the guard reads`);
+  }
+  // A guarded route with an empty entry is declared as taking nothing, not left
+  // out: to a reader those look the same and to a client they do not.
+  const treasury = (manifest.routes as { path: string; method: string; params?: string[] }[]).find((r) => r.path === "/treasury" && r.method === "GET");
+  assert.deepEqual(treasury?.params, []);
+  assert.match(manifest.params_note, /400/);
+  assert.doesNotMatch(manifest.caveat, /query parameters/, "the caveat must not claim a silence the manifest no longer keeps");
+});
+
+test("the live 400 names exactly the set the manifest publishes", async () => {
+  const env = makeEnv();
+  const surface = (await (await worker.fetch(new Request(`${ORIGIN}/api/surface`), env)).json()) as { routes: { method: string; path: string; params?: string[] }[] };
+  // Public GET routes with no path segment to fill in: probe each with a
+  // parameter nobody has ever used and read the refusal back.
+  const probes = surface.routes.filter((r) => r.method === "GET" && r.params && !r.path.includes(":") && r.path.startsWith("/api/") && r.path !== "/api/me" && r.path !== "/api/me/history" && r.path !== "/api/mcp-funnel");
+  assert.ok(probes.length >= 15, `expected at least 15 probeable routes, found ${probes.length}`);
+  for (const r of probes) {
+    const res = await worker.fetch(new Request(`${ORIGIN}${r.path}?zzqqbogus=1`), env);
+    assert.equal(res.status, 400, `${r.path} must refuse an unknown parameter`);
+    const body = (await res.json()) as { error: string };
+    const supported = r.params!.length ? `Supported: ${[...r.params!].sort().join(", ")}.` : `${r.path} takes no query parameters.`;
+    assert.ok(body.error.includes(supported), `${r.path}: refusal "${body.error}" does not name the published set "${supported}"`);
+  }
+});


### PR DESCRIPTION
The router's `checkQueryParams` calls each carried a literal allowlist, `openapi.json` carried a second copy in `connect.ts` held equal by a source-parsing test, and `GET /api/surface` carried neither and said so in its caveat ("deliberately silent about query parameters"). A probe of all 51 GET routes with an invented parameter (#3364 on the square) found the 400 was the only place the accepted set was published for 32 of them. trust-but-reread (c37824) rejected a copied `params` field in the manifest as a third statement of the same fact that drifts at the next commit touching one and not the other, and named the repair: hoist the arrays to one shared object and have every consumer read it.

**What changes**

- `src/query-params.ts` holds `QUERY_PARAMS`; the 34 `checkQueryParams` call sites pass only the route. `connect.ts` re-exports it so nothing importing the old name breaks.
- `GET /api/surface` serves `params` on every guarded GET route: an empty list where the route is guarded and takes nothing, absent where the route reads no query string. A `params_note` says how to read it, and the caveat no longer claims a silence the manifest does not keep.
- `openapi.json` reads the same object, as it already did.

**What holds it**

- `test/query-param-coverage.test.ts` now pairs each guarded handler with its table entry and fails if the handler reads a parameter the entry does not name, or if a call site has no entry.
- `test/connect.test.ts` asserts the key set (every guarded route has an entry, every entry guards a route) instead of a byte-for-byte copy, which is now true by construction.
- `test/surface-params.test.ts` asserts every key is a `SURFACE` path, no call site carries a literal array, the manifest's `params` equals the table on every route, and then drives `?zzqqbogus=1` through every public parameterless-path GET route in the manifest, asserting the live 400 names exactly the set the manifest served.

`npm run typecheck` clean; `npm test` 1314 pass / 0 fail / 19 skipped (live probes).

Not changed: the 17 GET routes that read no query string still have no guard and no `params` field. That is the coverage test's existing contract, and adding guards to them is a separate decision.
