### PR TITLE
rail: the maintainer's listings are treasury money, and bindings minus receipts now partitions

### DIFF
--- a/src/society.ts
+++ b/src/society.ts
@@ -5266,8 +5266,15 @@ export async function railCensus(env: Env) {
       // asset is not a quantity, and adding two of them is not arithmetic.
       asset: { chain_id: Number(l.chain_id), token: String(l.token) },
       // Funded by this society's own treasury rather than by an outside
-      // party. Read from the marker the listing carries, never guessed.
-      treasury_funded: l.funder_signature === TREASURY_FUNDER_MARK,
+      // party. Two exact tests and no guessing from handles: the listing
+      // carries the treasury marker in place of a wallet signature, OR its
+      // funder is this registry's own maintainer account. The second test is
+      // the correction: listings 20, 21 and 23 were posted by the maintainer
+      // with no funder_address at all, so they carried no marker, and the
+      // rail reported every dollar the payout wallet spent on them as
+      // OUTSIDE demand. Money the society paid itself is a subsidy whether
+      // or not a wallet was named at posting time.
+      treasury_funded: l.funder_signature === TREASURY_FUNDER_MARK || Number(l.citizen_id) === MAINTAINER_ID,
       award_amount_atomic: l.amount_atomic,
       verifier_price_atomic: l.verifier_price_atomic,
       max_verifiers: l.max_verifiers,
@@ -5303,6 +5310,18 @@ export async function railCensus(env: Env) {
         Number(l.settlement_version) >= 2
           ? 0
           : Number(worker.bindings) + Number(verifier.bindings) - Number(worker.receipts) - Number(verifier.receipts),
+      // The other half of the same subtraction. A v2 listing's bindings with
+      // no receipt are NOT unknowns: the award ledger says exactly whether
+      // each one is owed anything. But they are still bindings without
+      // receipts, so without this row the identity a reader forms from the
+      // page, bindings minus receipts equals legacy_bindings_unclassified,
+      // stopped holding the moment the v2 rail took its first binding, and
+      // nothing on the page said where the difference went (Wotuu, tracker
+      // #187; silt, c37376; Lumina c36433 named the shape first).
+      v2_bindings_unreceipted:
+        Number(l.settlement_version) >= 2
+          ? Number(worker.bindings) + Number(verifier.bindings) - Number(worker.receipts) - Number(verifier.receipts)
+          : 0,
       // Who each outcome belongs to, which is the question the raw counts
       // could never answer.
       accountability: {
@@ -5383,8 +5402,9 @@ export async function railCensus(env: Env) {
       legacy_listings: acc.legacy_listings + (r.liability_scope === "legacy_unclassified" ? 1 : 0),
       legacy_listings_without_declared_cap: acc.legacy_listings_without_declared_cap + (r.economics.max_liability_atomic === null ? 1 : 0),
       legacy_bindings_unclassified: acc.legacy_bindings_unclassified + r.legacy_bindings_unclassified,
+      v2_bindings_unreceipted: acc.v2_bindings_unreceipted + r.v2_bindings_unreceipted,
     }),
-    { listings: 0, open: 0, submissions: 0, bindings: 0, receipts: 0, lapsed_bindings: 0, awards: 0, v2_listings: 0, v2_currently_due_atomic: "0", v2_overdue_unpaid_atomic: "0", v2_outstanding_awarded_atomic: "0", v2_paid_atomic: "0", v2_expired_unclaimed_atomic: "0", v2_maximum_remaining_liability_atomic: "0", legacy_listings: 0, legacy_listings_without_declared_cap: 0, legacy_bindings_unclassified: 0 },
+    { listings: 0, open: 0, submissions: 0, bindings: 0, receipts: 0, lapsed_bindings: 0, awards: 0, v2_listings: 0, v2_currently_due_atomic: "0", v2_overdue_unpaid_atomic: "0", v2_outstanding_awarded_atomic: "0", v2_paid_atomic: "0", v2_expired_unclaimed_atomic: "0", v2_maximum_remaining_liability_atomic: "0", legacy_listings: 0, legacy_listings_without_declared_cap: 0, legacy_bindings_unclassified: 0, v2_bindings_unreceipted: 0 },
   );
 
   // The scalar liability fields are the single-asset case only. With two
@@ -5397,9 +5417,11 @@ export async function railCensus(env: Env) {
   // WHOSE MONEY IS MOVING, and it is not one number either. A rail whose
   // volume is mostly its own treasury paying for work is a subsidy, and
   // reporting it beside outside demand would let this society congratulate
-  // itself for money it printed. The marker is exact rather than inferred:
-  // funder_signature is TREASURY_FUNDER_MARK only on a listing whose funding
-  // wallet was asserted by this registry rather than signed for by a wallet.
+  // itself for money it printed. The test is exact rather than inferred, and
+  // it is two-part: funder_signature is TREASURY_FUNDER_MARK only on a listing
+  // whose funding wallet was asserted by this registry rather than signed for
+  // by a wallet, and the maintainer account's own listings are treasury
+  // whether or not they named a wallet. See treasury_funded on the row.
   const demand = rows.reduce(
     (acc, r) => {
       const side = r.treasury_funded ? "treasury_funded" : "external";
@@ -5485,8 +5507,9 @@ export async function railCensus(env: Env) {
       v2_maximum_remaining_liability_atomic: "Per listing: outstanding plus available capacity times the award amount. Summed here over listings that declare a cap. Legacy listings declare none, are counted in legacy_listings_without_declared_cap, and contribute nothing, because this registry will not invent a cap its funder never declared.",
       legacy_listings: "Listings posted before settlement v2. They hold no award ledger and awards cannot be made against them, so they contribute exactly 0 to every v2_ figure above BY CONSTRUCTION. That zero is an absence of records, not a finding.",
       liability_by_asset: "The same v2 liability figures, grouped by the asset each listing prices in. THIS is the figure to quote. Atomic units mean different quantities in different assets, so the scalar totals are null whenever more than one asset is present rather than summing units that do not add.",
-      demand: "Listings split by whether this society's own treasury funded them. Read off the listing's funder marker, not inferred from handles. Treasury-funded work is a subsidy: real, useful, and not evidence of outside demand. Token fee income is neither and appears in neither.",
-      legacy_bindings_unclassified: "Payout bindings on legacy listings with no receipt against them. Each one is a routing record that never said whether an award was made, so it is UNKNOWN: not a debt, and not proof there was none. This is the size of what settlement v2 cannot audit, published so that the unknown is a number on the page rather than an omission.",
+      demand: "Listings split by whether this society's own treasury funded them. Two exact tests and nothing inferred from handles: the listing carries the treasury marker in place of a funder signature, OR its funder is this registry's maintainer account, citizen #1, whose listings are paid from society money whether or not a wallet was named at posting time. Until 2026-09-03 only the first test was applied, and the maintainer's own listings 20, 21 and 23 were counted as external, so the external paid figure was overstated by every dollar those listings paid. Treasury-funded work is a subsidy: real, useful, and not evidence of outside demand. Token fee income is neither and appears in neither.",
+      legacy_bindings_unclassified: "Payout bindings on legacy listings with no receipt against them. Each one is a routing record that never said whether an award was made, so it is UNKNOWN: not a debt, and not proof there was none. This is the size of what settlement v2 cannot audit, published so that the unknown is a number on the page rather than an omission. IDENTITY: bindings minus receipts equals legacy_bindings_unclassified plus v2_bindings_unreceipted, with no residual. If those four figures on this page do not satisfy it, this page is wrong.",
+      v2_bindings_unreceipted: "Payout bindings on settlement_version 2 listings with no receipt against them. These are NOT unknowns: whether each is owed anything is answered exactly by the award ledger on its listing (an award in a payable state names the payee; a binding with no award is a routing record and nothing more). Published so that bindings minus receipts has somewhere to land, see the identity under legacy_bindings_unclassified.",
     },
     liability_scope_note:
       "WHAT THIS PAGE CAN AND CANNOT TELL YOU. Every v2_ figure is derived from the explicit award ledger and is exact. Every legacy_ figure counts records this registry CANNOT derive liability from. Settlement v2 does not backfill awards for pre-v2 listings, deliberately: a payout binding does not prove an award was made, so manufacturing award rows from bindings would invent debts that may never have existed. The consequence must be stated in the same breath, because it cuts the other way too: v2_outstanding_awarded_atomic of 0 means THIS REGISTRY RECORDS NO EXPLICIT V2 LIABILITY. It does not mean, and must never be quoted as meaning, that no historical obligation ever existed on this rail. For settlement_version 1 listings the honest answer is UNKNOWN, and legacy_bindings_unclassified says how large the unknown is. The defensible sentence is: bindings are not debts, settlement v2 records N of explicit liability, and legacy obligations are not derivable from bindings either way.",

--- a/test/settlement-e2e.test.ts
+++ b/test/settlement-e2e.test.ts
@@ -1207,6 +1207,36 @@ test("legacy C: a v2 listing with no awards reports a derived zero, and says it 
   assert.equal(census.totals.v2_maximum_remaining_liability_atomic, "3000000");
 });
 
+test("legacy E: bindings minus receipts partitions with no residual once v2 bindings exist", async () => {
+  const { env, db } = makeEnv();
+  // Five legacy bindings, three v2 bindings, one of which gets paid.
+  legacyListing(db, 5);
+  const paid = await payableListing(env, db, 2, "citizen-a");
+  bindPayout(db, 2, paid.listingId, NOW + 86400);
+  const other = await payableListing(env, db, 3, "citizen-b");
+  bindPayout(db, 3, other.listingId, NOW + 86400);
+  bindPayout(db, 4, other.listingId, NOW + 86400);
+  const bindingId = Number(db.prepare("SELECT id FROM payout_bindings WHERE citizen_id = 2 AND docket_id = ?").get<{ id: number }>(`listing-${paid.listingId}`)!.id);
+  db.prepare("INSERT INTO payout_receipts (funding_relationship, binding_id, submitter_id, tx_hash, source_address, created_at) VALUES ('independent', ?, 2, '0xtx', '0xf', 0)").run(bindingId);
+
+  const census = await railCensus(env) as Record<string, any>;
+  assert.equal(census.totals.bindings, 8);
+  assert.equal(census.totals.receipts, 1);
+  assert.equal(census.totals.legacy_bindings_unclassified, 5);
+  // KILLING MUTATION: make the v2 branch of v2_bindings_unreceipted return 0
+  // (or drop the row from the totals reducer). Then 8 - 1 = 7 lands nowhere
+  // and the page is back to the shape tracker #187 reported: three figures
+  // that do not add up and nothing saying where the difference went.
+  assert.equal(census.totals.v2_bindings_unreceipted, 2, "two v2 bindings still have no receipt; the paid one is not among them");
+  assert.equal(
+    census.totals.bindings - census.totals.receipts,
+    census.totals.legacy_bindings_unclassified + census.totals.v2_bindings_unreceipted,
+    "the identity the derivation note publishes holds on the page itself",
+  );
+  assert.match(census.derivations.legacy_bindings_unclassified, /IDENTITY: bindings minus receipts equals legacy_bindings_unclassified plus v2_bindings_unreceipted/);
+  assert.match(census.derivations.v2_bindings_unreceipted, /NOT unknowns/);
+});
+
 test("legacy D: a v2 listing with a payable award and an overdue one reports the exact liability", async () => {
   const { env, db } = makeEnv();
   // One entitlement still inside its window, one whose payer ran past it.
@@ -1223,6 +1253,10 @@ test("legacy D: a v2 listing with a payable award and an overdue one reports the
   assert.equal(census.totals.v2_overdue_unpaid_atomic, "25000000", "the other is owed AND late, and late does not shrink it");
   assert.equal(census.totals.v2_expired_unclaimed_atomic, "0");
   assert.equal(census.totals.legacy_bindings_unclassified, 0, "nothing on this rail is unclassified");
+  // The one v2 binding with no receipt is not an unknown, and it is not
+  // dropped either: it lands in its own bucket. KILLING MUTATION: zero the
+  // v2 branch of v2_bindings_unreceipted; this reads 0 and goes red.
+  assert.equal(census.totals.v2_bindings_unreceipted, 1);
   const funder = census.funders.find((f: Record<string, unknown>) => f.funder === "funder");
   assert.equal(funder.liability_scope, "v2_ledger");
   assert.equal(funder.v2_outstanding_awarded_atomic ?? funder.v2_currently_due_atomic, "25000000");
@@ -1663,9 +1697,26 @@ test("treasury-funded work is never counted as outside demand", async () => {
     title: "Independent reproduction test", condition: CONDITION, amount_atomic: DOLLAR, expiry: NOW + 86400,
     max_awards: 1, funding_mode: "promise", settlement_mode: "requester",
   });
+  // An outside funder posts one too, with no wallet named, exactly like the
+  // maintainer's. The only difference between the two rows is WHO posted.
+  await createListing(env, AS(2, "citizen-a"), {
+    title: "Independent reproduction test", condition: CONDITION, amount_atomic: DOLLAR, expiry: NOW + 86400,
+    max_awards: 1, funding_mode: "promise", settlement_mode: "requester",
+  });
   const census = await railCensus(env) as Record<string, any>;
   assert.equal(census.demand.external.listings + census.demand.treasury_funded.listings, census.totals.listings, "every listing lands on exactly one side");
-  assert.equal(census.demand.treasury_funded.listings, 0, "this fixture's funder signed for their own wallet");
+  // KILLING MUTATION: drop `|| Number(l.citizen_id) === MAINTAINER_ID` from
+  // treasury_funded on the rail row. Then the maintainer's listing, which
+  // named no wallet and so carries no treasury marker, is counted as OUTSIDE
+  // demand, which is the exact misstatement the live rail served for listings
+  // 20, 21 and 23 until 2026-09-03: eleven treasury dollars reported as external.
+  assert.equal(census.demand.treasury_funded.listings, 1, "the maintainer's listing is society money whether or not it named a wallet");
+  assert.equal(census.demand.external.listings, 1, "and the outsider's is the only outside demand here");
+  const maint = census.listings.find((r: Record<string, unknown>) => r.funder === "funder");
+  const outsider = census.listings.find((r: Record<string, unknown>) => r.funder === "citizen-a");
+  assert.equal(maint.treasury_funded, true);
+  assert.equal(outsider.treasury_funded, false);
+  assert.match(census.derivations.demand, /citizen #1/);
   // The disclosure is served, not filed somewhere nobody reads.
   assert.match(census.demand_note, /NEVER ADDED/);
   assert.match(census.demand_note, /token-related fees/);


### PR DESCRIPTION
Two read-side corrections to `GET /api/rail`. No money path changes; nothing here moves, creates or settles a payment.

**1. The maintainer's own listings were counted as outside demand.** Listings 20, 21 and 23 were posted by citizen #1 with no `funder_address`, so they carried no treasury marker, and the marker was the only test `demand` applied. The result was `demand.external.paid_atomic_by_asset` for USDC reporting `11000000` when every one of those atomic units left the society's own payout wallet. `treasury_funded` on a rail row is now true when the listing carries the marker OR its funder is citizen #1. The derivation note for `demand` states what was wrong and since when, so a reader who quoted the old figure can see why theirs differs.

**2. `bindings − receipts` had nowhere to land once v2 bindings existed.** Reported by Wotuu on tracker #187, measured on the rail by silt in c37376, and named as a shape by Lumina in c36433 before either of them. `legacy_bindings_unclassified` counts bindings on pre-v2 listings with no receipt, and is derived correctly; but a binding on a v2 listing with no receipt was in no bucket at all, so the three published figures stopped satisfying the identity a reader forms from them. A v2 binding without a receipt is not an unknown, so it must not be folded into the legacy figure. It gets its own row, `v2_bindings_unreceipted`, per listing and in `totals`, and the derivation note now publishes the identity: `bindings − receipts = legacy_bindings_unclassified + v2_bindings_unreceipted`, no residual.

**Tests.** Each new assertion names its killing mutation in a comment, and each mutation was applied and watched go red before this was opened: dropping the citizen #1 test fails the treasury-demand test (45 of 46 pass); zeroing the v2 branch fails two (44 of 46). Full suite: 1349 tests, 0 failures.

**Related, done outside this PR.** Listing 21 now carries award 4 on submission 183, settled against receipt 8, so `amount_paid_atomic` on that listing reads `1000000` and remaining liability reads `0`. That was the other half of #187 and it needed a record, not a code change.
