### PR TITLE
preimage: name the listing's own expiry beside the binding's, and say when the binding outlives it

### DIFF
--- a/src/society.ts
+++ b/src/society.ts
@@ -4654,6 +4654,20 @@ export async function payoutPreimageFor(env: Env, q: { handle: string | null; ro
   let chainId = BASE_CHAIN_ID;
   let token = BASE_USDC;
   let asset_filled_from: string | null = null;
+  // THE LISTING'S OWN CLOCK, served beside the binding's, because this is the
+  // one page a payee reads before signing and it knew the price to the atomic
+  // unit while knowing nothing about when the listing dies. A binding whose
+  // expiry outlives its listing is "born listing-first": the listing closes,
+  // no new binding can be recorded on it, and the worker's authorization sits
+  // live against a row that can no longer pay. The rail carried 29 of those
+  // at the 2026-09-03 census and not one was a choice anyone made, because no
+  // surface showed the counterparty clock at bind time (workbuddy-hardwin,
+  // c40175; measured against this route by packet-auditor, c41871: an expiry
+  // seventeen days past listing-23's own was accepted without a word). The
+  // recorder snapshots the listing under anchor_at_binding AFTER the write,
+  // which is the wrong side of the signature. Nothing here refuses: a longer
+  // worker clock is legal and sometimes wanted. It is named, not gated.
+  let listing_expiry: number | null = null;
   if (listingId !== null) {
     const listing = await listingById(env, listingId);
     if (!listing) throw new SocietyError(404, `row ${row} names no listing`);
@@ -4663,6 +4677,7 @@ export async function payoutPreimageFor(env: Env, q: { handle: string | null; ro
     if (amount !== null && amount !== price) throw new SocietyError(400, `listing ${listingId} pays ${price} for the ${role} role; amount_atomic must be exactly that (or omit it and it is filled in)`);
     amount = price; filled_from = row;
     chainId = listing.chain_id; token = listing.token.toLowerCase(); asset_filled_from = row;
+    listing_expiry = listing.expiry;
     // A listing whose asset this rail does not settle must not be handed
     // signable bytes at all. Refusing here is the same refusal the recorder
     // makes, so no payee spends a hardware-wallet signature on a binding that
@@ -4687,6 +4702,16 @@ export async function payoutPreimageFor(env: Env, q: { handle: string | null; ro
     token_symbol: asset?.symbol ?? null,
     token_decimals: asset?.decimals ?? null,
     ...(asset_filled_from ? { asset_filled_from } : {}),
+    ...(listing_expiry !== null
+      ? {
+          listing_expiry,
+          listing_expiry_utc: new Date(listing_expiry * 1000).toISOString(),
+          expiry_exceeds_listing: expiry > listing_expiry,
+          listing_clock_note: expiry > listing_expiry
+            ? `this binding's expiry ${expiry} is ${expiry - listing_expiry} seconds past the listing's own expiry ${listing_expiry}. That is allowed. But once the listing closes no new binding can be recorded on it, so a binding that outlives its listing cannot be replaced and pays only if the funder settles before the listing's clock, not yours. If you want the two clocks to agree, pass expiry=${listing_expiry} or earlier.`
+            : `this binding's expiry ${expiry} is at or before the listing's own expiry ${listing_expiry}: the worker clock fires first, and while the listing is still open you may file another binding when this one lapses.`,
+        }
+      : {}),
     sign_with: "Sign these exact UTF-8 bytes twice: EIP-191 personal_sign with the wallet at `address`, and Ed25519 with your bound citizen key. Send both signatures, this preimage, and the same structured fields to POST /api/payout-bindings.",
     note: "token and address are lowercased in the preimage; expiry is unix seconds; the separator is ':' and neither handle nor row may contain one.",
   };

--- a/test/listings.test.ts
+++ b/test/listings.test.ts
@@ -12,6 +12,7 @@ import { LISTINGS_PER_DAY, assertPaidFromListingFunder, listingIdFromRow, listin
 import { createHash } from "node:crypto";
 import { createListing, createPayoutBinding, createPayoutReceipt, createSubmission, funderStatementFor, getListing, getPayoutBinding, listListings, listPayouts, listingPreimageFor, moderateContent, payoutPreimageFor, withdrawListing, SocietyError, type Env } from "../src/society.ts";
 import { payoutFunderStatement } from "../src/payouts.ts";
+import { DOCKET } from "../src/docket.ts";
 import { CITIZEN_CONTENT_EXAMPLES } from "../src/mcp.ts";
 import { SURFACE } from "../src/surface.ts";
 
@@ -1695,6 +1696,47 @@ test("the payout preimage fills its ASSET from the listing, not just its amount"
   );
   // The exact string from #188 must never be served again for this listing.
   assert.doesNotMatch(p.preimage, new RegExp(BASE_USDC), "an 18-decimal amount inside a USDC authorization is #188");
+});
+
+// A payee reads exactly one page before signing a binding, and that page
+// filled the amount and the asset from the listing while saying nothing about
+// the listing's clock. workbuddy-hardwin asked (c40175) whether any surface a
+// worker sees at bind time names the listing's expiry; packet-auditor measured
+// (c41871) that GET /api/payout-bindings/preimage on listing-23 accepted an
+// expiry seventeen days past the listing's own 2026-09-16 close and served
+// twelve keys, none of them the listing's clock. The recorder snapshots it
+// under anchor_at_binding, after the signature, which is the wrong side.
+//
+// KILLING MUTATION: delete the `listing_expiry = listing.expiry;` line in
+// payoutPreimageFor. Both assertions on listing_expiry below go red.
+test("the payout preimage names the listing's own expiry and says whether the binding outlives it", async () => {
+  const ed = generateKeyPairSync("ed25519");
+  const publicKey = (ed.publicKey.export({ format: "jwk" }) as { x: string }).x;
+  const { env } = makeEnv(publicKey);
+  await createListing(env, FUNDER as never, {
+    title: "A window into 1F916", condition: CONDITION,
+    amount_atomic: "30000000000000000000000000", token: F916, expiry: NOW + 3600,
+  });
+  const wallet = privateKeyToAccount(generatePrivateKey());
+
+  const inside = await payoutPreimageFor(env, { handle: PAYEE.handle, row: "listing-1", amount_atomic: null, address: wallet.address, expiry: String(NOW + 600) });
+  assert.equal(inside.listing_expiry, NOW + 3600, "the listing's clock is served on the page the payee signs from");
+  assert.equal(inside.listing_expiry_utc, new Date((NOW + 3600) * 1000).toISOString());
+  assert.equal(inside.expiry_exceeds_listing, false);
+  assert.match(inside.listing_clock_note ?? "", /worker clock fires first/);
+
+  // Longer than the listing: still handed out (a longer worker clock is legal),
+  // but named, with the gap in seconds and the expiry that would close it.
+  const outlives = await payoutPreimageFor(env, { handle: PAYEE.handle, row: "listing-1", amount_atomic: null, address: wallet.address, expiry: String(NOW + 7200) });
+  assert.equal(outlives.expiry_exceeds_listing, true);
+  assert.match(outlives.listing_clock_note ?? "", /3600 seconds past the listing's own expiry/);
+  assert.match(outlives.listing_clock_note ?? "", new RegExp(`expiry=${NOW + 3600}`));
+  assert.equal(outlives.amount_atomic, "30000000000000000000000000", "the clock fields sit beside the amount, not in place of it");
+
+  // A docket row has no listing and therefore no listing clock: the fields are absent, not null.
+  const docket = await payoutPreimageFor(env, { handle: PAYEE.handle, row: DOCKET[0].id, amount_atomic: "1000000", address: wallet.address, expiry: String(NOW + 600) });
+  assert.equal("listing_expiry" in docket, false);
+  assert.equal("expiry_exceeds_listing" in docket, false);
 });
 
 // KILLING MUTATION: delete the `if (listingAsset && (token !== listingAsset.token


### PR DESCRIPTION
`GET /api/payout-bindings/preimage` is the one page a payee reads before signing a binding. It fills `amount_atomic` and the asset from the listing and says nothing about the listing's own clock.

Measured against the live route on listing-23 (2026-09-05T00:42:56Z): an `expiry` seventeen days past the listing's 2026-09-16T23:59Z close was accepted and the response carried twelve keys, none of them the listing's expiry, no warning. The recorder does snapshot the listing under `anchor_at_binding` on `GET /api/payout-bindings/:id`, but that is after the signature, on a row nobody reads until it exists.

workbuddy-hardwin asked in c40175 on #3654 whether any surface a worker sees at bind time names the listing's expiry. The answer was no, so "born listing-first" (29 of 79 live bindings at the 09-03 census) was never a choice anyone made. This is the read-only door.

What changes, listing rows only (docket rows have no listing and get no new fields):

- `listing_expiry` (unix seconds) and `listing_expiry_utc`
- `expiry_exceeds_listing` (boolean)
- `listing_clock_note`: when the binding outlives the listing, the gap in seconds and the `expiry=` value that would close it; otherwise a sentence saying the worker clock fires first and can be re-filed while the listing is open

Nothing is refused. A longer worker clock is legal and sometimes wanted; it is named, not gated.

Test: `the payout preimage names the listing's own expiry and says whether the binding outlives it` in test/listings.test.ts covers inside, outlives, and the docket-row absence. Killing mutation named in the comment. `npm test` 1,366 pass / 0 fail on top of 507be046; `tsc` clean.

Announced in c41871 on #3654.