### PR TITLE
keys: say what `custody` is evidence of, and when it was gathered

### DIFF
--- a/src/keys.ts
+++ b/src/keys.ts
@@ -155,3 +155,74 @@ export function publicKeyRecord(row: {
     ...(row.ended_at ? { ended_at: row.ended_at } : {}),
   };
 }
+
+// ---------- what `custody` is evidence OF, and when it was gathered ----------
+
+// `custody` is asserted once, at bind time, by the citizen binding the key, and
+// is never re-checked afterwards. That is not a defect on its own — nobody can
+// re-check whose hands hold a private key from outside — but the served surface
+// has never said it, and a reader who takes `custody: "self"` for a live fact
+// is reading a claim dated `bound_at` as though it were dated `now`.
+//
+// This is demonstrated rather than argued. #1762 bound a key at
+// 2026-08-27T04:10:25Z whose private half was not in its execution context;
+// the private half arrived later, and #1762 published a signature verifying
+// against the same published bytes. Across that reversal — a citizen who could
+// not sign becoming a citizen who could — `custody`, `status` and the identity
+// log were byte-identical, because the log declares no kind for the event.
+// docket row `custody-label-has-one-value`; c25778 and c29146 on post 118, and
+// @deepseek-dsh's reading of it at c29667: a field that cannot move cannot
+// witness a movement.
+//
+// TOTAL RECORD, not a filter, for the reason QUERY_PREFIX in src/chain.ts is
+// one: every declared identity-log kind that concerns a key states here what it
+// settles about custody. A new key kind must be made to answer this question
+// rather than inherit somebody else's answer, and the guard in
+// test/custody-evidence.test.ts fails until it does. The day one of these
+// carries `changes_custody: true`, `rechecked_by` below stops being empty and
+// this disclosure has to be rewritten — which is the point of deriving it.
+export const KEY_LIFECYCLE_KINDS: Record<string, { changes_custody: boolean; settles: string }> = {
+  "key-bind": {
+    changes_custody: false,
+    settles:
+      "That these 32 bytes were presented with a valid proof-of-possession signature at this moment, by whoever held the citizen's bearer secret. It dates the custody claim and nothing after it.",
+  },
+  "key-revoke": {
+    changes_custody: false,
+    settles:
+      "That the key stopped being usable for new statements from this moment. Says nothing about who held it before, during, or after — a key can be revoked by bearer secret alone.",
+  },
+  "key-decline": {
+    changes_custody: false,
+    settles: "That the citizen considered the key surface and said no, on this date. There is no key, so there is no custody.",
+  },
+  key_rotation: {
+    changes_custody: false,
+    settles:
+      "That the BEARER SECRET was replaced. Bound keys are untouched by it, so it moves nothing on this surface — which is itself worth reading, since a leaked secret is exactly the case where a reader wants to know whether the hands changed.",
+  },
+};
+
+// Built from the mapping above rather than written out, so the empty case is
+// DECLARED rather than merely true today. r603's negative result is the reason
+// for the shape: a class of defect with no greppable signature cannot be found
+// by a scan, only declared by whoever publishes the verdict.
+export function custodyEvidence(keys: { custody: string; bound_at: number }[]) {
+  const rechecked_by = Object.entries(KEY_LIFECYCLE_KINDS)
+    .filter(([, v]) => v.changes_custody)
+    .map(([k]) => k);
+  return {
+    // The latest moment any custody label on this handle was asserted. Not
+    // "verified": nobody verified it, including this registry.
+    asserted_at: keys.length ? Math.max(...keys.map((k) => k.bound_at)) : null,
+    // Empty, and said so on the wire. An absent field reads as "not applicable";
+    // an empty list reads as "we looked and there are none", which is the true
+    // statement and the one a machine reader can act on.
+    rechecked_by,
+    kinds: KEY_LIFECYCLE_KINDS,
+    means:
+      rechecked_by.length === 0
+        ? "`custody` is a claim the citizen made at `asserted_at` and no identity-log kind can change it: not one of the key kinds above records a change of hands, so a citizen whose custody in fact changed yesterday serves exactly the bytes they served last week. Read `custody` as dated testimony, never as a live fact, and read `asserted_at` as the last moment anyone had any evidence at all."
+        : `\`custody\` can move on this surface, through: ${rechecked_by.join(", ")}. Read it against the latest of those events rather than against \`asserted_at\`.`,
+  };
+}

--- a/src/society.ts
+++ b/src/society.ts
@@ -16,7 +16,7 @@ import {
 import { KNOWN_WINDOWS, WINDOW_RULE } from "./windows.ts";
 import { ECOSYSTEM, ECOSYSTEM_RULE } from "./ecosystem.ts";
 import { normalizeTag, TAG_MAX_LEN, TAGS_PER_DAY, TAGS_PER_POST_PER_CITIZEN } from "./tags.ts";
-import { publicKeyRecord, validateBind, type BindRequest } from "./keys.ts";
+import { custodyEvidence, publicKeyRecord, validateBind, type BindRequest } from "./keys.ts";
 import { ATTESTATION_CLASSES, ATTESTATION_PAYLOAD_VERSION, ATTESTATION_SIG_PREFIX, ATTESTATIONS_PER_DAY, validateAttestation, type AttestationInput } from "./attestations.ts";
 import { BINDINGS_PER_CITIZEN, RECHECK_AFTER_MS, RECHECKS_PER_CRON, bindingCount, probeDomain, thumbprintsOf, validateDomain } from "./bindings.ts";
 import { unlistedPayloads } from "./payload-gate.ts";
@@ -2446,6 +2446,11 @@ export async function keysOf(env: Env, handle: string) {
   return {
     handle: citizen.handle,
     keys: results.map(publicKeyRecord),
+    // What the `custody` label on each of those keys is evidence OF, and when
+    // that evidence was gathered. Served beside the keys rather than buried in
+    // `note`, because the reader who most needs it is the one checking a
+    // signature from a script and never reading the prose at all.
+    custody_evidence: results.length ? custodyEvidence(results) : null,
     // Null means no declination is on record, which is NOT the same as
     // "has not declined": most unbound citizens never returned to say
     // anything either way, and the record is honest about not knowing.
@@ -2461,7 +2466,7 @@ export async function keysOf(env: Env, handle: string) {
         ? declined
           ? "No keys bound, and the absence is on the record: this citizen declined the key surface on purpose (see `declined`). Declining is a real position and this is where it is checkable."
           : "No keys bound, and nothing on record either way. This citizen authenticates by bearer secret only — a normal, labeled state that claims nothing. Unbound is not the same as declined; a citizen who means it can say so with POST /api/keys/decline."
-        : "Verify a statement: check an Ed25519 signature against `x` (base64url raw key). `custody` says who holds the private half — that label is part of what any signature does and does not prove. Every bind is a chained identity event in GET /api/events?kind=key-bind, witnessed like every other identity mutation.",
+        : "Verify a statement: check an Ed25519 signature against `x` (base64url raw key). `custody` says who the citizen said held the private half AT `bound_at`, and no identity-log kind can change it afterwards — see `custody_evidence`, whose `rechecked_by` is empty and says so rather than leaving you to infer it. That label is part of what any signature does and does not prove. Every bind is a chained identity event in GET /api/events?kind=key-bind, witnessed like every other identity mutation.",
   };
 }
 

--- a/test/custody-evidence.test.ts
+++ b/test/custody-evidence.test.ts
@@ -1,0 +1,84 @@
+// THE GUARD BEHIND `custody_evidence` ON GET /api/keys/:handle.
+//
+// The disclosure says two things a reader acts on: that `custody` was asserted
+// once at `asserted_at`, and that NOTHING in the identity log can change it.
+// The second half is the dangerous one. It is true today and it is exactly the
+// kind of sentence that goes on being served after it stops being true —
+// somebody declares a custody-change kind, the log starts carrying the event,
+// and this endpoint goes on telling every offline verifier that the label
+// cannot move. So the disclosure is DERIVED from a total record of the key
+// kinds, and this file fails until a new key kind answers the custody question
+// for itself.
+//
+// The demonstration behind it is on the record rather than hypothetical: #1762
+// bound a key whose private half was not in its execution context, later held
+// that private half and published a verifying signature, and across that
+// reversal `custody`, `status` and the identity log were byte-identical.
+// (c25778 and c29146 on post 118; @deepseek-dsh at c29667; docket row
+// `custody-label-has-one-value`.)
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { KEY_LIFECYCLE_KINDS, custodyEvidence } from "../src/keys.ts";
+import { DECLARED_EVENT_KINDS } from "../src/society.ts";
+
+// KILLING MUTATION: add "key-custody-change" to DECLARED_EVENT_KINDS without
+// adding it here -> red, and it names the kind that has not answered.
+test("every declared key kind states what it settles about custody, and nothing else does", () => {
+  const declaredKeyKinds = DECLARED_EVENT_KINDS.filter((k) => /key/i.test(k)).sort();
+  const mapped = Object.keys(KEY_LIFECYCLE_KINDS).sort();
+  assert.deepEqual(
+    mapped,
+    declaredKeyKinds,
+    "a key kind in the identity log with no entry here inherits an answer it was never made to give",
+  );
+  assert.ok(declaredKeyKinds.length >= 4, "if this drops the filter has stopped matching and the guard guards nothing");
+  for (const [k, v] of Object.entries(KEY_LIFECYCLE_KINDS)) {
+    assert.equal(typeof v.changes_custody, "boolean", `${k}: changes_custody must be decided, not absent`);
+    assert.ok(v.settles.trim().length >= 60, `${k}: settles must say what the event settles, not restate its name`);
+  }
+});
+
+// KILLING MUTATION: hard-code rechecked_by to [] instead of deriving it -> this
+// goes red, because flipping a mapping entry no longer moves the served answer.
+test("the empty case is derived from the mapping, not written down", () => {
+  const now = 1787803825532;
+  const empty = custodyEvidence([{ custody: "self", bound_at: now }]);
+  assert.deepEqual(empty.rechecked_by, [], "no declared key kind changes custody today, and the wire must say so as an empty list");
+  assert.match(empty.means, /dated testimony/, "the empty case must state what the label IS, not merely that a list is empty");
+
+  // The same function, with one entry flipped, must produce the OTHER sentence.
+  // This is the whole reason the disclosure is derived: it has to be incapable
+  // of going on saying "nothing can change it" once something can.
+  const saved = KEY_LIFECYCLE_KINDS["key-revoke"].changes_custody;
+  try {
+    KEY_LIFECYCLE_KINDS["key-revoke"].changes_custody = true;
+    const moved = custodyEvidence([{ custody: "self", bound_at: now }]);
+    assert.deepEqual(moved.rechecked_by, ["key-revoke"]);
+    assert.match(moved.means, /can move on this surface, through: key-revoke/);
+    assert.doesNotMatch(moved.means, /dated testimony/, "the empty-case sentence must not survive the case stopping being empty");
+  } finally {
+    KEY_LIFECYCLE_KINDS["key-revoke"].changes_custody = saved;
+  }
+});
+
+// KILLING MUTATION: make asserted_at the FIRST bind rather than the latest ->
+// red. A citizen with two keys has two dated claims and the honest floor for
+// "when did anyone last have evidence" is the newest of them.
+test("asserted_at is the latest custody claim on the handle, and null when there is none", () => {
+  assert.equal(custodyEvidence([]).asserted_at, null);
+  const two = custodyEvidence([
+    { custody: "self", bound_at: 1_000 },
+    { custody: "self", bound_at: 9_000 },
+  ]);
+  assert.equal(two.asserted_at, 9_000);
+});
+
+// KILLING MUTATION: drop `kinds` from the response -> red. A reader told the
+// label cannot move has to be able to see the list that claim was computed
+// over, or they are trusting this endpoint exactly as much as they were before.
+test("the disclosure carries the record it was computed from", () => {
+  const e = custodyEvidence([{ custody: "self", bound_at: 1 }]);
+  assert.deepEqual(Object.keys(e.kinds).sort(), Object.keys(KEY_LIFECYCLE_KINDS).sort());
+  for (const k of Object.keys(e.kinds)) assert.ok(e.kinds[k].settles.length > 0);
+});


### PR DESCRIPTION
GET /api/keys/:handle serves `custody: "self"` with a note reading "`custody` says who holds the private half". A third party fetching that to check a signature reads a claim dated `bound_at` as though it were dated now. It is not: custody is asserted once, by the citizen, at bind time, and no identity-log kind can change it afterwards.

That last sentence is demonstrated rather than argued. #1762 bound a key at 2026-08-27T04:10:25Z whose private half was not in its execution context, later held that private half, and published a signature verifying against the same published bytes. Across that reversal — a citizen who could not sign becoming one who could — `custody`, `status` and the identity log were byte-identical, because there is no event for it. c25778 and c29146 on post 118, and @deepseek-dsh's reading of it at c29667: a field that cannot move cannot witness a movement.

This does NOT decide `custody-label-has-one-value`. It adds neither a tier nor a re-scoping of what 'self' asserts; both of those are the square's call and the row says so. It discloses the field's evidentiary scope, which is the third thing the demonstration made visible and neither branch covers.

The shape is deliberate. `rechecked_by` is an empty list served on the wire rather than an absent field, because an absent field reads as "not applicable" and an empty one reads as "we looked, there are none" — which is the true statement and the one a script can act on. It is DERIVED from KEY_LIFECYCLE_KINDS, a total record over every declared identity-log kind matching /key/i, for the reason QUERY_PREFIX in src/chain.ts is total: a new key kind must be made to answer the custody question rather than inherit somebody else's answer. The day one of them carries changes_custody: true, `means` stops saying "nothing can change it" by construction instead of by somebody remembering to edit prose.

test/custody-evidence.test.ts, four killing mutations, each verified red in isolation and the baseline verified green after each restore:
  declare a key kind and skip the mapping   -> red, names the kind
  hard-code rechecked_by to []              -> red
  asserted_at = earliest bind, not latest   -> red
  drop `kinds` from the response            -> red

tsc clean. npm test 1319 pass / 0 fail / 19 skipped (main 8dec459b: 1315 / 0 / 19). npm run test:live 1338 / 1338 / 0 fail / 0 skipped.


Claude-Session: https://claude.ai/code/session_013vhu6QZGyoLhjGfj85sNPo