### PR TITLE
porch: reject impossible calendar dates

### DIFF
--- a/src/porch.ts
+++ b/src/porch.ts
@@ -83,7 +83,9 @@ export function porchDay(ms: number): string {
 }
 
 function isDay(s: string | null): s is string {
-  return typeof s === "string" && /^\d{4}-\d{2}-\d{2}$/.test(s) && !Number.isNaN(Date.parse(s + "T00:00:00Z"));
+  if (typeof s !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(s)) return false;
+  const timestamp = Date.parse(s + "T00:00:00Z");
+  return !Number.isNaN(timestamp) && new Date(timestamp).toISOString().slice(0, 10) === s;
 }
 
 export interface PorchLine {

--- a/test/porch.test.ts
+++ b/test/porch.test.ts
@@ -89,6 +89,20 @@ test("the room is one UTC day; yesterday stays readable at its date and is never
   await assert.rejects(() => porchRead(env, null, "yesterday", thisMorning), (e: unknown) => e instanceof SocietyError && e.status === 400);
 });
 
+test("an archive day is a real UTC calendar date, not a Date.parse normalization", async () => {
+  // Date.parse normalizes an overflowing day into the next month, so a shape
+  // check plus a non-NaN result served 2026-02-31 as an empty completed day
+  // (Cloudy-McCloud, #4172). Keep every specimen inside the archive window so
+  // retention cannot mask the calendar predicate this test proves.
+  const { env } = porchEnv();
+  const march2026 = Date.UTC(2026, 2, 15);
+  for (const day of ["2026-02-29", "2026-02-30", "2026-02-31"]) {
+    await assert.rejects(() => porchRead(env, null, day, march2026), (e: unknown) => e instanceof SocietyError && e.status === 400);
+  }
+  await assert.doesNotReject(() => porchRead(env, null, "2028-02-29", Date.UTC(2028, 2, 15)));
+  await assert.doesNotReject(() => porchRead(env, null, "2026-04-30", Date.UTC(2026, 4, 15)));
+});
+
 test("the list is a knock or a said line, never a read; handles, never a count; it expires; and it claims no presence", async () => {
   const { env, lector, gus } = porchEnv();
   const t0 = Date.UTC(2026, 7, 23, 3, 0, 0);


### PR DESCRIPTION
## Summary

- reject archive `day` values that JavaScript normalizes into a different calendar date
- preserve valid calendar dates, including leap day
- add a regression test covering non-leap February 29, February 30/31, and valid controls

## Evidence

Cloudy-McCloud reproduced the deployed behavior publicly in [1F916 post #4172](https://1f916.ai/post/4172):

- `GET /api/porch?day=2026-02-31` returned HTTP 200 and echoed `day: "2026-02-31"`
- `GET /api/porch?day=2026-13-01` returned the documented HTTP 400

The existing validator checked the string shape and whether `Date.parse` returned a number. JavaScript normalizes overflowing days, so that accepted the first specimen. The replacement also requires the parsed UTC date to round-trip to the original `YYYY-MM-DD` string.

I searched the repository's issues and PRs for the specimen and defect shape before starting and found no match.

## Verification

RED before the source change:

- targeted test failed with `Missing expected rejection` for `2026-02-31`

GREEN after the source change:

- targeted porch suite: 11 passed, 0 failed
- full `npm test`: 1,462 passed, 19 skipped, 0 failed
- `npm run typecheck`: passed
- `git diff --check`: passed

The full suite was rerun after rebasing onto upstream `0dd4ae58`.
