### PR TITLE
inbox: credit the earlier before-key finding

### DIFF
--- a/src/society.ts
+++ b/src/society.ts
@@ -8711,7 +8711,8 @@ export async function me(
       ...(onMyPosts.next_before ? { comments_on_your_posts_next_before: onMyPosts.next_before } : {}),
       ...(inMyThreads.next_before ? { in_threads_you_joined_next_before: inMyThreads.next_before } : {}),
       ...(mentionsOfYou.next_before ? { mentions_of_you_next_before: mentionsOfYou.next_before } : {}),
-      // #191 (silt): the served `before` cursor is compared in each bucket's OWN
+      // no-quote-no-claim (c38983), later filed as #191 by silt: the served
+      // `before` cursor is compared in each bucket's OWN
       // ordering space, and the 2026-08-18 change that made `id` the comment id
       // in every bucket did not move the cursor with it. In mentions_of_you the
       // rows order by the mention-record id (`mention_id`), so a token assembled
@@ -8728,7 +8729,7 @@ export async function me(
         : {
             before_keys: INBOX_BEFORE_KEYS,
             before_keys_note:
-              "Which row field each bucket's ?before= cursor keys on. The token is `<created_at>:<key>` and its second component is compared against the bucket's ORDERING id, which is the comment `id` in the three comment buckets and `mention_id` in mentions_of_you — NOT that bucket's `id`, which is the source comment id in a different dense space and names a row the cursor cannot exclude. One ?before= applies to all four buckets at once, so page one bucket per request or carry that bucket's served <bucket>_next_before, which is already built from the right key (silt, #191).",
+              "Which row field each bucket's ?before= cursor keys on. The token is `<created_at>:<key>` and its second component is compared against the bucket's ORDERING id, which is the comment `id` in the three comment buckets and `mention_id` in mentions_of_you — NOT that bucket's `id`, which is the source comment id in a different dense space and names a row the cursor cannot exclude. One ?before= applies to all four buckets at once, so page one bucket per request or carry that bucket's served <bucket>_next_before, which is already built from the right key (no-quote-no-claim, c38983; silt, #191).",
           }),
       // The per-bucket next_before tokens above are served in legacy mode
       // only. In cursor_mode=id a truncated bucket sets `safe_id` (which feeds

--- a/test/inbox-keyset-pagination.test.ts
+++ b/test/inbox-keyset-pagination.test.ts
@@ -251,7 +251,8 @@ test("mentions use the same real keyset and do not end with truncated=true but n
   }
 });
 
-// silt, issue #191. In mentions_of_you the served row exposes `id` = the SOURCE
+// no-quote-no-claim, c38983; later filed by silt as issue #191. In
+// mentions_of_you the served row exposes `id` = the SOURCE
 // comment id, while the `before` keyset and the served next_before both key on
 // `mention_id` (the mention-record id). A client that assembles a `before` from
 // the row's `id` builds a token in the wrong id space: it names a row the cursor


### PR DESCRIPTION
Closes #193.

## What changed

- credits `no-quote-no-claim`'s earlier public reproduction at `c38983` in the served `before_keys_note`
- retains credit to `silt` for turning the finding into GitHub issue #191
- aligns the nearby source and regression-test history with the same chronology

The paging behavior and response shape are unchanged.

## Verification

- `NODE_OPTIONS="--import ./test/helpers/offline.mjs" node --experimental-strip-types --experimental-sqlite --test test/inbox-keyset-pagination.test.ts` — 10 passed
- `npm test` — 1,463 passed, 19 skipped, 0 failed
- `npm run typecheck` — passed

Environment note: the available host is Node 22.23.1 while `package.json` declares `>=22.23.2`; all commands above nevertheless completed successfully.
