### PR TITLE
test: live probes fail closed on unreachability and missing markers

### DIFF
--- a/test/live-probe-gate.test.ts
+++ b/test/live-probe-gate.test.ts
@@ -83,3 +83,23 @@ test("the deterministic suite is the default and the live one is opt-in", () => 
   assert.match(pkg.scripts["test:live"], /LIVE_PROBES=1/, "`npm run test:live` turns them on");
   assert.ok(pkg.scripts["test:all"], "and there is one command that runs both");
 });
+
+test("the live lane does not skip on unreachability or a missing deployment marker", () => {
+  // #151 remaining: LIVE_PROBES=1 used to skip those two cases, so a green
+  // live run could mean "could not check". npm test still skips via
+  // LIVE_SKIP_REASON when the probes are off; that skip is the gate, not a hole.
+  const dir = new URL("./", import.meta.url);
+  for (const f of ["schema.test.ts", "param-home.test.ts"]) {
+    const src = readFileSync(new URL(f, dir), "utf8");
+    assert.equal(
+      /t\.skip\(`API unreachable/.test(src),
+      false,
+      `${f} still skips when the API is unreachable under LIVE_PROBES=1`,
+    );
+    assert.equal(
+      /t\.skip\(`new contract not deployed yet/.test(src),
+      false,
+      `${f} still skips when a deployment marker is missing under LIVE_PROBES=1`,
+    );
+  }
+});

--- a/test/param-home.test.ts
+++ b/test/param-home.test.ts
@@ -64,8 +64,8 @@ const liveOrSkip = async (t: { skip: (why: string) => void }, url: string): Prom
     return await liveFetch(url, { headers: { "User-Agent": "1f916-param-home-check/1.0" } });
   } catch (e) {
     if (e instanceof RateLimited) throw e;
-    t.skip(`API unreachable: ${(e as Error).message}`);
-    return null;
+    // #151 remaining: LIVE_PROBES=1 must fail closed on an unreachable API.
+    throw new Error(`API unreachable: ${(e as Error).message}`);
   }
 };
 

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -398,13 +398,13 @@ for (const [path, schemaFile, deploymentMarker] of endpoints) {
       // report `fail 0` with every probe silently skipped, so "checked" and
       // "could not check" produced the same summary line.
       if (e instanceof RateLimited || e instanceof ProbeRefused) throw e;
-      t.skip(`API unreachable: ${e.message}`);
-      return;
+      // #151 remaining: unreachable and undeployed used to skip green under
+      // LIVE_PROBES=1. The live lane is supposed to fail closed.
+      throw new Error(`API unreachable: ${e instanceof Error ? e.message : e}`);
     }
     const markerPresent = (marker) => marker.split(".").reduce((o, k) => (o != null && typeof o === "object" ? o[k] : undefined), data) !== undefined;
     if (deploymentMarker && !markerPresent(deploymentMarker)) {
-      t.skip(`new contract not deployed yet: missing ${deploymentMarker}`);
-      return;
+      throw new Error(`new contract not deployed yet: missing ${deploymentMarker}`);
     }
     const schema = loadSchema(schemaFile);
     const errors = validate(schema, data);


### PR DESCRIPTION
Closes nothing yet — slice of #151 remaining work.

## Problem
The deterministic/live split already shipped. Under `LIVE_PROBES=1`, schema and param-home probes still called `t.skip` when fetch failed or a deployment marker was absent. A green live run could mean the contract was not checked.

## Change
- `test/schema.test.ts`: throw on unreachability and on a missing deployment marker.
- `test/param-home.test.ts`: throw on unreachability (429 still fails via `RateLimited`).
- `test/live-probe-gate.test.ts`: forbids restoring those two skip strings.
- `npm test` still skips via `LIVE_SKIP_REASON` when probes are off.

Not in this PR: moving files under `test/live/`, serial pacing, daily workflow, origin-locked helper inventory.

## Tests
- `npm test`: 1534 tests, 1515 pass, 0 fail, 19 LIVE_PROBES-off skips.
- `npm run typecheck`: pass.

I am not merging this.