### PR TITLE
test: origin-lock liveFetch to anonymous HTTPS GET at one per second

### DIFF
--- a/test/helpers/live.ts
+++ b/test/helpers/live.ts
@@ -37,6 +37,9 @@ export const LIVE_PROBES = process.env.LIVE_PROBES === "1";
 export const LIVE_SKIP_REASON =
   "live probes are off; run `npm run test:live` (or LIVE_PROBES=1 npm test) to check the deployment";
 
+export const LIVE_ORIGIN = "https://1f916.ai";
+export const LIVE_MIN_INTERVAL_MS = 1000;
+
 export class RateLimited extends Error {}
 
 // A 400 is not unreachability. The deployment answered, read the request, and
@@ -54,17 +57,59 @@ export class RateLimited extends Error {}
 // skipping and this stays the narrow case it was written for.
 export class ProbeRefused extends Error {}
 
+let lastLiveFetchAt = 0;
+
+function assertLiveRequest(url: string, init?: RequestInit): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error("liveFetch refuses an unparseable url: " + url);
+  }
+  if (parsed.origin !== LIVE_ORIGIN) {
+    throw new Error("liveFetch is origin-locked to " + LIVE_ORIGIN + "; got " + parsed.origin + ".");
+  }
+  const method = (init?.method ?? "GET").toUpperCase();
+  if (method !== "GET") {
+    throw new Error("liveFetch is GET-only; got " + method + ".");
+  }
+  if (init?.body != null) {
+    throw new Error("liveFetch refuses a request body.");
+  }
+  if (init?.credentials !== undefined && init.credentials !== "omit") {
+    throw new Error("liveFetch is anonymous: credentials must be omit.");
+  }
+  if (init?.redirect !== undefined && init.redirect !== "error") {
+    throw new Error("liveFetch does not follow redirects.");
+  }
+}
+
+async function pace(): Promise<void> {
+  const now = Date.now();
+  const wait = lastLiveFetchAt === 0 ? 0 : LIVE_MIN_INTERVAL_MS - (now - lastLiveFetchAt);
+  if (wait > 0) await new Promise((done) => setTimeout(done, wait));
+  lastLiveFetchAt = Date.now();
+}
+
 // One retry, then fail. The limiter's window is ten seconds, so a single wait
 // clears an incidental collision with another reader; a second 429 means the
 // probe genuinely cannot see the deployment and must say so out loud.
 export async function liveFetch(url: string, init?: RequestInit): Promise<Response> {
+  assertLiveRequest(url, init);
+  const locked: RequestInit = {
+    ...init,
+    method: "GET",
+    credentials: "omit",
+    redirect: "error",
+  };
   for (let attempt = 0; attempt < 2; attempt++) {
-    const r = await fetch(url, init);
+    await pace();
+    const r = await fetch(url, locked);
     if (r.status !== 429) return r;
     if (attempt === 0) await new Promise((done) => setTimeout(done, 11_000));
   }
   throw new RateLimited(
-    `${url} -> 429 twice. The probe did not run, which is not the same as passing. ` +
-      `Re-run when the per-IP limit has cleared rather than reading this as green.`,
+    url + " -> 429 twice. The probe did not run, which is not the same as passing. " +
+      "Re-run when the per-IP limit has cleared rather than reading this as green.",
   );
 }

--- a/test/live-fetch-lock.test.ts
+++ b/test/live-fetch-lock.test.ts
@@ -1,0 +1,59 @@
+// Origin lock, GET-only, anonymous, no-follow, one-per-second pace for liveFetch.
+// Slice of issue #151 remaining work. These tests stub fetch so they stay in
+// the deterministic suite. A green run here is not evidence the live lane ran.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { liveFetch, LIVE_MIN_INTERVAL_MS } from "./helpers/live.ts";
+
+test("liveFetch origin lock GET-only anonymous no-follow and pace", async (t) => {
+  await t.test("refuses a stranger origin before opening a socket", async () => {
+    await assert.rejects(() => liveFetch("https://example.com/api/pulse"), /origin-locked/);
+  });
+  await t.test("refuses http even on the locked host", async () => {
+    await assert.rejects(() => liveFetch("http://1f916.ai/api/pulse"), /origin-locked/);
+  });
+  await t.test("is GET-only", async () => {
+    await assert.rejects(() => liveFetch("https://1f916.ai/api/pulse", { method: "POST" }), /GET-only/);
+  });
+  await t.test("refuses a request body", async () => {
+    await assert.rejects(() => liveFetch("https://1f916.ai/api/pulse", { body: "x" }), /request body/);
+  });
+  await t.test("refuses credentials", async () => {
+    await assert.rejects(() => liveFetch("https://1f916.ai/api/pulse", { credentials: "include" }), /anonymous/);
+  });
+  await t.test("refuses following redirects", async () => {
+    await assert.rejects(() => liveFetch("https://1f916.ai/api/pulse", { redirect: "follow" }), /does not follow redirects/);
+  });
+  await t.test("pins GET omit credentials and redirect error", async () => {
+    const originalFetch = globalThis.fetch;
+    const seen: RequestInit[] = [];
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      seen.push(init ?? {});
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+    try {
+      const r = await liveFetch("https://1f916.ai/api/pulse", { headers: { "User-Agent": "gate-test/1.0" } });
+      assert.equal(r.status, 200);
+      assert.equal(seen.length, 1);
+      assert.equal(seen[0].method, "GET");
+      assert.equal(seen[0].credentials, "omit");
+      assert.equal(seen[0].redirect, "error");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+  await t.test("paces at least one second between sockets", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => new Response("{}", { status: 200 })) as typeof fetch;
+    try {
+      const t0 = Date.now();
+      await liveFetch("https://1f916.ai/api/pulse");
+      await liveFetch("https://1f916.ai/api/new");
+      const elapsed = Date.now() - t0;
+      assert.ok(elapsed >= LIVE_MIN_INTERVAL_MS, "paced " + elapsed + "ms");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/test/live-probe-gate.test.ts
+++ b/test/live-probe-gate.test.ts
@@ -103,3 +103,13 @@ test("the live lane does not skip on unreachability or a missing deployment mark
     );
   }
 });
+
+test("liveFetch is an anonymous origin-locked HTTPS GET paced at one per second", () => {
+  const src = readFileSync(new URL("./helpers/live.ts", import.meta.url), "utf8");
+  assert.match(src, /LIVE_ORIGIN = "https:\/\/1f916.ai"/);
+  assert.match(src, /LIVE_MIN_INTERVAL_MS = 1000/);
+  assert.match(src, /credentials: "omit"/);
+  assert.match(src, /redirect: "error"/);
+  assert.match(src, /parsed.origin !== LIVE_ORIGIN/);
+  assert.match(src, /method !== "GET"/);
+});


### PR DESCRIPTION
Closes nothing yet — slice of #151 remaining work.

## Problem
The deterministic/live split and fail-closed skips already shipped. `liveFetch` still accepted any URL, method, body, credentials, and redirect mode, and fired as fast as the runner allowed. A probe that posts, follows a stranger redirect, or bursts past the edge limiter is not the anonymous production check #151 asked for.

## Change
- `test/helpers/live.ts`: refuse a non-`https://1f916.ai` origin, a non-GET method, a body, credentials other than `omit`, and `redirect: follow`; pin GET / omit / `redirect: error` on the socket; pace at least 1000ms between requests.
- `test/live-fetch-lock.test.ts`: stub `fetch` so the lock and the pace stay in `npm test`.
- `test/live-probe-gate.test.ts`: pin origin, interval, and locked init fields.

Not in this PR: moving files under `test/live/`, daily workflow, mechanical inventory of unrun probes.

## Tests
- `npm test`: 1544 tests, 1525 pass, 0 fail, 19 LIVE_PROBES-off skips.
- `npm run typecheck`: pass.

I am not merging this.
