### PR TITLE
ci: add a daily read-only live-probe workflow

### DIFF
--- a/.github/workflows/live.yml
+++ b/.github/workflows/live.yml
@@ -1,0 +1,40 @@
+# Daily live-lane. Remaining slice of #151.
+#
+# `npm test` is the PR verdict. This workflow is not. It reads the currently deployed service
+# on a schedule, so a red here is a fact about production (network, rate limit,
+# undeployed marker, or contract drift) and is never a verdict on an undeployed
+# pull-request diff. test.yml already runs `npm run test:live` with
+# continue-on-error on push/PR; that still cannot cover hours when the only
+# commits are witness/ paths-ignore drops. A schedule is the missing caller.
+#
+# What this deliberately does NOT do: gate merge, write to the tree, or
+# persist checkout credentials. contents: read. persist-credentials: false.
+name: live
+on:
+  schedule:
+    # Offset from witness.yml's hourly :07 backstop so the two do not stack.
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+permissions:
+  contents: read
+concurrency:
+  group: live
+  cancel-in-progress: true
+jobs:
+  live:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      # Pin the commit, not the floating major. v4.4.0.
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          persist-credentials: false
+      # Pin the commit, not the floating major. v4.4.0.
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: "22.23.2"
+          cache: npm
+      - run: npm ci
+      # The live lane only. A green here means the deployed contract was
+      # exercised, not that an undeployed change is safe.
+      - run: npm run test:live

--- a/test/live-probe-gate.test.ts
+++ b/test/live-probe-gate.test.ts
@@ -113,3 +113,46 @@ test("liveFetch is an anonymous origin-locked HTTPS GET paced at one per second"
   assert.match(src, /parsed.origin !== LIVE_ORIGIN/);
   assert.match(src, /method !== "GET"/);
 });
+
+test("a daily read-only live workflow checks the deployment, not a pull request", () => {
+  // #151 remaining: test.yml runs test:live on push/PR with continue-on-error.
+  // That still misses hours whose only commits are witness/ (paths-ignore).
+  // The daily workflow is the caller for the deployed contract.
+  const yml = readFileSync(new URL("../.github/workflows/live.yml", import.meta.url), "utf8");
+  assert.match(yml, /^name:\s*live\s*$/m);
+  assert.match(yml, /schedule:/);
+  assert.match(yml, /cron:\s*"17 6 \* \* \*"/);
+  assert.match(yml, /permissions:\s*\n\s*contents:\s*read/);
+  assert.match(yml, /persist-credentials:\s*false/);
+  assert.match(yml, /timeout-minutes:\s*30/);
+  assert.match(yml, /concurrency:\s*\n\s*group:\s*live/);
+  assert.match(yml, /run:\s*npm run test:live/);
+  assert.equal(/run:\s*npm test\b/.test(yml), false, "the daily live lane must not run the deterministic suite as its verdict");
+  assert.match(yml, /uses:\s*actions\/checkout@[0-9a-f]{40}/);
+  assert.match(yml, /uses:\s*actions\/setup-node@[0-9a-f]{40}/);
+  assert.equal(/uses:\s*actions\/checkout@v\d/.test(yml), false, "checkout must be pinned to a commit, not a floating tag");
+  assert.equal(/uses:\s*actions\/setup-node@v\d/.test(yml), false, "setup-node must be pinned to a commit, not a floating tag");
+  assert.match(yml, /currently deployed service/);
+});
+
+test("the live-probe inventory is the three files that call liveFetch", () => {
+  // #151 remaining: a mechanical inventory of production probes. Helper-lock
+  // tests import liveFetch to stub fetch; they do not read the deployment.
+  // A new liveFetch import outside this list is an unlisted probe until the
+  // list moves with it. The physical move under test/live/ is a later slice.
+  const dir = new URL("./", import.meta.url);
+  const callers: string[] = [];
+  for (const f of testFiles(dir)) {
+    if (f === "helpers/live.ts") continue;
+    if (f === "live-fetch-lock.test.ts") continue;
+    if (f === "live-probe-gate.test.ts") continue;
+    const src = readFileSync(new URL(f, dir), "utf8");
+    if (!/from "\.\/helpers\/live\.ts"/.test(src)) continue;
+    if (/(?<![.\w])liveFetch\s*\(/.test(src)) callers.push(f);
+  }
+  assert.deepEqual(
+    callers.sort(),
+    ["ledger-tx-migration.test.ts", "param-home.test.ts", "schema.test.ts"],
+    `liveFetch callers changed: ${callers.join(", ")}`,
+  );
+});


### PR DESCRIPTION
Remaining slice of #151. Does not close the issue.

## Problem

`npm test` is offline. `npm run test:live` already exists, and `.github/workflows/test.yml` runs it on push/PR with `continue-on-error`. That still cannot cover hours whose only commits are `witness/` (`paths-ignore`). Issue #151 asked for a daily scheduled workflow with read-only permissions, pinned action commits, concurrency, timeouts, and non-persisted checkout credentials, and for that lane to validate the currently deployed service rather than an undeployed pull-request diff.

Fail-closed skips, origin-lock, and one-request-per-second pacing already shipped. The physical move under `test/live/` is not in this PR.

## Change

- `.github/workflows/live.yml`: daily `17 6 * * *` plus `workflow_dispatch`; `permissions.contents: read`; `persist-credentials: false`; checkout and setup-node pinned to commit SHAs (v4.4.0); 30-minute timeout; runs `npm run test:live` only.
- `test/live-probe-gate.test.ts`: pins those workflow properties, and pins the production `liveFetch` inventory to `schema.test.ts`, `param-home.test.ts`, and `ledger-tx-migration.test.ts`.

## Tests

- focused `test/live-probe-gate.test.ts`: 6 passed, 0 failed
- `npm test`: 1546 tests, 1527 passed, 19 skipped, 0 failed
- `npm run typecheck`: passed
- `git diff --check`: passed

I am not merging this.