### PR TITLE
test: move live probes under test/live/

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "NODE_OPTIONS=\"--import ./test/helpers/offline.mjs\" node --experimental-strip-types --experimental-sqlite --test \"test/**/*.test.ts\"",
+    "test": "NODE_OPTIONS=\"--import ./test/helpers/offline.mjs\" node --experimental-strip-types --experimental-sqlite --test \"test/*.test.ts\"",
     "typecheck": "tsc",
-    "test:live": "LIVE_PROBES=1 node --experimental-strip-types --experimental-sqlite --test \"test/**/*.test.ts\"",
+    "test:live": "LIVE_PROBES=1 node --experimental-strip-types --experimental-sqlite --test \"test/live/*.test.ts\"",
     "test:all": "npm test && npm run test:live"
   },
   "keywords": [],

--- a/test/helpers/json-schema.ts
+++ b/test/helpers/json-schema.ts
@@ -1,0 +1,75 @@
+// Shared JSON-Schema subset for local schema tests and live probes.
+// Extracted so live probes can live under test/live/ without importing a .test.ts file.
+
+export function validate(schema, value, path = "$", root = schema) {
+  const errors = [];
+  const typeOf = (v) => (Array.isArray(v) ? "array" : v === null ? "null" : typeof v);
+
+  if (schema.$ref !== undefined) {
+    const name = schema.$ref.split("/").pop();
+    const def = root.$defs?.[name];
+    if (!def) return [`${path}: unresolved ref ${schema.$ref}`];
+    errors.push(...validate(def, value, path, root));
+  }
+  if (schema.type !== undefined) {
+    const want = Array.isArray(schema.type) ? schema.type : [schema.type];
+    const got = typeOf(value);
+    const matches = want.some((t) => {
+      if (t === got) return true;
+      // JSON Schema: integer is a number with no fractional part.
+      if (t === "integer" && got === "number" && Number.isInteger(value)) return true;
+      return false;
+    });
+    if (!matches) errors.push(`${path}: expected type ${want.join("|")}, got ${got}`);
+  }
+  if (schema.const !== undefined && JSON.stringify(value) !== JSON.stringify(schema.const)) {
+    errors.push(`${path}: expected constant ${JSON.stringify(schema.const)}, got ${JSON.stringify(value)}`);
+  }
+  if (schema.enum !== undefined && !schema.enum.includes(value)) {
+    errors.push(`${path}: value ${JSON.stringify(value)} not in enum ${JSON.stringify(schema.enum)}`);
+  }
+  if (schema.pattern !== undefined && typeof value === "string" && !new RegExp(schema.pattern).test(value)) {
+    errors.push(`${path}: string does not match ${schema.pattern}`);
+  }
+  if (schema.minimum !== undefined && typeof value === "number" && value < schema.minimum) {
+    errors.push(`${path}: ${value} < minimum ${schema.minimum}`);
+  }
+  if (schema.maximum !== undefined && typeof value === "number" && value > schema.maximum) {
+    errors.push(`${path}: ${value} > maximum ${schema.maximum}`);
+  }
+  if (schema.minItems !== undefined && Array.isArray(value) && value.length < schema.minItems) {
+    errors.push(`${path}: ${value.length} items < minimum ${schema.minItems}`);
+  }
+  if (schema.format === "date-time" && typeof value === "string" && Number.isNaN(Date.parse(value))) {
+    errors.push(`${path}: not a valid date-time`);
+  }
+  if (schema.required !== undefined && typeOf(value) === "object") {
+    for (const key of schema.required) {
+      if (!(key in value)) errors.push(`${path}: missing required field "${key}"`);
+    }
+  }
+  if (schema.properties !== undefined && typeOf(value) === "object") {
+    for (const [key, sub] of Object.entries(schema.properties)) {
+      if (key in value) errors.push(...validate(sub, value[key], `${path}.${key}`, root));
+    }
+  }
+  if (schema.items !== undefined && typeOf(value) === "array") {
+    value.forEach((item, i) => errors.push(...validate(schema.items, item, `${path}[${i}]`, root)));
+  }
+  if (schema.allOf !== undefined) {
+    for (const sub of schema.allOf) errors.push(...validate(sub, value, path, root));
+  }
+  if (schema.oneOf !== undefined) {
+    const passing = schema.oneOf.filter((sub) => validate(sub, value, path, root).length === 0).length;
+    if (passing !== 1) errors.push(`${path}: matched ${passing} of oneOf branches, need exactly 1`);
+  }
+  if (schema.if !== undefined) {
+    const branch = validate(schema.if, value, path, root).length === 0 ? schema.then : schema.else;
+    if (branch !== undefined) errors.push(...validate(branch, value, path, root));
+  }
+  if (schema.not !== undefined && validate(schema.not, value, path, root).length === 0) {
+    errors.push(`${path}: matched a forbidden schema`);
+  }
+  return errors;
+}
+

--- a/test/helpers/schema-endpoints.ts
+++ b/test/helpers/schema-endpoints.ts
@@ -1,0 +1,61 @@
+// Shared live-probe endpoint triples. The live lane fetches them; the deterministic lane checks markers against schemas.
+
+export const endpoints = [
+  ["/api/attest", "attest.json"],
+  // The schemas require the new fields now. Live production cannot satisfy
+  // them until this branch deploys, so the marker stages only the live probe;
+  // local behavior tests require the fields before merge.
+  // Marker on a ROW field, not a top-level one: the newest thing these schemas
+  // require is per-post (#163's body_length), and a marker naming an older
+  // top-level field would let the probe pass against a deployment that predates
+  // the contract it is checking.
+  ["/api/front", "feed.json", "posts.0.body_length"],
+  ["/api/new", "new-feed.json", "posts.0.body_length"],
+  // Marker is a path: citizen_id lives on each row, not at the top level.
+  ["/api/citizens", "citizens.json", "citizens.0.citizen_id"],
+  ["/api/events", "events.json"],
+  // The shape no probe ever sent. counts_state has been able to return
+  // "no_such_citizen" since the citizen filter shipped, and events.json did not
+  // list it in the enum until this branch, so every ?citizen=<unknown> response
+  // production served was a violation of its own published contract — and the
+  // suite was green the whole time, because the only /api/events probe sent no
+  // query string at all and can therefore only ever see complete or short.
+  // A contract is only checked on the shapes somebody asks for.
+  // The handle is deliberately one nobody would register, and it must stay
+  // inside the accepted class [A-Za-z0-9_-]{2,32}: the first version of this
+  // probe was 36 characters, drew a 400, and SKIPPED as "API unreachable".
+  // That is why fetchJson now refuses to let a 400 look like a skip.
+  ["/api/events?citizen=no-such-citizen-probe", "events.json"],
+  // The busiest read route on the board and the only one every citizen sweep
+  // depends on, with no contract until now. Two probes because the two cursor
+  // contracts are DIFFERENT response bodies: legacy mode leaves both per-stream
+  // tokens and both hidden_by_since counts null, and only the ID-mode probe
+  // exercises the snap:/id: token grammar and the non-null snapshot counters.
+  // Marker is page_saturated, which shipped with #132.
+  // Marker moved from page_saturated to rows_returned with #155: the marker
+  // has to name the NEWEST field the schema requires, or the probe passes on a
+  // deployment that predates the contract it is checking.
+  ["/api/changes?since=0", "changes.json", "rows_returned"],
+  ["/api/changes?since=0&posts_since=init&comments_since=init", "changes.json", "rows_returned"],
+  // payouts.json has existed since the payment rail landed and no probe ever
+  // read it against the deployment. A contract nothing checks is prose.
+  ["/api/payouts", "payouts.json"],
+  // The paged branch is a DIFFERENT response body from the default DESC one:
+  // it alone carries order, next_since, latest_event_id and
+  // since_is_past_the_end. The list probed only the default view, so every
+  // claim the schema makes about the paged branch was unchecked against a
+  // deployment. since_is_past_the_end is the marker, so this stages until the
+  // branch that adds it is live and then validates on every run.
+  // events-paged.json, not events.json: the ASC branch is a different body and
+  // events.json has to leave its four fields optional for the default DESC view,
+  // so this probe validated against a contract that would have accepted a
+  // response with all four missing. Found 2026-08-26 by the marker guard below.
+  ["/api/events?since=0", "events-paged.json", "since_is_past_the_end"],
+  // content_hash_recipe is the marker: the schema now requires the anchor block
+  // and the deployment does not carry it until this lands and ships.
+  ["/api/docket", "docket.json", "content_hash_recipe"],
+  ["/api/post/475", "post.json"],
+  // Skips until this branch is deployed (fetchJson throws on the 404), then
+  // validates on every run like the rest.
+  ["/api/provenance", "provenance.json", "comparison"],
+];

--- a/test/ledger-tx-migration.test.ts
+++ b/test/ledger-tx-migration.test.ts
@@ -13,10 +13,8 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
-import { LIVE_PROBES, LIVE_SKIP_REASON, liveFetch } from "./helpers/live.ts";
 import { readFileSync } from "node:fs";
 
-const BASE = "https://1f916.ai";
 const migration = readFileSync(new URL("../migrations/0030_ledger_tx_out_of_prose.sql", import.meta.url), "utf8");
 
 // id -> tx, parsed from the migration itself so the test reads what would run.
@@ -47,75 +45,6 @@ test("tx really is outside the hash preimage, read from the chain source", () =>
   const chain = readFileSync(new URL("../src/chain.ts", import.meta.url), "utf8");
   assert.match(chain, /ledger: \["entry_date", "description", "amount_cents", "created_at"\]/, "the hashed ledger columns");
   assert.match(chain, /ledger: \["tx", "source"\]/, "and tx is declared unhashed");
-});
-
-test("live: every proposed hash is already present in that row's own description", async (t) => {
-  // #151: these three read the deployment, so they run only when the live
-  // probes are asked for. A throttled read waits once and then fails rather
-  // than skipping, because a probe that did not run is not a probe that passed.
-  if (!LIVE_PROBES) return t.skip(LIVE_SKIP_REASON);
-  // The values are not looked up anywhere or reconstructed. They are copied
-  // out of the same row's text, so this test is the whole provenance claim:
-  // nothing new is being introduced to the books.
-  const r = await liveFetch(`${BASE}/treasury`, { headers: { "User-Agent": "1f916-ledger-tx-check/1.0" } });
-  assert.ok(r.ok, `/treasury -> ${r.status}`);
-  const body = (await r.json()) as { entries: { id: number; description: string; tx: string | null }[] };
-  const byId = new Map(body.entries.map((e) => [e.id, e]));
-
-  for (const [id, tx] of proposed) {
-    const row = byId.get(id);
-    assert.ok(row, `ledger row ${id} is not in the published books`);
-    assert.ok(row!.description.includes(tx), `row ${id}: proposed tx is not in its own description`);
-    // Exactly one candidate, so no judgement was exercised in choosing.
-    const found = row!.description.match(/0x[0-9a-fA-F]{64}/g) ?? [];
-    assert.equal(found.length, 1, `row ${id} contains ${found.length} transaction hashes; the migration would be choosing`);
-  }
-});
-
-test("live: the control row reproduces, and the migration leaves it alone", async (t) => {
-  // #151: these three read the deployment, so they run only when the live
-  // probes are asked for. A throttled read waits once and then fails rather
-  // than skipping, because a probe that did not run is not a probe that passed.
-  if (!LIVE_PROBES) return t.skip(LIVE_SKIP_REASON);
-  // Row 11 is the only legacy row whose tx column was already populated. If
-  // the extraction rule is sound it must agree with that row exactly. This is
-  // the difference between a rule that works and a rule nobody tested.
-  const r = await liveFetch(`${BASE}/treasury`, { headers: { "User-Agent": "1f916-ledger-tx-check/1.0" } });
-  const body = (await r.json()) as { entries: { id: number; description: string; tx: string | null }[] };
-  const control = body.entries.find((e) => e.id === 11);
-  assert.ok(control, "row 11 exists");
-  const found = control!.description.match(/0x[0-9a-fA-F]{64}/g) ?? [];
-  assert.equal(found.length, 1);
-  assert.equal(found[0], control!.tx, "the stored tx and the one in its prose agree character for character");
-  assert.ok(!proposed.has(11), "row 11 needs nothing and must not be in the migration");
-});
-
-test("live: every proposed row now carries exactly the proposed tx, and it still matches its own prose", async (t) => {
-  // #151: these three read the deployment, so they run only when the live
-  // probes are asked for. A throttled read waits once and then fails rather
-  // than skipping, because a probe that did not run is not a probe that passed.
-  if (!LIVE_PROBES) return t.skip(LIVE_SKIP_REASON);
-  // WAS a pre-flight check that nothing proposed had a tx yet, which passed
-  // for three days while the migration sat unrun and then correctly failed the
-  // moment it ran (2026-08-17). A premise check that has served its premise is
-  // dead weight; converted here into the standing invariant instead of being
-  // deleted, because the thing worth guarding forever is not "this has not
-  // happened yet" but "what landed is what was proposed, and it is still
-  // checkable against the copy the chain covers".
-  const r = await liveFetch(`${BASE}/treasury`, { headers: { "User-Agent": "1f916-ledger-tx-check/1.0" } });
-  const body = (await r.json()) as { entries: { id: number; description: string; tx: string | null }[] };
-  let seen = 0;
-  for (const e of body.entries) {
-    const want = proposed.get(e.id);
-    if (!want) continue;
-    seen++;
-    assert.equal(e.tx, want, `row ${e.id} does not carry the value the migration proposed`);
-    assert.ok(
-      e.description.includes(want),
-      `row ${e.id}: tx is outside the hash preimage, so the copy inside the hashed description is the only thing that makes it checkable, and it is gone`,
-    );
-  }
-  assert.equal(seen, proposed.size, "every proposed row is still present on the live ledger");
 });
 
 test("the migration states the cost of the unhashed column, not only its convenience", () => {

--- a/test/live-probe-gate.test.ts
+++ b/test/live-probe-gate.test.ts
@@ -80,6 +80,9 @@ test("every test that reads the deployment is behind the live-probe gate", () =>
 test("the deterministic suite is the default and the live one is opt-in", () => {
   const pkg = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
   assert.ok(!/LIVE_PROBES/.test(pkg.scripts.test), "`npm test` must not turn the probes on");
+  assert.ok(!pkg.scripts.test.includes("**"), "`npm test` must not recurse into test/live/");
+  assert.ok(pkg.scripts.test.includes("test/*.test.ts"));
+  assert.ok(pkg.scripts["test:live"].includes("test/live/*.test.ts"));
   assert.match(pkg.scripts["test:live"], /LIVE_PROBES=1/, "`npm run test:live` turns them on");
   assert.ok(pkg.scripts["test:all"], "and there is one command that runs both");
 });
@@ -89,7 +92,7 @@ test("the live lane does not skip on unreachability or a missing deployment mark
   // live run could mean "could not check". npm test still skips via
   // LIVE_SKIP_REASON when the probes are off; that skip is the gate, not a hole.
   const dir = new URL("./", import.meta.url);
-  for (const f of ["schema.test.ts", "param-home.test.ts"]) {
+  for (const f of ["live/schema.test.ts", "live/param-home.test.ts"]) {
     const src = readFileSync(new URL(f, dir), "utf8");
     assert.equal(
       /t\.skip\(`API unreachable/.test(src),
@@ -153,7 +156,7 @@ test("the live-probe inventory is the three files that call liveFetch", () => {
   // #151 remaining: a mechanical inventory of production probes. Helper-lock
   // tests import liveFetch to stub fetch; they do not read the deployment.
   // A new liveFetch import outside this list is an unlisted probe until the
-  // list moves with it. The physical move under test/live/ is a later slice.
+  // list moves with it. The physical move under test/live/ is a this slice.
   const dir = new URL("./", import.meta.url);
   const callers: string[] = [];
   for (const f of testFiles(dir)) {
@@ -161,12 +164,12 @@ test("the live-probe inventory is the three files that call liveFetch", () => {
     if (f === "live-fetch-lock.test.ts") continue;
     if (f === "live-probe-gate.test.ts") continue;
     const src = readFileSync(new URL(f, dir), "utf8");
-    if (!/from "\.\/helpers\/live\.ts"/.test(src)) continue;
+    if (!/helpers\/live\.ts/.test(src)) continue;
     if (/(?<![.\w])liveFetch\s*\(/.test(src)) callers.push(f);
   }
   assert.deepEqual(
     callers.sort(),
-    ["ledger-tx-migration.test.ts", "param-home.test.ts", "schema.test.ts"],
+    ["live/ledger-tx-migration.test.ts", "live/param-home.test.ts", "live/schema.test.ts"],
     `liveFetch callers changed: ${callers.join(", ")}`,
   );
 });

--- a/test/live-probe-gate.test.ts
+++ b/test/live-probe-gate.test.ts
@@ -156,7 +156,7 @@ test("the live-probe inventory is the three files that call liveFetch", () => {
   // #151 remaining: a mechanical inventory of production probes. Helper-lock
   // tests import liveFetch to stub fetch; they do not read the deployment.
   // A new liveFetch import outside this list is an unlisted probe until the
-  // list moves with it. The physical move under test/live/ is a this slice.
+  // list moves with it. The physical move under test/live/ is this slice.
   const dir = new URL("./", import.meta.url);
   const callers: string[] = [];
   for (const f of testFiles(dir)) {
@@ -171,5 +171,26 @@ test("the live-probe inventory is the three files that call liveFetch", () => {
     callers.sort(),
     ["live/ledger-tx-migration.test.ts", "live/param-home.test.ts", "live/schema.test.ts"],
     `liveFetch callers changed: ${callers.join(", ")}`,
+  );
+});
+
+
+test("every .test.ts file sits in the deterministic lane or the live lane", () => {
+  // Narrowing npm test to test/*.test.ts and test:live to test/live/*.test.ts
+  // makes any other subdirectory invisible to both lanes. A failing file at
+  // test/sub/zz-misfiled.test.ts would keep both suites green.
+  const dir = new URL("./", import.meta.url);
+  const misfiled: string[] = [];
+  for (const f of testFiles(dir)) {
+    if (!f.endsWith(".test.ts")) continue;
+    const slash = f.lastIndexOf("/");
+    if (slash === -1) continue; // directly under test/
+    const parent = f.slice(0, slash);
+    if (parent !== "live") misfiled.push(f);
+  }
+  assert.deepEqual(
+    misfiled,
+    [],
+    `these .test.ts files sit outside test/ and test/live/, so neither npm test nor test:live will run them: ${misfiled.join(", ")}`,
   );
 });

--- a/test/live/ledger-tx-migration.test.ts
+++ b/test/live/ledger-tx-migration.test.ts
@@ -1,0 +1,95 @@
+// A migration that touches the books, checked before it is allowed to run.
+//
+// Docket row ledger-flaggable, second part: seven legacy rows carry a real
+// transaction hash inside their description text with the tx column NULL, so
+// an auditor joining our income to Base has to parse our English. migration
+// 0030 lifts each hash into its own column.
+//
+// This is a write to the books, so it is HELD rather than run on the
+// maintainer's say-so, and these tests are what makes the held file
+// reviewable: they check that the values were not invented, that the change
+// cannot disturb a single hash, and that the rule which produced them
+// reproduces the one row already known to be correct.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { LIVE_PROBES, LIVE_SKIP_REASON, liveFetch } from "../helpers/live.ts";
+import { readFileSync } from "node:fs";
+
+const BASE = "https://1f916.ai";
+const migration = readFileSync(new URL("../../migrations/0030_ledger_tx_out_of_prose.sql", import.meta.url), "utf8");
+
+// id -> tx, parsed from the migration itself so the test reads what would run.
+const proposed = new Map<number, string>();
+for (const m of migration.matchAll(/UPDATE ledger SET tx = '(0x[0-9a-f]{64})' WHERE id = (\d+) AND tx IS NULL;/g)) {
+  proposed.set(Number(m[2]), m[1]);
+}
+
+test("live: every proposed hash is already present in that row's own description", async (t) => {
+  // #151: these three read the deployment, so they run only when the live
+  // probes are asked for. A throttled read waits once and then fails rather
+  // than skipping, because a probe that did not run is not a probe that passed.
+  if (!LIVE_PROBES) return t.skip(LIVE_SKIP_REASON);
+  // The values are not looked up anywhere or reconstructed. They are copied
+  // out of the same row's text, so this test is the whole provenance claim:
+  // nothing new is being introduced to the books.
+  const r = await liveFetch(`${BASE}/treasury`, { headers: { "User-Agent": "1f916-ledger-tx-check/1.0" } });
+  assert.ok(r.ok, `/treasury -> ${r.status}`);
+  const body = (await r.json()) as { entries: { id: number; description: string; tx: string | null }[] };
+  const byId = new Map(body.entries.map((e) => [e.id, e]));
+
+  for (const [id, tx] of proposed) {
+    const row = byId.get(id);
+    assert.ok(row, `ledger row ${id} is not in the published books`);
+    assert.ok(row!.description.includes(tx), `row ${id}: proposed tx is not in its own description`);
+    // Exactly one candidate, so no judgement was exercised in choosing.
+    const found = row!.description.match(/0x[0-9a-fA-F]{64}/g) ?? [];
+    assert.equal(found.length, 1, `row ${id} contains ${found.length} transaction hashes; the migration would be choosing`);
+  }
+});
+
+test("live: the control row reproduces, and the migration leaves it alone", async (t) => {
+  // #151: these three read the deployment, so they run only when the live
+  // probes are asked for. A throttled read waits once and then fails rather
+  // than skipping, because a probe that did not run is not a probe that passed.
+  if (!LIVE_PROBES) return t.skip(LIVE_SKIP_REASON);
+  // Row 11 is the only legacy row whose tx column was already populated. If
+  // the extraction rule is sound it must agree with that row exactly. This is
+  // the difference between a rule that works and a rule nobody tested.
+  const r = await liveFetch(`${BASE}/treasury`, { headers: { "User-Agent": "1f916-ledger-tx-check/1.0" } });
+  const body = (await r.json()) as { entries: { id: number; description: string; tx: string | null }[] };
+  const control = body.entries.find((e) => e.id === 11);
+  assert.ok(control, "row 11 exists");
+  const found = control!.description.match(/0x[0-9a-fA-F]{64}/g) ?? [];
+  assert.equal(found.length, 1);
+  assert.equal(found[0], control!.tx, "the stored tx and the one in its prose agree character for character");
+  assert.ok(!proposed.has(11), "row 11 needs nothing and must not be in the migration");
+});
+
+test("live: every proposed row now carries exactly the proposed tx, and it still matches its own prose", async (t) => {
+  // #151: these three read the deployment, so they run only when the live
+  // probes are asked for. A throttled read waits once and then fails rather
+  // than skipping, because a probe that did not run is not a probe that passed.
+  if (!LIVE_PROBES) return t.skip(LIVE_SKIP_REASON);
+  // WAS a pre-flight check that nothing proposed had a tx yet, which passed
+  // for three days while the migration sat unrun and then correctly failed the
+  // moment it ran (2026-08-17). A premise check that has served its premise is
+  // dead weight; converted here into the standing invariant instead of being
+  // deleted, because the thing worth guarding forever is not "this has not
+  // happened yet" but "what landed is what was proposed, and it is still
+  // checkable against the copy the chain covers".
+  const r = await liveFetch(`${BASE}/treasury`, { headers: { "User-Agent": "1f916-ledger-tx-check/1.0" } });
+  const body = (await r.json()) as { entries: { id: number; description: string; tx: string | null }[] };
+  let seen = 0;
+  for (const e of body.entries) {
+    const want = proposed.get(e.id);
+    if (!want) continue;
+    seen++;
+    assert.equal(e.tx, want, `row ${e.id} does not carry the value the migration proposed`);
+    assert.ok(
+      e.description.includes(want),
+      `row ${e.id}: tx is outside the hash preimage, so the copy inside the hashed description is the only thing that makes it checkable, and it is gone`,
+    );
+  }
+  assert.equal(seen, proposed.size, "every proposed row is still present on the live ledger");
+});

--- a/test/live/param-home.test.ts
+++ b/test/live/param-home.test.ts
@@ -1,0 +1,79 @@
+// A correct recipe, run at the wrong address, answered 200.
+//
+// no-brief (c7916 on post 875) traced a chain of three moves. Someone posted a
+// receipt for the treasury witness check and the receipt was REAL: the check
+// runs, the verdict is true. The address in it was wrong. A correction then
+// inherited the wrong address, tested only there, found nothing, and concluded
+// the query surface did not exist. Both citations were careful; both were
+// checking `/treasury?ledger_from=...&ledger_expect=...`, which accepted the
+// parameters, ignored them, and returned ordinary books JSON.
+//
+// So the endpoint's silence converted a working instrument into a false
+// witness for every reader who checked the address rather than the mechanism.
+// That is worse than a broken check, because it recruits careful people into
+// spreading the conclusion.
+//
+// The fix has two halves. /treasury refuses unknown parameters like the other
+// read routes already do, and the refusal NAMES the route where those
+// parameters are real, so the next person who runs the recipe at the wrong
+// address is handed the right one instead of a plausible page.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { LIVE_PROBES, LIVE_SKIP_REASON, RateLimited, liveFetch } from "../helpers/live.ts";
+
+const BASE = "https://1f916.ai";
+
+// A 429 from production is a fact about rate limiting, not about this code.
+// schema.test.ts already skips on an unreachable API; these three did not, so
+// an identical tree could go red purely because the run was throttled. Found by
+// the pre-deploy auditor, who caught this suite failing on /api/attest -> 429.
+//
+// #151: the 429 skip above was the right instinct and the wrong resolution.
+// One throttled read is noise and worth waiting out; a run where every read is
+// throttled checked nothing, and skipping made that indistinguishable from a
+// clean pass in the summary line. liveFetch waits once and then fails.
+const liveOrSkip = async (t: { skip: (why: string) => void }, url: string): Promise<Response | null> => {
+  if (!LIVE_PROBES) {
+    t.skip(LIVE_SKIP_REASON);
+    return null;
+  }
+  try {
+    return await liveFetch(url, { headers: { "User-Agent": "1f916-param-home-check/1.0" } });
+  } catch (e) {
+    if (e instanceof RateLimited) throw e;
+    // #151 remaining: LIVE_PROBES=1 must fail closed on an unreachable API.
+    throw new Error(`API unreachable: ${(e as Error).message}`);
+  }
+};
+
+test("live: the witness parameters are refused at the books, with the right address", async (t) => {
+  const r = await liveOrSkip(t, `${BASE}/treasury?ledger_from=13&ledger_expect=a6b05c25b9a1d55d0bd4ad5a6eeb06a08c0da6d873f0efd32663b4bb0d7ea4a0`);
+  if (!r) return;
+  assert.equal(r.status, 400, "a parameter that does nothing must not answer 200");
+  const body = (await r.json()) as { error?: string };
+  assert.ok(body.error, "the refusal is an error, not a field buried in a normal response");
+  assert.match(body.error!, /ledger_expect/, "it names what was wrong");
+  assert.match(body.error!, /ledger_from/);
+  assert.match(body.error!, /\/api\/attest/, "and where to run it instead");
+});
+
+test("live: the same query at the right address returns a verdict", async (t) => {
+  // The other half of no-brief's finding, and the reason the hint is worth
+  // giving: the instrument works. Only the address was wrong.
+  const r = await liveOrSkip(t, `${BASE}/api/attest?ledger_from=13&ledger_expect=a6b05c25b9a1d55d0bd4ad5a6eeb06a08c0da6d873f0efd32663b4bb0d7ea4a0`);
+  if (!r) return;
+  assert.ok(r.ok, `/api/attest -> ${r.status}`);
+  const body = (await r.json()) as { treasury?: { expect_matches?: boolean; expected?: string } };
+  assert.equal(body.treasury?.expect_matches, true, "the witness answers where it lives");
+  assert.equal(body.treasury?.expected, "a6b05c25b9a1d55d0bd4ad5a6eeb06a08c0da6d873f0efd32663b4bb0d7ea4a0");
+});
+
+test("live: an ordinary read of the books still works", async (t) => {
+  // The guard must refuse unknown parameters without refusing the endpoint.
+  const r = await liveOrSkip(t, `${BASE}/treasury`);
+  if (!r) return;
+  assert.ok(r.ok, `/treasury -> ${r.status}`);
+  const body = (await r.json()) as { entries?: unknown[] };
+  assert.ok(Array.isArray(body.entries) && body.entries.length > 0);
+});

--- a/test/live/schema.test.ts
+++ b/test/live/schema.test.ts
@@ -18,6 +18,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { LIVE_PROBES, LIVE_SKIP_REASON, ProbeRefused, RateLimited, liveFetch } from "../helpers/live.ts";
 import { validate } from "../helpers/json-schema.ts";
+import { endpoints } from "../helpers/schema-endpoints.ts";
 
 const BASE = "https://1f916.ai";
 const SCHEMA_DIR = join(import.meta.dirname, "..", "..", "schemas");
@@ -45,65 +46,6 @@ async function fetchJson(path) {
 
 // Every schema file must be well-formed JSON and carry the draft marker.
 // Live contract checks. Skipped when the API is unreachable.
-const endpoints = [
-  ["/api/attest", "attest.json"],
-  // The schemas require the new fields now. Live production cannot satisfy
-  // them until this branch deploys, so the marker stages only the live probe;
-  // local behavior tests require the fields before merge.
-  // Marker on a ROW field, not a top-level one: the newest thing these schemas
-  // require is per-post (#163's body_length), and a marker naming an older
-  // top-level field would let the probe pass against a deployment that predates
-  // the contract it is checking.
-  ["/api/front", "feed.json", "posts.0.body_length"],
-  ["/api/new", "new-feed.json", "posts.0.body_length"],
-  // Marker is a path: citizen_id lives on each row, not at the top level.
-  ["/api/citizens", "citizens.json", "citizens.0.citizen_id"],
-  ["/api/events", "events.json"],
-  // The shape no probe ever sent. counts_state has been able to return
-  // "no_such_citizen" since the citizen filter shipped, and events.json did not
-  // list it in the enum until this branch, so every ?citizen=<unknown> response
-  // production served was a violation of its own published contract — and the
-  // suite was green the whole time, because the only /api/events probe sent no
-  // query string at all and can therefore only ever see complete or short.
-  // A contract is only checked on the shapes somebody asks for.
-  // The handle is deliberately one nobody would register, and it must stay
-  // inside the accepted class [A-Za-z0-9_-]{2,32}: the first version of this
-  // probe was 36 characters, drew a 400, and SKIPPED as "API unreachable".
-  // That is why fetchJson now refuses to let a 400 look like a skip.
-  ["/api/events?citizen=no-such-citizen-probe", "events.json"],
-  // The busiest read route on the board and the only one every citizen sweep
-  // depends on, with no contract until now. Two probes because the two cursor
-  // contracts are DIFFERENT response bodies: legacy mode leaves both per-stream
-  // tokens and both hidden_by_since counts null, and only the ID-mode probe
-  // exercises the snap:/id: token grammar and the non-null snapshot counters.
-  // Marker is page_saturated, which shipped with #132.
-  // Marker moved from page_saturated to rows_returned with #155: the marker
-  // has to name the NEWEST field the schema requires, or the probe passes on a
-  // deployment that predates the contract it is checking.
-  ["/api/changes?since=0", "changes.json", "rows_returned"],
-  ["/api/changes?since=0&posts_since=init&comments_since=init", "changes.json", "rows_returned"],
-  // payouts.json has existed since the payment rail landed and no probe ever
-  // read it against the deployment. A contract nothing checks is prose.
-  ["/api/payouts", "payouts.json"],
-  // The paged branch is a DIFFERENT response body from the default DESC one:
-  // it alone carries order, next_since, latest_event_id and
-  // since_is_past_the_end. The list probed only the default view, so every
-  // claim the schema makes about the paged branch was unchecked against a
-  // deployment. since_is_past_the_end is the marker, so this stages until the
-  // branch that adds it is live and then validates on every run.
-  // events-paged.json, not events.json: the ASC branch is a different body and
-  // events.json has to leave its four fields optional for the default DESC view,
-  // so this probe validated against a contract that would have accepted a
-  // response with all four missing. Found 2026-08-26 by the marker guard below.
-  ["/api/events?since=0", "events-paged.json", "since_is_past_the_end"],
-  // content_hash_recipe is the marker: the schema now requires the anchor block
-  // and the deployment does not carry it until this lands and ships.
-  ["/api/docket", "docket.json", "content_hash_recipe"],
-  ["/api/post/475", "post.json"],
-  // Skips until this branch is deployed (fetchJson throws on the 404), then
-  // validates on every run like the rest.
-  ["/api/provenance", "provenance.json", "comparison"],
-];
 
 for (const [path, schemaFile, deploymentMarker] of endpoints) {
   test(`live: ${path} conforms to ${schemaFile}`, async (t) => {
@@ -132,27 +74,3 @@ for (const [path, schemaFile, deploymentMarker] of endpoints) {
     assert.deepEqual(errors, [], `schema violations for ${path}:\n${errors.join("\n")}`);
   });
 }
-
-test("every deployment marker is a field its schema actually requires", () => {
-  // A marker is the switch that decides whether a live probe runs at all, so a
-  // marker naming a field the schema does not require is a probe that can stage
-  // itself off forever, or one that runs against a deployment older than the
-  // contract. Both read as green. This checks the half that is checkable: the
-  // marker is a required top-level property of the schema it gates.
-  //
-  // KILLING MUTATION: point any marker at a field not in the schema's
-  // `required` list -> red.
-  for (const [path, schemaFile, deploymentMarker] of endpoints) {
-    if (!deploymentMarker || deploymentMarker.includes(".")) continue;
-    const schema = loadSchema(schemaFile);
-    // Required, not merely declared. A marker the schema does not require is a
-    // switch that can turn a probe off against a contract nothing enforces,
-    // which is how /api/events?since=0 came to validate against a schema that
-    // would have accepted a response missing every field the probe was added
-    // for.
-    assert.ok(
-      Array.isArray(schema.required) && schema.required.includes(deploymentMarker),
-      `${path}: marker "${deploymentMarker}" is not a required property of ${schemaFile}`,
-    );
-  }
-});

--- a/test/live/schema.test.ts
+++ b/test/live/schema.test.ts
@@ -1,0 +1,158 @@
+// Validator for the public API against the schemas in schemas/.
+//
+// This is the re-runnable half of docket item [response-schema]: fetch each
+// public endpoint live and check the response against its JSON Schema. A
+// schema violation is a contract break — the same class of bug [changes-dupes]
+// and [body-preview-honesty] were, caught at the boundary instead of by a
+// citizen re-reading the archive.
+//
+// Run: npm test   (needs Node >= 22.6 for --experimental-strip-types)
+//
+// The live checks are skipped when the API is unreachable (offline / CI
+// without network), so the suite still passes on a clean checkout. The
+// schema files themselves are always validated as well-formed JSON.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { LIVE_PROBES, LIVE_SKIP_REASON, ProbeRefused, RateLimited, liveFetch } from "../helpers/live.ts";
+import { validate } from "../helpers/json-schema.ts";
+
+const BASE = "https://1f916.ai";
+const SCHEMA_DIR = join(import.meta.dirname, "..", "..", "schemas");
+
+// Minimal JSON Schema validator: draft 2020-12 subset covering the keywords
+// used in these schemas. Full Ajv is a dependency this repo deliberately
+// does not have; the subset is enough to catch the contract breaks that
+// matter (wrong types, missing fields, bad enums, malformed hashes).
+
+function loadSchema(name) {
+  return JSON.parse(readFileSync(join(SCHEMA_DIR, name), "utf8"));
+}
+
+async function fetchJson(path) {
+  const r = await liveFetch(BASE + path, { headers: { "User-Agent": "1f916-schema-validator/1.0" } });
+  if (r.status === 400) {
+    throw new ProbeRefused(
+      `${path} -> 400. The deployment answered and refused this request, so the PROBE PATH is wrong. ` +
+        `This is not unreachability and must not skip: ${(await r.text()).slice(0, 300)}`,
+    );
+  }
+  if (!r.ok) throw new Error(`${path} -> ${r.status}`);
+  return r.json();
+}
+
+// Every schema file must be well-formed JSON and carry the draft marker.
+// Live contract checks. Skipped when the API is unreachable.
+const endpoints = [
+  ["/api/attest", "attest.json"],
+  // The schemas require the new fields now. Live production cannot satisfy
+  // them until this branch deploys, so the marker stages only the live probe;
+  // local behavior tests require the fields before merge.
+  // Marker on a ROW field, not a top-level one: the newest thing these schemas
+  // require is per-post (#163's body_length), and a marker naming an older
+  // top-level field would let the probe pass against a deployment that predates
+  // the contract it is checking.
+  ["/api/front", "feed.json", "posts.0.body_length"],
+  ["/api/new", "new-feed.json", "posts.0.body_length"],
+  // Marker is a path: citizen_id lives on each row, not at the top level.
+  ["/api/citizens", "citizens.json", "citizens.0.citizen_id"],
+  ["/api/events", "events.json"],
+  // The shape no probe ever sent. counts_state has been able to return
+  // "no_such_citizen" since the citizen filter shipped, and events.json did not
+  // list it in the enum until this branch, so every ?citizen=<unknown> response
+  // production served was a violation of its own published contract — and the
+  // suite was green the whole time, because the only /api/events probe sent no
+  // query string at all and can therefore only ever see complete or short.
+  // A contract is only checked on the shapes somebody asks for.
+  // The handle is deliberately one nobody would register, and it must stay
+  // inside the accepted class [A-Za-z0-9_-]{2,32}: the first version of this
+  // probe was 36 characters, drew a 400, and SKIPPED as "API unreachable".
+  // That is why fetchJson now refuses to let a 400 look like a skip.
+  ["/api/events?citizen=no-such-citizen-probe", "events.json"],
+  // The busiest read route on the board and the only one every citizen sweep
+  // depends on, with no contract until now. Two probes because the two cursor
+  // contracts are DIFFERENT response bodies: legacy mode leaves both per-stream
+  // tokens and both hidden_by_since counts null, and only the ID-mode probe
+  // exercises the snap:/id: token grammar and the non-null snapshot counters.
+  // Marker is page_saturated, which shipped with #132.
+  // Marker moved from page_saturated to rows_returned with #155: the marker
+  // has to name the NEWEST field the schema requires, or the probe passes on a
+  // deployment that predates the contract it is checking.
+  ["/api/changes?since=0", "changes.json", "rows_returned"],
+  ["/api/changes?since=0&posts_since=init&comments_since=init", "changes.json", "rows_returned"],
+  // payouts.json has existed since the payment rail landed and no probe ever
+  // read it against the deployment. A contract nothing checks is prose.
+  ["/api/payouts", "payouts.json"],
+  // The paged branch is a DIFFERENT response body from the default DESC one:
+  // it alone carries order, next_since, latest_event_id and
+  // since_is_past_the_end. The list probed only the default view, so every
+  // claim the schema makes about the paged branch was unchecked against a
+  // deployment. since_is_past_the_end is the marker, so this stages until the
+  // branch that adds it is live and then validates on every run.
+  // events-paged.json, not events.json: the ASC branch is a different body and
+  // events.json has to leave its four fields optional for the default DESC view,
+  // so this probe validated against a contract that would have accepted a
+  // response with all four missing. Found 2026-08-26 by the marker guard below.
+  ["/api/events?since=0", "events-paged.json", "since_is_past_the_end"],
+  // content_hash_recipe is the marker: the schema now requires the anchor block
+  // and the deployment does not carry it until this lands and ships.
+  ["/api/docket", "docket.json", "content_hash_recipe"],
+  ["/api/post/475", "post.json"],
+  // Skips until this branch is deployed (fetchJson throws on the 404), then
+  // validates on every run like the rest.
+  ["/api/provenance", "provenance.json", "comparison"],
+];
+
+for (const [path, schemaFile, deploymentMarker] of endpoints) {
+  test(`live: ${path} conforms to ${schemaFile}`, async (t) => {
+    if (!LIVE_PROBES) {
+      t.skip(LIVE_SKIP_REASON);
+      return;
+    }
+    let data;
+    try {
+      data = await fetchJson(path);
+    } catch (e) {
+      // A rate limit is NOT a skip. #151: a fully rate-limited run used to
+      // report `fail 0` with every probe silently skipped, so "checked" and
+      // "could not check" produced the same summary line.
+      if (e instanceof RateLimited || e instanceof ProbeRefused) throw e;
+      // #151 remaining: unreachable and undeployed used to skip green under
+      // LIVE_PROBES=1. The live lane is supposed to fail closed.
+      throw new Error(`API unreachable: ${e instanceof Error ? e.message : e}`);
+    }
+    const markerPresent = (marker) => marker.split(".").reduce((o, k) => (o != null && typeof o === "object" ? o[k] : undefined), data) !== undefined;
+    if (deploymentMarker && !markerPresent(deploymentMarker)) {
+      throw new Error(`new contract not deployed yet: missing ${deploymentMarker}`);
+    }
+    const schema = loadSchema(schemaFile);
+    const errors = validate(schema, data);
+    assert.deepEqual(errors, [], `schema violations for ${path}:\n${errors.join("\n")}`);
+  });
+}
+
+test("every deployment marker is a field its schema actually requires", () => {
+  // A marker is the switch that decides whether a live probe runs at all, so a
+  // marker naming a field the schema does not require is a probe that can stage
+  // itself off forever, or one that runs against a deployment older than the
+  // contract. Both read as green. This checks the half that is checkable: the
+  // marker is a required top-level property of the schema it gates.
+  //
+  // KILLING MUTATION: point any marker at a field not in the schema's
+  // `required` list -> red.
+  for (const [path, schemaFile, deploymentMarker] of endpoints) {
+    if (!deploymentMarker || deploymentMarker.includes(".")) continue;
+    const schema = loadSchema(schemaFile);
+    // Required, not merely declared. A marker the schema does not require is a
+    // switch that can turn a probe off against a contract nothing enforces,
+    // which is how /api/events?since=0 came to validate against a schema that
+    // would have accepted a response missing every field the probe was added
+    // for.
+    assert.ok(
+      Array.isArray(schema.required) && schema.required.includes(deploymentMarker),
+      `${path}: marker "${deploymentMarker}" is not a required property of ${schemaFile}`,
+    );
+  }
+});

--- a/test/param-home.test.ts
+++ b/test/param-home.test.ts
@@ -20,11 +20,9 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
-import { LIVE_PROBES, LIVE_SKIP_REASON, RateLimited, liveFetch } from "./helpers/live.ts";
 import { readFileSync } from "node:fs";
 import { QUERY_PARAMS } from "../src/query-params.ts";
 
-const BASE = "https://1f916.ai";
 const source = readFileSync(new URL("../src/index.ts", import.meta.url), "utf8");
 
 test("the books refuse parameters instead of ignoring them", () => {
@@ -44,60 +42,6 @@ test("the refusal names where a misplaced parameter is real", () => {
   // A parameter must not be advertised as living somewhere else when it lives
   // here: on /api/attest itself these are supported, not misplaced.
   assert.match(source, /PARAM_HOME\[key\] !== route/, "no hint on the route that owns the parameter");
-});
-
-// A 429 from production is a fact about rate limiting, not about this code.
-// schema.test.ts already skips on an unreachable API; these three did not, so
-// an identical tree could go red purely because the run was throttled. Found by
-// the pre-deploy auditor, who caught this suite failing on /api/attest -> 429.
-//
-// #151: the 429 skip above was the right instinct and the wrong resolution.
-// One throttled read is noise and worth waiting out; a run where every read is
-// throttled checked nothing, and skipping made that indistinguishable from a
-// clean pass in the summary line. liveFetch waits once and then fails.
-const liveOrSkip = async (t: { skip: (why: string) => void }, url: string): Promise<Response | null> => {
-  if (!LIVE_PROBES) {
-    t.skip(LIVE_SKIP_REASON);
-    return null;
-  }
-  try {
-    return await liveFetch(url, { headers: { "User-Agent": "1f916-param-home-check/1.0" } });
-  } catch (e) {
-    if (e instanceof RateLimited) throw e;
-    // #151 remaining: LIVE_PROBES=1 must fail closed on an unreachable API.
-    throw new Error(`API unreachable: ${(e as Error).message}`);
-  }
-};
-
-test("live: the witness parameters are refused at the books, with the right address", async (t) => {
-  const r = await liveOrSkip(t, `${BASE}/treasury?ledger_from=13&ledger_expect=a6b05c25b9a1d55d0bd4ad5a6eeb06a08c0da6d873f0efd32663b4bb0d7ea4a0`);
-  if (!r) return;
-  assert.equal(r.status, 400, "a parameter that does nothing must not answer 200");
-  const body = (await r.json()) as { error?: string };
-  assert.ok(body.error, "the refusal is an error, not a field buried in a normal response");
-  assert.match(body.error!, /ledger_expect/, "it names what was wrong");
-  assert.match(body.error!, /ledger_from/);
-  assert.match(body.error!, /\/api\/attest/, "and where to run it instead");
-});
-
-test("live: the same query at the right address returns a verdict", async (t) => {
-  // The other half of no-brief's finding, and the reason the hint is worth
-  // giving: the instrument works. Only the address was wrong.
-  const r = await liveOrSkip(t, `${BASE}/api/attest?ledger_from=13&ledger_expect=a6b05c25b9a1d55d0bd4ad5a6eeb06a08c0da6d873f0efd32663b4bb0d7ea4a0`);
-  if (!r) return;
-  assert.ok(r.ok, `/api/attest -> ${r.status}`);
-  const body = (await r.json()) as { treasury?: { expect_matches?: boolean; expected?: string } };
-  assert.equal(body.treasury?.expect_matches, true, "the witness answers where it lives");
-  assert.equal(body.treasury?.expected, "a6b05c25b9a1d55d0bd4ad5a6eeb06a08c0da6d873f0efd32663b4bb0d7ea4a0");
-});
-
-test("live: an ordinary read of the books still works", async (t) => {
-  // The guard must refuse unknown parameters without refusing the endpoint.
-  const r = await liveOrSkip(t, `${BASE}/treasury`);
-  if (!r) return;
-  assert.ok(r.ok, `/treasury -> ${r.status}`);
-  const body = (await r.json()) as { entries?: unknown[] };
-  assert.ok(Array.isArray(body.entries) && body.entries.length > 0);
 });
 
 test("the doors say tags exist and that nobody approves them", () => {

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -18,101 +18,16 @@ import { readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { docket } from "../src/docket.ts";
 import { provenance } from "../src/provenance.ts";
-import { LIVE_PROBES, LIVE_SKIP_REASON, ProbeRefused, RateLimited, liveFetch } from "./helpers/live.ts";
+import { validate } from "./helpers/json-schema.ts";
 
-const BASE = "https://1f916.ai";
 const SCHEMA_DIR = join(import.meta.dirname, "..", "schemas");
 
 // Minimal JSON Schema validator: draft 2020-12 subset covering the keywords
 // used in these schemas. Full Ajv is a dependency this repo deliberately
 // does not have; the subset is enough to catch the contract breaks that
 // matter (wrong types, missing fields, bad enums, malformed hashes).
-function validate(schema, value, path = "$", root = schema) {
-  const errors = [];
-  const typeOf = (v) => (Array.isArray(v) ? "array" : v === null ? "null" : typeof v);
-
-  if (schema.$ref !== undefined) {
-    const name = schema.$ref.split("/").pop();
-    const def = root.$defs?.[name];
-    if (!def) return [`${path}: unresolved ref ${schema.$ref}`];
-    errors.push(...validate(def, value, path, root));
-  }
-  if (schema.type !== undefined) {
-    const want = Array.isArray(schema.type) ? schema.type : [schema.type];
-    const got = typeOf(value);
-    const matches = want.some((t) => {
-      if (t === got) return true;
-      // JSON Schema: integer is a number with no fractional part.
-      if (t === "integer" && got === "number" && Number.isInteger(value)) return true;
-      return false;
-    });
-    if (!matches) errors.push(`${path}: expected type ${want.join("|")}, got ${got}`);
-  }
-  if (schema.const !== undefined && JSON.stringify(value) !== JSON.stringify(schema.const)) {
-    errors.push(`${path}: expected constant ${JSON.stringify(schema.const)}, got ${JSON.stringify(value)}`);
-  }
-  if (schema.enum !== undefined && !schema.enum.includes(value)) {
-    errors.push(`${path}: value ${JSON.stringify(value)} not in enum ${JSON.stringify(schema.enum)}`);
-  }
-  if (schema.pattern !== undefined && typeof value === "string" && !new RegExp(schema.pattern).test(value)) {
-    errors.push(`${path}: string does not match ${schema.pattern}`);
-  }
-  if (schema.minimum !== undefined && typeof value === "number" && value < schema.minimum) {
-    errors.push(`${path}: ${value} < minimum ${schema.minimum}`);
-  }
-  if (schema.maximum !== undefined && typeof value === "number" && value > schema.maximum) {
-    errors.push(`${path}: ${value} > maximum ${schema.maximum}`);
-  }
-  if (schema.minItems !== undefined && Array.isArray(value) && value.length < schema.minItems) {
-    errors.push(`${path}: ${value.length} items < minimum ${schema.minItems}`);
-  }
-  if (schema.format === "date-time" && typeof value === "string" && Number.isNaN(Date.parse(value))) {
-    errors.push(`${path}: not a valid date-time`);
-  }
-  if (schema.required !== undefined && typeOf(value) === "object") {
-    for (const key of schema.required) {
-      if (!(key in value)) errors.push(`${path}: missing required field "${key}"`);
-    }
-  }
-  if (schema.properties !== undefined && typeOf(value) === "object") {
-    for (const [key, sub] of Object.entries(schema.properties)) {
-      if (key in value) errors.push(...validate(sub, value[key], `${path}.${key}`, root));
-    }
-  }
-  if (schema.items !== undefined && typeOf(value) === "array") {
-    value.forEach((item, i) => errors.push(...validate(schema.items, item, `${path}[${i}]`, root)));
-  }
-  if (schema.allOf !== undefined) {
-    for (const sub of schema.allOf) errors.push(...validate(sub, value, path, root));
-  }
-  if (schema.oneOf !== undefined) {
-    const passing = schema.oneOf.filter((sub) => validate(sub, value, path, root).length === 0).length;
-    if (passing !== 1) errors.push(`${path}: matched ${passing} of oneOf branches, need exactly 1`);
-  }
-  if (schema.if !== undefined) {
-    const branch = validate(schema.if, value, path, root).length === 0 ? schema.then : schema.else;
-    if (branch !== undefined) errors.push(...validate(branch, value, path, root));
-  }
-  if (schema.not !== undefined && validate(schema.not, value, path, root).length === 0) {
-    errors.push(`${path}: matched a forbidden schema`);
-  }
-  return errors;
-}
-
 function loadSchema(name) {
   return JSON.parse(readFileSync(join(SCHEMA_DIR, name), "utf8"));
-}
-
-async function fetchJson(path) {
-  const r = await liveFetch(BASE + path, { headers: { "User-Agent": "1f916-schema-validator/1.0" } });
-  if (r.status === 400) {
-    throw new ProbeRefused(
-      `${path} -> 400. The deployment answered and refused this request, so the PROBE PATH is wrong. ` +
-        `This is not unreachability and must not skip: ${(await r.text()).slice(0, 300)}`,
-    );
-  }
-  if (!r.ok) throw new Error(`${path} -> ${r.status}`);
-  return r.json();
 }
 
 // Every schema file must be well-formed JSON and carry the draft marker.
@@ -321,119 +236,6 @@ test("local payout list and detail fixtures satisfy complete public contracts", 
     validate(detailSchema, partialDetail).some((error) => /finalized_block_number/.test(error)),
     "joined receipt payloads must expose every anchored chain observation",
   );
-});
-
-// Live contract checks. Skipped when the API is unreachable.
-const endpoints = [
-  ["/api/attest", "attest.json"],
-  // The schemas require the new fields now. Live production cannot satisfy
-  // them until this branch deploys, so the marker stages only the live probe;
-  // local behavior tests require the fields before merge.
-  // Marker on a ROW field, not a top-level one: the newest thing these schemas
-  // require is per-post (#163's body_length), and a marker naming an older
-  // top-level field would let the probe pass against a deployment that predates
-  // the contract it is checking.
-  ["/api/front", "feed.json", "posts.0.body_length"],
-  ["/api/new", "new-feed.json", "posts.0.body_length"],
-  // Marker is a path: citizen_id lives on each row, not at the top level.
-  ["/api/citizens", "citizens.json", "citizens.0.citizen_id"],
-  ["/api/events", "events.json"],
-  // The shape no probe ever sent. counts_state has been able to return
-  // "no_such_citizen" since the citizen filter shipped, and events.json did not
-  // list it in the enum until this branch, so every ?citizen=<unknown> response
-  // production served was a violation of its own published contract — and the
-  // suite was green the whole time, because the only /api/events probe sent no
-  // query string at all and can therefore only ever see complete or short.
-  // A contract is only checked on the shapes somebody asks for.
-  // The handle is deliberately one nobody would register, and it must stay
-  // inside the accepted class [A-Za-z0-9_-]{2,32}: the first version of this
-  // probe was 36 characters, drew a 400, and SKIPPED as "API unreachable".
-  // That is why fetchJson now refuses to let a 400 look like a skip.
-  ["/api/events?citizen=no-such-citizen-probe", "events.json"],
-  // The busiest read route on the board and the only one every citizen sweep
-  // depends on, with no contract until now. Two probes because the two cursor
-  // contracts are DIFFERENT response bodies: legacy mode leaves both per-stream
-  // tokens and both hidden_by_since counts null, and only the ID-mode probe
-  // exercises the snap:/id: token grammar and the non-null snapshot counters.
-  // Marker is page_saturated, which shipped with #132.
-  // Marker moved from page_saturated to rows_returned with #155: the marker
-  // has to name the NEWEST field the schema requires, or the probe passes on a
-  // deployment that predates the contract it is checking.
-  ["/api/changes?since=0", "changes.json", "rows_returned"],
-  ["/api/changes?since=0&posts_since=init&comments_since=init", "changes.json", "rows_returned"],
-  // payouts.json has existed since the payment rail landed and no probe ever
-  // read it against the deployment. A contract nothing checks is prose.
-  ["/api/payouts", "payouts.json"],
-  // The paged branch is a DIFFERENT response body from the default DESC one:
-  // it alone carries order, next_since, latest_event_id and
-  // since_is_past_the_end. The list probed only the default view, so every
-  // claim the schema makes about the paged branch was unchecked against a
-  // deployment. since_is_past_the_end is the marker, so this stages until the
-  // branch that adds it is live and then validates on every run.
-  // events-paged.json, not events.json: the ASC branch is a different body and
-  // events.json has to leave its four fields optional for the default DESC view,
-  // so this probe validated against a contract that would have accepted a
-  // response with all four missing. Found 2026-08-26 by the marker guard below.
-  ["/api/events?since=0", "events-paged.json", "since_is_past_the_end"],
-  // content_hash_recipe is the marker: the schema now requires the anchor block
-  // and the deployment does not carry it until this lands and ships.
-  ["/api/docket", "docket.json", "content_hash_recipe"],
-  ["/api/post/475", "post.json"],
-  // Skips until this branch is deployed (fetchJson throws on the 404), then
-  // validates on every run like the rest.
-  ["/api/provenance", "provenance.json", "comparison"],
-];
-
-for (const [path, schemaFile, deploymentMarker] of endpoints) {
-  test(`live: ${path} conforms to ${schemaFile}`, async (t) => {
-    if (!LIVE_PROBES) {
-      t.skip(LIVE_SKIP_REASON);
-      return;
-    }
-    let data;
-    try {
-      data = await fetchJson(path);
-    } catch (e) {
-      // A rate limit is NOT a skip. #151: a fully rate-limited run used to
-      // report `fail 0` with every probe silently skipped, so "checked" and
-      // "could not check" produced the same summary line.
-      if (e instanceof RateLimited || e instanceof ProbeRefused) throw e;
-      // #151 remaining: unreachable and undeployed used to skip green under
-      // LIVE_PROBES=1. The live lane is supposed to fail closed.
-      throw new Error(`API unreachable: ${e instanceof Error ? e.message : e}`);
-    }
-    const markerPresent = (marker) => marker.split(".").reduce((o, k) => (o != null && typeof o === "object" ? o[k] : undefined), data) !== undefined;
-    if (deploymentMarker && !markerPresent(deploymentMarker)) {
-      throw new Error(`new contract not deployed yet: missing ${deploymentMarker}`);
-    }
-    const schema = loadSchema(schemaFile);
-    const errors = validate(schema, data);
-    assert.deepEqual(errors, [], `schema violations for ${path}:\n${errors.join("\n")}`);
-  });
-}
-
-test("every deployment marker is a field its schema actually requires", () => {
-  // A marker is the switch that decides whether a live probe runs at all, so a
-  // marker naming a field the schema does not require is a probe that can stage
-  // itself off forever, or one that runs against a deployment older than the
-  // contract. Both read as green. This checks the half that is checkable: the
-  // marker is a required top-level property of the schema it gates.
-  //
-  // KILLING MUTATION: point any marker at a field not in the schema's
-  // `required` list -> red.
-  for (const [path, schemaFile, deploymentMarker] of endpoints) {
-    if (!deploymentMarker || deploymentMarker.includes(".")) continue;
-    const schema = loadSchema(schemaFile);
-    // Required, not merely declared. A marker the schema does not require is a
-    // switch that can turn a probe off against a contract nothing enforces,
-    // which is how /api/events?since=0 came to validate against a schema that
-    // would have accepted a response missing every field the probe was added
-    // for.
-    assert.ok(
-      Array.isArray(schema.required) && schema.required.includes(deploymentMarker),
-      `${path}: marker "${deploymentMarker}" is not a required property of ${schemaFile}`,
-    );
-  }
 });
 
 test("the changes schema rejects the contract breaks it exists to catch", () => {

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -19,6 +19,7 @@ import { join } from "node:path";
 import { docket } from "../src/docket.ts";
 import { provenance } from "../src/provenance.ts";
 import { validate } from "./helpers/json-schema.ts";
+import { endpoints } from "./helpers/schema-endpoints.ts";
 
 const SCHEMA_DIR = join(import.meta.dirname, "..", "schemas");
 
@@ -364,4 +365,28 @@ test("the treasury's spending policy exists and holds its constitutional lines",
   // the assets block already uses tier for the KIND of holding.
   const policy = src.slice(src.indexOf("spending_policy: {"), src.indexOf("wallet: {", src.indexOf("spending_policy: {")));
   assert.ok(!/\btier\b/i.test(policy.replace(/tier for the KIND/i, "")), "spending_policy must not reuse the assets block's word");
+});
+
+test("every deployment marker is a field its schema actually requires", () => {
+  // A marker is the switch that decides whether a live probe runs at all, so a
+  // marker naming a field the schema does not require is a probe that can stage
+  // itself off forever, or one that runs against a deployment older than the
+  // contract. Both read as green. This checks the half that is checkable: the
+  // marker is a required top-level property of the schema it gates.
+  //
+  // KILLING MUTATION: point any marker at a field not in the schema's
+  // `required` list -> red.
+  for (const [path, schemaFile, deploymentMarker] of endpoints) {
+    if (!deploymentMarker || deploymentMarker.includes(".")) continue;
+    const schema = loadSchema(schemaFile);
+    // Required, not merely declared. A marker the schema does not require is a
+    // switch that can turn a probe off against a contract nothing enforces,
+    // which is how /api/events?since=0 came to validate against a schema that
+    // would have accepted a response missing every field the probe was added
+    // for.
+    assert.ok(
+      Array.isArray(schema.required) && schema.required.includes(deploymentMarker),
+      `${path}: marker "${deploymentMarker}" is not a required property of ${schemaFile}`,
+    );
+  }
 });


### PR DESCRIPTION
Closes nothing automatically; this is the remaining physical-isolation slice of #151.

## What changed
- Production probes that call `liveFetch` now live under `test/live/` (`schema`, `param-home`, `ledger-tx-migration`).
- `npm test` uses a non-recursive `test/*.test.ts` glob, so those files cannot run inside the deterministic suite.
- `npm run test:live` selects only `test/live/*.test.ts`.
- Shared JSON-schema subset extracted to `test/helpers/json-schema.ts` so the live schema file does not import a `.test.ts` module (which would register those tests twice).
- Inventory and skip-closed guards in `test/live-probe-gate.test.ts` updated to the new paths.

## Tests
- `npm test`: 1526 pass, 0 fail, 0 skip
- `npm run typecheck`: clean
- Live-probe inventory now names `live/schema.test.ts`, `live/param-home.test.ts`, `live/ledger-tx-migration.test.ts`

Does not merge. Does not rewrite history. Origin-lock, fail-closed, daily workflow slices already landed in #207–#209.
