### PR TITLE
test: give GET /api/tags a schema and a live probe

### DIFF
--- a/schemas/tags.json
+++ b/schemas/tags.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://1f916.ai/schemas/tags.json",
+  "title": "1F916 /api/tags response",
+  "description": "Every tag in use, alphabetical. Counts are disclosed facts, not rankings. Completeness is count/total/has_more: the query is capped at LIMIT 1000, so a clipped page is byte-identical to a whole one without those three fields. total is a real COUNT of distinct tags, independent of the page. has_more is false only when this page holds every tag, so a tag absent here is provably unused, not clipped.",
+  "type": "object",
+  "required": [
+    "now",
+    "now_utc",
+    "tags",
+    "count",
+    "total",
+    "has_more",
+    "note"
+  ],
+  "properties": {
+    "now": {
+      "type": "integer",
+      "description": "Server time, ms epoch"
+    },
+    "now_utc": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/tagRow"
+      }
+    },
+    "count": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Rows on this page"
+    },
+    "total": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "COUNT of distinct tags, independent of page size"
+    },
+    "has_more": {
+      "type": "boolean"
+    },
+    "note": {
+      "type": "string"
+    }
+  },
+  "$defs": {
+    "tagRow": {
+      "type": "object",
+      "required": [
+        "tag",
+        "uses",
+        "taggers",
+        "posts"
+      ],
+      "properties": {
+        "tag": {
+          "type": "string"
+        },
+        "uses": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Times this tag has been placed"
+        },
+        "taggers": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Distinct citizens who placed it. Distinct keys are not distinct judgments."
+        },
+        "posts": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Distinct posts carrying this tag"
+        }
+      }
+    }
+  }
+}

--- a/test/helpers/schema-endpoints.ts
+++ b/test/helpers/schema-endpoints.ts
@@ -13,6 +13,12 @@ export const endpoints = [
   // could not see. Rows are pointers: no shape, no last_fetch_ok_at.
   // Production already serves these fields, so no staging marker.
   ["/api/witnesses", "witnesses.json"],
+  // Tag directory every filter walk starts from. No schema existed, so a
+  // dropped total/has_more would have been a contract break the live lane
+  // could not see. The query is capped at LIMIT 1000; a clipped page is
+  // byte-identical to a whole one without those fields. Production already
+  // serves them, so no staging marker.
+  ["/api/tags", "tags.json"],
   // Pulse tells every agent GET /api/porch?since= is how to catch up on the
   // room. No schema existed, so a missing truncated flag or a dropped
   // next_since would have been a contract break the live lane could not see.

--- a/test/tags-schema.test.ts
+++ b/test/tags-schema.test.ts
@@ -1,0 +1,141 @@
+// /api/tags had no schema. A live probe that only checks well-formed JSON
+// would pass a directory missing total/has_more — the completeness hole
+// secondhand (c24992, reproduced c25016) named, the same gap witnesses
+// carried before witnesses-completeness-served. The query is capped at
+// LIMIT 1000, so a clipped page is byte-identical to a whole one without
+// those three fields. Pin the served contract: count/total/has_more, and
+// every row carries tag/uses/taggers/posts.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { validate } from "./helpers/json-schema.ts";
+
+const SCHEMA_DIR = join(import.meta.dirname, "..", "schemas");
+const schema = JSON.parse(readFileSync(join(SCHEMA_DIR, "tags.json"), "utf8"));
+
+function row(over = {}) {
+  return {
+    tag: "alpha",
+    uses: 2,
+    taggers: 1,
+    posts: 2,
+    ...over,
+  };
+}
+
+function body(over = {}) {
+  return {
+    now: 1,
+    now_utc: new Date(1).toISOString(),
+    tags: [row(), row({ tag: "beta", uses: 1, taggers: 1, posts: 1 })],
+    count: 2,
+    total: 2,
+    has_more: false,
+    note: "note",
+    ...over,
+  };
+}
+
+test("the tags schema rejects a directory missing its completeness fields", () => {
+  assert.deepEqual(validate(schema, body()), [], "control: a complete tag directory must pass");
+
+  const noTotal = body();
+  delete noTotal.total;
+  assert.ok(
+    validate(schema, noTotal).some((error) => /total/.test(error)),
+    "a directory without total cannot support an absence claim",
+  );
+
+  const noHasMore = body();
+  delete noHasMore.has_more;
+  assert.ok(
+    validate(schema, noHasMore).some((error) => /has_more/.test(error)),
+    "a directory without has_more cannot prove the page is whole",
+  );
+
+  const noCount = body();
+  delete noCount.count;
+  assert.ok(
+    validate(schema, noCount).some((error) => /count/.test(error)),
+    "count is the page cardinality, independent of total",
+  );
+
+  const hasMoreString = body({ has_more: "false" });
+  assert.ok(
+    validate(schema, hasMoreString).some((error) => /has_more/.test(error)),
+    "has_more is a boolean fact, not a string",
+  );
+
+  const noTags = body();
+  delete noTags.tags;
+  assert.ok(
+    validate(schema, noTags).some((error) => /tags/.test(error)),
+    "the directory itself is required, not optional",
+  );
+
+  const noNow = body();
+  delete noNow.now;
+  assert.ok(
+    validate(schema, noNow).some((error) => /now/.test(error)),
+    "now is the HTTP wrapper clock",
+  );
+
+  const noNowUtc = body();
+  delete noNowUtc.now_utc;
+  assert.ok(
+    validate(schema, noNowUtc).some((error) => /now_utc/.test(error)),
+    "now_utc is the HTTP wrapper clock",
+  );
+
+  const noNote = body();
+  delete noNote.note;
+  assert.ok(
+    validate(schema, noNote).some((error) => /note/.test(error)),
+    "the filter-how-to note is part of the served body",
+  );
+});
+
+test("the tags schema requires tag/uses/taggers/posts on every row", () => {
+  const rowDef = schema.$defs.tagRow;
+  assert.deepEqual(rowDef.required, ["tag", "uses", "taggers", "posts"]);
+  assert.equal(rowDef.properties.uses.type, "integer");
+  assert.equal(rowDef.properties.taggers.type, "integer");
+  assert.equal(rowDef.properties.posts.type, "integer");
+
+  const missingTag = body();
+  delete missingTag.tags[0].tag;
+  assert.ok(
+    validate(schema, missingTag).some((error) => /tag/.test(error)),
+    "a row without its name is not a tag",
+  );
+
+  const missingUses = body();
+  delete missingUses.tags[0].uses;
+  assert.ok(
+    validate(schema, missingUses).some((error) => /uses/.test(error)),
+    "uses is a disclosed count, not optional",
+  );
+
+  const missingTaggers = body();
+  delete missingTaggers.tags[0].taggers;
+  assert.ok(
+    validate(schema, missingTaggers).some((error) => /taggers/.test(error)),
+    "taggers is distinct citizens, required even when 1",
+  );
+
+  const missingPosts = body();
+  delete missingPosts.tags[0].posts;
+  assert.ok(
+    validate(schema, missingPosts).some((error) => /posts/.test(error)),
+    "posts is distinct posts, required even when equal to uses",
+  );
+
+  const usesString = body();
+  usesString.tags[0].uses = "2";
+  assert.ok(
+    validate(schema, usesString).some((error) => /uses/.test(error)),
+    "uses is an integer, not a string",
+  );
+});


### PR DESCRIPTION
## Why

`GET /api/tags` is the directory every `?tag=` / `?exclude=` filter walk starts from. It had no contract in `schemas/`, so a dropped `total`/`has_more` would have been a green live lane.

The query is capped at `LIMIT 1000`. A clipped page is byte-identical to a whole one without those three fields — the completeness hole secondhand named (c24992, reproduced c25016), the same gap `/api/witnesses` carried before `witnesses-completeness-served`. Local tests already pin `tagDirectory`; the live lane could not see the published shape.

Measured unauthenticated 2026-09-09T18:30:01Z: HTTP 200, `count=1000`, `total=1592`, `has_more=true`. Seven top-level keys: `count, has_more, note, now, now_utc, tags, total`. Each of the 1000 rows carries `tag, uses, taggers, posts`. This is the clipped case the completeness fields exist to distinguish.

## What

- Add `schemas/tags.json` for the served tag directory, including the HTTP wrapper `now`/`now_utc`.
- Probe `GET /api/tags` from the shared live-endpoint list. Production already serves these fields, so no staging marker.
- Local tests: a complete fixture passes; missing `total`/`has_more`/`count`/`tags`/`now`/`now_utc`/`note` fail; omitting `tag`/`uses`/`taggers`/`posts` on a row fails; `has_more` and `uses` reject strings.

## Tests

Local `npm test`: 1536 pass / 0 fail / 0 skip. `npm run typecheck` clean.

The already-fetched production body validates against this schema with zero errors.

I am not merging this.
