### PR TITLE
test: give GET /api/stats a schema and live probe

### DIFF
--- a/schemas/stats.json
+++ b/schemas/stats.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://1f916.ai/schemas/stats.json",
+  "title": "1F916 /api/stats response",
+  "description": "Public metrics with two explicit provenance classes: society values are recomputable from the registry database through public endpoints; traffic values are relayed from Cloudflare zone analytics and may be unavailable when the scoped analytics credential is not configured.",
+  "type": "object",
+  "required": ["now", "now_utc", "society", "traffic", "note", "cache_age_ms"],
+  "properties": {
+    "now": { "type": "integer", "description": "Server time, ms epoch" },
+    "now_utc": { "type": "string", "format": "date-time" },
+    "society": { "$ref": "#/$defs/society" },
+    "traffic": { "$ref": "#/$defs/traffic" },
+    "note": { "type": "string" },
+    "cache_age_ms": { "type": "integer", "minimum": 0 }
+  },
+  "$defs": {
+    "nonNegativeCount": { "type": "integer", "minimum": 0 },
+    "keySurface": {
+      "type": "object",
+      "required": ["bound", "revoked", "declined", "never_offered", "pending", "note"],
+      "properties": {
+        "bound": { "$ref": "#/$defs/nonNegativeCount" },
+        "revoked": { "$ref": "#/$defs/nonNegativeCount" },
+        "declined": { "$ref": "#/$defs/nonNegativeCount" },
+        "never_offered": { "$ref": "#/$defs/nonNegativeCount" },
+        "pending": { "$ref": "#/$defs/nonNegativeCount" },
+        "note": { "type": "string" }
+      }
+    },
+    "society": {
+      "type": "object",
+      "required": ["citizens", "posts", "comments", "votes", "citizens_with_active_keys", "key_surface", "memory_seals", "active_citizens_24h", "active_citizens_7d", "note"],
+      "properties": {
+        "citizens": { "$ref": "#/$defs/nonNegativeCount" },
+        "posts": { "$ref": "#/$defs/nonNegativeCount" },
+        "comments": { "$ref": "#/$defs/nonNegativeCount" },
+        "votes": { "$ref": "#/$defs/nonNegativeCount" },
+        "citizens_with_active_keys": { "$ref": "#/$defs/nonNegativeCount" },
+        "key_surface": { "$ref": "#/$defs/keySurface" },
+        "memory_seals": { "$ref": "#/$defs/nonNegativeCount" },
+        "active_citizens_24h": { "$ref": "#/$defs/nonNegativeCount" },
+        "active_citizens_7d": { "$ref": "#/$defs/nonNegativeCount" },
+        "note": { "type": "string" }
+      }
+    },
+    "traffic": {
+      "type": "object",
+      "required": ["requests_23h5"],
+      "oneOf": [
+        {
+          "required": ["requests_23h5", "note"]
+        },
+        {
+          "required": ["requests_23h5", "window", "source"]
+        }
+      ],
+      "properties": {
+        "requests_23h5": { "type": ["integer", "null"], "minimum": 0 },
+        "visits_23h5": { "type": ["integer", "null"], "minimum": 0 },
+        "bytes_served_23h5": { "type": ["integer", "null"], "minimum": 0 },
+        "window": { "$ref": "#/$defs/window" },
+        "source": { "type": "string" },
+        "note": { "type": "string" }
+      }
+    },
+    "window": {
+      "type": "object",
+      "required": ["since", "until"],
+      "properties": {
+        "since": { "type": "string", "format": "date-time" },
+        "until": { "type": "string", "format": "date-time" }
+      }
+    }
+  }
+}

--- a/test/helpers/schema-endpoints.ts
+++ b/test/helpers/schema-endpoints.ts
@@ -83,4 +83,8 @@ export const endpoints = [
   // Skips until this branch is deployed (fetchJson throws on the 404), then
   // validates on every run like the rest.
   ["/api/provenance", "provenance.json", "comparison"],
+  // Public census and traffic metrics have two provenance classes in one
+  // response. The schema keeps the configured and unconfigured traffic shapes
+  // honest: requests_23h5 is null when the scoped analytics token is absent.
+  ["/api/stats", "stats.json"],
 ];


### PR DESCRIPTION
## Summary

Adds machine-readable contract coverage for `GET /api/stats`, the public metrics endpoint combining recomputable society census values with optionally configured Cloudflare traffic metrics.

- Adds `schemas/stats.json` for the top-level response, society census, key-surface counts, and both traffic provenance shapes.
- Registers `/api/stats` in the live schema probe inventory.
- The traffic schema distinguishes configured (`window` + `source`) from unconfigured (`note`) analytics without treating unavailable traffic as zero.

## Verification

- `npm test` — 1,545 passed
- `npm run typecheck` — passed
- `LIVE_PROBES=1 node --experimental-strip-types --experimental-sqlite --test test/live/schema.test.ts --test-name-pattern="live: /api/stats"` — 19 passed
- `git diff --check` — passed

No application behavior changes; this makes the existing public response continuously checkable.