### PR TITLE
test: give GET /api/checkpoint a schema and live probe

### DIFF
--- a/schemas/checkpoint.json
+++ b/schemas/checkpoint.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://1f916.ai/schemas/checkpoint.json",
+  "title": "1F916 /api/checkpoint response",
+  "description": "The signed transparency-checkpoint head for each hash log, plus everything a verifier needs to check it offline: the registry public key, the exact payload preimages, and the verify recipe. A checkpoint row is a signed commitment to the RFC 6962 root of the sealed rows of one log.",
+  "type": "object",
+  "required": [
+    "now",
+    "now_utc",
+    "registry_public_key",
+    "witness_dispatch",
+    "signed_payload_format",
+    "countersignature_payload_format",
+    "countersignature_note",
+    "checkpoints",
+    "leaves_are",
+    "tree",
+    "how_to_verify"
+  ],
+  "properties": {
+    "now": { "type": "integer", "description": "Server time, ms epoch" },
+    "now_utc": { "type": "string", "format": "date-time" },
+    "registry_public_key": { "$ref": "#/$defs/okpEd25519" },
+    "witness_dispatch": { "$ref": "#/$defs/witnessDispatch" },
+    "signed_payload_format": { "type": "string", "minLength": 1 },
+    "countersignature_payload_format": { "type": "string", "minLength": 1 },
+    "countersignature_note": { "type": "string" },
+    "checkpoints": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/checkpointRow" }
+    },
+    "leaves_are": { "type": "string" },
+    "tree": { "type": "string" },
+    "how_to_verify": { "type": "string" }
+  },
+  "$defs": {
+    "okpEd25519": {
+      "type": "object",
+      "required": ["kty", "crv", "x"],
+      "properties": {
+        "kty": { "const": "OKP" },
+        "crv": { "const": "Ed25519" },
+        "x": { "type": "string", "pattern": "^[A-Za-z0-9_-]+$" }
+      }
+    },
+    "witnessDispatch": {
+      "type": "object",
+      "required": ["recorded", "note"],
+      "properties": {
+        "recorded": { "type": "boolean" },
+        "last_attempt_at": { "type": ["integer", "null"], "description": "Ms epoch of the newest dispatch attempt; absent when recorded is false" },
+        "last_attempt_age_seconds": { "type": ["integer", "null"] },
+        "last_status": { "type": ["integer", "null"] },
+        "last_error": { "type": ["string", "null"] },
+        "last_ok_at": { "type": ["integer", "null"] },
+        "last_ok_age_seconds": { "type": ["integer", "null"] },
+        "note": { "type": "string" }
+      }
+    },
+    "checkpointRow": {
+      "type": "object",
+      "required": ["id", "log", "tree_size", "root", "sig", "created_at"],
+      "properties": {
+        "id": { "type": "integer", "minimum": 1 },
+        "log": { "type": "string", "minLength": 1, "description": "Which hash log this root commits to, e.g. identity_events or ledger" },
+        "tree_size": { "type": "integer", "minimum": 0, "description": "Number of sealed leaf rows covered" },
+        "root": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+        "sig": { "type": "string", "pattern": "^[A-Za-z0-9_-]+$", "description": "Ed25519 signature, base64url, by registry_public_key over signed_payload_format" },
+        "created_at": { "type": "integer", "minimum": 0, "description": "Ms epoch when this checkpoint was signed" }
+      }
+    }
+  }
+}

--- a/test/helpers/schema-endpoints.ts
+++ b/test/helpers/schema-endpoints.ts
@@ -87,4 +87,11 @@ export const endpoints = [
   // response. The schema keeps the configured and unconfigured traffic shapes
   // honest: requests_23h5 is null when the scoped analytics token is absent.
   ["/api/stats", "stats.json"],
+  // The tamper-evidence root: every offline verifier starts here. No schema
+  // existed, so a dropped registry_public_key, a mutated payload-format
+  // preimage, or a checkpoint row without its signature would have been a
+  // contract break the live lane could not see. root and sig are pinned to
+  // their exact wire shapes (lowercase hex; base64url) because a verifier
+  // that pattern-fails loudly is better than one that 500s on a wrong format.
+  ["/api/checkpoint", "checkpoint.json"],
 ];


### PR DESCRIPTION
## Summary

Adds a machine-readable contract for `GET /api/checkpoint`, the tamper-evidence root every offline verifier starts from.

- Adds `schemas/checkpoint.json`: registry public key (OKP Ed25519), witness-dispatch state, checkpoint rows (`log`, `tree_size`, lowercase 64-hex `root`, base64url `sig`, and `created_at`), and the required verification-recipe fields.
- Pins the root and signature wire formats so a regression fails the live probe loudly rather than reaching a downstream verifier as malformed input.
- Registers `/api/checkpoint` in the live schema-probe inventory.

## Verification

- `npm test` — 1,551 passed
- `npm run typecheck` — passed
- live schema lane filtered for checkpoint — 20/20 passed; deployed `/api/checkpoint` conforms
- `git diff --check` — passed

No application behavior changes; this makes the existing public response continuously checkable.