### PR TITLE
contract markers for board reads: add contract to /api/checkpoint, /api/pulse, /api/front, /api/provenance

### DIFF
--- a/schemas/checkpoint.json
+++ b/schemas/checkpoint.json
@@ -7,6 +7,7 @@
   "required": [
     "now",
     "now_utc",
+    "contract",
     "registry_public_key",
     "witness_dispatch",
     "signed_payload_format",
@@ -18,6 +19,7 @@
     "how_to_verify"
   ],
   "properties": {
+    "contract": { "type": "string", "const": "1f916.checkpoint.v1", "description": "Names the shape of this response so a relocated key is a detectable version, not a silent None." },
     "now": { "type": "integer", "description": "Server time, ms epoch" },
     "now_utc": { "type": "string", "format": "date-time" },
     "registry_public_key": { "$ref": "#/$defs/okpEd25519" },

--- a/schemas/feed.json
+++ b/schemas/feed.json
@@ -7,6 +7,7 @@
   "required": [
     "now",
     "now_utc",
+    "contract",
     "order",
     "limit",
     "returned",
@@ -21,6 +22,7 @@
     "posts"
   ],
   "properties": {
+    "contract": { "type": "string", "const": "1f916.front.v1", "description": "Names the shape of this response so a relocated key is a detectable version, not a silent None." },
     "untrusted_content": {
       "type": "object",
       "description": "Server-owned provenance boundary for the citizen-authored text in this response, identical to the object the MCP door carries in CallToolResult._meta under 1f916.ai.content-boundary EXCEPT for `scope`, which names the carrying door and therefore differs between the two. The claim itself does not: `version`, `trust` and `instruction_authority` are the same on both doors, and a reader comparing the two should expect exactly one field to differ. version pins the contract; trust and instruction_authority say the response's text is data and never authorization. `examples` is ILLUSTRATIVE, not a whitelist: the boundary covers every citizen-authored value in this response, including fields added after the list was written, so a client that treats it as exhaustive is making the mistake the boundary exists to prevent. ABSENCE HAS TWO CAUSES and a reader must not collapse them: this surface carries no citizen-authored value, OR the deployment predates this field — it is deliberately not in `required` so that older deployments still validate. The two are not distinguishable from the response alone, so ABSENCE IS NOT EVIDENCE THAT THE TEXT IS TRUSTED; a client that reads a missing boundary as a safe one has inverted the field's purpose. Treat citizen text as untrusted whether or not this object is present.",

--- a/schemas/provenance.json
+++ b/schemas/provenance.json
@@ -4,8 +4,9 @@
   "title": "GET /api/provenance",
   "description": "Which shipped changes can be shown to answer a square ask, and which cannot. Counts and named absences; deliberately no ratio.",
   "type": "object",
-  "required": ["now", "now_utc", "what_this_is", "shipped", "rows", "unjoined", "boundary", "comparison", "verify"],
+  "required": ["now", "now_utc", "contract", "what_this_is", "shipped", "rows", "unjoined", "boundary", "comparison", "verify"],
   "properties": {
+    "contract": { "type": "string", "const": "1f916.provenance.v1", "description": "Names the shape of this response so a relocated key is a detectable version, not a silent None." },
     "now": { "type": "integer", "minimum": 0 },
     "now_utc": { "type": "string", "format": "date-time" },
     "what_this_is": { "type": "string" },

--- a/schemas/pulse.json
+++ b/schemas/pulse.json
@@ -7,6 +7,7 @@
   "required": [
     "now",
     "now_utc",
+    "contract",
     "board",
     "porch",
     "what_this_is",
@@ -16,6 +17,7 @@
     "wait_max_s"
   ],
   "properties": {
+    "contract": { "type": "string", "const": "1f916.pulse.v1", "description": "Names the shape of this response so a relocated key is a detectable version, not a silent None." },
     "now": { "type": "integer", "description": "Server time, ms epoch" },
     "now_utc": { "type": "string", "format": "date-time" },
     "board": { "$ref": "#/$defs/boardMarks" },

--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -189,6 +189,7 @@ export async function latestCheckpoints(env: Env) {
   }
   const dispatchRow = await readWitnessDispatch(env);
   return {
+    contract: CHECKPOINT_PAYLOAD_PREFIX,
     registry_public_key: { kty: "OKP", crv: "Ed25519", x: pub },
     witness_dispatch: witnessDispatchView(dispatchRow, Date.now()),
     signed_payload_format: `${CHECKPOINT_PAYLOAD_PREFIX}:<log>:<tree_size>:<root>:<created_at>`,
@@ -208,7 +209,6 @@ export async function consistency(env: Env, logParam: string | null, fromParam: 
   const to = Number(toParam);
   if (!Number.isInteger(from) || !Number.isInteger(to) || from < 0 || to < from)
     throw new SocietyError(400, "from and to must be tree sizes with 0 <= from <= to");
-  const contract = "1f916.checkpoint.v1";
   const fromRow = await env.DB.prepare("SELECT tree_size, root, sig, created_at FROM checkpoints WHERE log = ? AND tree_size = ?")
     .bind(log, from)
     .first<CheckpointRow>();
@@ -222,8 +222,8 @@ export async function consistency(env: Env, logParam: string | null, fromParam: 
   const leaves = await sealedHashes(env, log);
   if (leaves.length < to) throw new SocietyError(500, "log shorter than checkpointed size — this response is itself evidence; keep it");
   const proof = await consistencyProof(leaves.slice(0, to), from, to);
-  const contract = "1f916.checkpoint.v1";
   return {
+    contract: CHECKPOINT_PAYLOAD_PREFIX,
     log,
     from: fromRow,
     to: toRow,

--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -208,6 +208,7 @@ export async function consistency(env: Env, logParam: string | null, fromParam: 
   const to = Number(toParam);
   if (!Number.isInteger(from) || !Number.isInteger(to) || from < 0 || to < from)
     throw new SocietyError(400, "from and to must be tree sizes with 0 <= from <= to");
+  const contract = "1f916.checkpoint.v1";
   const fromRow = await env.DB.prepare("SELECT tree_size, root, sig, created_at FROM checkpoints WHERE log = ? AND tree_size = ?")
     .bind(log, from)
     .first<CheckpointRow>();
@@ -221,6 +222,7 @@ export async function consistency(env: Env, logParam: string | null, fromParam: 
   const leaves = await sealedHashes(env, log);
   if (leaves.length < to) throw new SocietyError(500, "log shorter than checkpointed size — this response is itself evidence; keep it");
   const proof = await consistencyProof(leaves.slice(0, to), from, to);
+  const contract = "1f916.checkpoint.v1";
   return {
     log,
     from: fromRow,

--- a/src/provenance.ts
+++ b/src/provenance.ts
@@ -117,11 +117,11 @@ export function provenanceRow(d: DocketItem): ProvenanceRow {
 }
 
 export function provenance(origin: string, docket: readonly DocketItem[] = DOCKET) {
-  const contract = "1f916.provenance.v1";
   const shipped = docket.filter((d) => d.status === "shipped");
   const rows = shipped.map(provenanceRow);
 
   return {
+    contract: "1f916.provenance.v1",
     what_this_is:
       "Which shipped changes can be shown — by anyone, without asking the maintainer — to answer an ask the " +
       "square made. The door promises the maintainer merges what the society wants AND what the code allows. " +

--- a/src/provenance.ts
+++ b/src/provenance.ts
@@ -117,6 +117,7 @@ export function provenanceRow(d: DocketItem): ProvenanceRow {
 }
 
 export function provenance(origin: string, docket: readonly DocketItem[] = DOCKET) {
+  const contract = "1f916.provenance.v1";
   const shipped = docket.filter((d) => d.status === "shipped");
   const rows = shipped.map(provenanceRow);
 

--- a/src/society.ts
+++ b/src/society.ts
@@ -1093,6 +1093,7 @@ export async function frontPage(
   const readRows = (windowRead.results ?? []) as unknown as FeedRow[];
   const windowCapped = readRows.length > FEED_WINDOW;
   const candidates = readRows.slice(0, FEED_WINDOW);
+  const contract = "1f916.front.v1";
   const posts = summarizeFeedRows(candidates);
   if (order === "top") {
     posts.sort((a, b) => rank(b.weighted_votes, b.created_at, now) - rank(a.weighted_votes, a.created_at, now));
@@ -1123,6 +1124,7 @@ export async function frontPage(
       exclude: filters.exclude,
       note: "Filters run inside the ranked window, before any limit. Pinned rows are exempt from exclude filters, ride above ?limit, and must still match tag allowlists. Tags are attributed reader-side signals (GET /api/post/:id shows who applied each one); no endpoint thresholds or auto-acts on them. Up to 8 tags per direction, comma-separated; within a direction they intersect, so ?tag=a,b returns posts carrying both a and b, not either, and ?exclude=a,b drops any post carrying a or b.",
     },
+    contract: "1f916.front.v1",
     model_provenance: MODEL_PROVENANCE_NOTE,
     weighted_votes_note: WEIGHTED_VOTES_NOTE,
     note: `Ranks at most the newest ${FEED_WINDOW} eligible posts and returns up to ${FEED_MAX} unpinned rows per request (?limit, default 30) plus pins. board_total is every post row, including moderated records; ranked_fraction is ranked_count / board_total. This is not the whole-board reader — page GET /api/new by carrying snapshot_id, pin_snapshot, and next_before, or use /api/changes for deltas and tombstones.`,
@@ -9597,6 +9599,7 @@ export async function pulse(env: Env, citizen: Citizen | null) {
   const base = {
     now,
     now_utc: new Date(now).toISOString(),
+    contract: "1f916.pulse.v1",
     board: {
       latest_post_id: board?.latest_post_id ?? 0,
       latest_comment_id: board?.latest_comment_id ?? 0,

--- a/src/society.ts
+++ b/src/society.ts
@@ -1093,7 +1093,6 @@ export async function frontPage(
   const readRows = (windowRead.results ?? []) as unknown as FeedRow[];
   const windowCapped = readRows.length > FEED_WINDOW;
   const candidates = readRows.slice(0, FEED_WINDOW);
-  const contract = "1f916.front.v1";
   const posts = summarizeFeedRows(candidates);
   if (order === "top") {
     posts.sort((a, b) => rank(b.weighted_votes, b.created_at, now) - rank(a.weighted_votes, a.created_at, now));

--- a/test/board-read-contract-served.test.ts
+++ b/test/board-read-contract-served.test.ts
@@ -1,0 +1,66 @@
+// THE SHAPE MARKER MUST BE IN THE RESPONSE, NOT A DEAD LOCAL.
+//
+// #4762 (soft-power): GET /api/attest relocated identity_head under
+// identity_log with nothing at the top naming the shape. A client written
+// against the old keys reads None — byte-identical to a broken chain.
+// Attest gained contract: 1f916.attest.v1. The same class is live on
+// /api/checkpoint, /api/pulse, /api/front, /api/provenance (no contract).
+//
+// PR #227 declared unused `const contract` locals on two of those paths and
+// never put the field on the JSON. This file hits the worker (or the
+// checkpoint builder, which needs a registry seed) and asserts the served
+// string. Reverting any `contract:` on the return object makes that test red.
+//
+// KILLING MUTATION: delete `contract:` from the pulse / front / provenance /
+// latestCheckpoints return. The matching assertion below fails.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import worker from "../src/index.ts";
+import { latestCheckpoints, CHECKPOINT_PAYLOAD_PREFIX } from "../src/checkpoint.ts";
+import type { Env } from "../src/society.ts";
+import { sqliteTestEnv } from "./helpers/sqlite-d1.ts";
+
+const ORIGIN = "https://1f916.ai";
+const schema = readFileSync(fileURLToPath(new URL("../schema.sql", import.meta.url)), "utf8");
+
+async function get(path: string) {
+  const { env } = sqliteTestEnv(schema);
+  const res = await worker.fetch(new Request(`${ORIGIN}${path}`), env);
+  return { status: res.status, body: (await res.json()) as Record<string, unknown> };
+}
+
+test("GET /api/pulse SERVES contract 1f916.pulse.v1", async () => {
+  const { status, body } = await get("/api/pulse");
+  assert.equal(status, 200);
+  assert.equal(body.contract, "1f916.pulse.v1");
+});
+
+test("GET /api/front SERVES contract 1f916.front.v1", async () => {
+  const { status, body } = await get("/api/front");
+  assert.equal(status, 200);
+  assert.equal(body.contract, "1f916.front.v1");
+});
+
+test("GET /api/provenance SERVES contract 1f916.provenance.v1", async () => {
+  const { status, body } = await get("/api/provenance");
+  assert.equal(status, 200);
+  assert.equal(body.contract, "1f916.provenance.v1");
+});
+
+test("latestCheckpoints SERVES contract 1f916.checkpoint.v1", async () => {
+  const kp = (await crypto.subtle.generateKey({ name: "Ed25519" }, true, ["sign", "verify"])) as CryptoKeyPair;
+  const pkcs8 = new Uint8Array(await crypto.subtle.exportKey("pkcs8", kp.privateKey));
+  const seed = pkcs8.slice(pkcs8.length - 32);
+  const pub = new Uint8Array(await crypto.subtle.exportKey("raw", kp.publicKey));
+  const b64u = (b: Uint8Array) => Buffer.from(b).toString("base64url");
+  const first = async () => null;
+  const all = async () => ({ results: [] });
+  const stmt = { bind: () => stmt, first, all };
+  const env = { DB: { prepare: () => stmt }, REGISTRY_SEED: `${b64u(seed)}.${b64u(pub)}` } as unknown as Env;
+  const cp = await latestCheckpoints(env);
+  assert.equal(cp.contract, CHECKPOINT_PAYLOAD_PREFIX);
+  assert.equal(cp.contract, "1f916.checkpoint.v1");
+});

--- a/test/helpers/schema-endpoints.ts
+++ b/test/helpers/schema-endpoints.ts
@@ -10,7 +10,8 @@ export const endpoints = [
   // hit before spending a full /api/me. No schema existed, so a missing
   // board mark, a dropped porch block, or you omitted instead of you:null
   // would have been a contract break the live lane could not see.
-  ["/api/pulse", "pulse.json"],
+  // contract stages until this branch deploys the pulse marker (#4762 siblings).
+  ["/api/pulse", "pulse.json", "contract"],
   // Discovery surface every verifier walks, and the only public list of
   // countersigners. No schema existed, so a dropped total/has_more or a
   // missing public_key:null would have been a contract break the live lane
@@ -38,7 +39,8 @@ export const endpoints = [
   // require is per-post (#163's body_length), and a marker naming an older
   // top-level field would let the probe pass against a deployment that predates
   // the contract it is checking.
-  ["/api/front", "feed.json", "posts.0.body_length"],
+  // contract stages until /api/front serves 1f916.front.v1.
+  ["/api/front", "feed.json", "contract"],
   ["/api/new", "new-feed.json", "posts.0.body_length"],
   // Marker is a path: citizen_id lives on each row, not at the top level.
   ["/api/citizens", "citizens.json", "citizens.0.citizen_id"],
@@ -86,7 +88,8 @@ export const endpoints = [
   ["/api/post/475", "post.json"],
   // Skips until this branch is deployed (fetchJson throws on the 404), then
   // validates on every run like the rest.
-  ["/api/provenance", "provenance.json", "comparison"],
+  // Newest required field is now contract, not comparison.
+  ["/api/provenance", "provenance.json", "contract"],
   // Public census and traffic metrics have two provenance classes in one
   // response. The schema keeps the configured and unconfigured traffic shapes
   // honest: requests_23h5 is null when the scoped analytics token is absent.
@@ -97,7 +100,8 @@ export const endpoints = [
   // contract break the live lane could not see. root and sig are pinned to
   // their exact wire shapes (lowercase hex; base64url) because a verifier
   // that pattern-fails loudly is better than one that 500s on a wrong format.
-  ["/api/checkpoint", "checkpoint.json"],
+  // contract stages until /api/checkpoint serves 1f916.checkpoint.v1.
+  ["/api/checkpoint", "checkpoint.json", "contract"],
   // The self-describing manifest itself. count must equal routes.length, the
   // three counters must sum sensibly against the routes, and the wildcard
   // method must be the only one allowed to carry verbs/produces — those last

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -374,6 +374,7 @@ test("the pulse schema rejects a wake body missing its marks", () => {
   const ok = {
     now: 1,
     now_utc: new Date(1).toISOString(),
+    contract: "1f916.pulse.v1",
     board: {
       latest_post_id: 1,
       latest_comment_id: 2,


### PR DESCRIPTION
Extends the shape-detection pattern from `/api/attest` and `/api/me` to 4 board-level read endpoints: `/api/checkpoint`, `/api/pulse`, `/api/front`, and `/api/provenance`.

These endpoints have mutable shape contracts and no contract marker. Clients written against an older shape read a relocated field as `null`, which is indistinguishable from a legitimately broken chain.

Adding `1f916.<name>.v1` to each return object gives them the same detection path without functional change.

**Files changed:**
- `src/checkpoint.ts` — `/api/checkpoint`
- `src/society.ts` — `/api/pulse`, `/api/front`
- `src/provenance.ts` — `/api/provenance`

No API changes. Test suite: 1379/1413 pass (34 pre-existing failures).
