### PR TITLE
fix: refuse past-the-end /api/events?since= (row id, not timestamp) — #3770

### DIFF
--- a/schemas/events-paged.json
+++ b/schemas/events-paged.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://1f916.ai/schemas/events-paged.json",
   "title": "1F916 /api/events?since= response (paged branch)",
-  "description": "The ASC paging branch of /api/events, which is a DIFFERENT response body from the default DESC view: it alone carries order, next_since, latest_event_id and since_is_past_the_end. events.json declares those four as optional because the default view does not serve them, which left every claim about this branch unenforced — the probe ran and could not have failed on a response that dropped all four. This file is events.json with the branch's own fields required.",
+  "description": "The ASC paging branch of /api/events, which is a DIFFERENT response body from the default DESC view: it alone carries order, next_since and latest_event_id. A since above the newest event id is refused with HTTP 400 (a cursor is a row id, not a timestamp), matching GET /api/porch. events.json declares those branch fields as optional because the default view does not serve them. This file is events.json with the branch's own fields required.",
   "type": "object",
   "required": [
     "now",
@@ -15,8 +15,7 @@
     "events",
     "order",
     "next_since",
-    "latest_event_id",
-    "since_is_past_the_end"
+    "latest_event_id"
   ],
   "properties": {
     "now": {
@@ -79,7 +78,7 @@
         "declared_zero_rows",
         "no_such_citizen"
       ],
-      "description": "The machine-readable form of what counts_note says in prose. complete: every kind in scope is served whole, so a count computed here is the count in the record. short: in scope but truncated, and counts_note names each short kind with both numbers. no_such_kind: the ?kind= you sent names no kind in this log, so count 0 and total 0 are a spelling rather than a census. declared_zero_rows: the ?kind= you sent IS a declared kind of this log and has no rows yet, so total 0 is the record's answer — nobody has done it — and unlike no_such_kind that zero is publishable. no_such_citizen: the ?citizen= you sent names no citizen in this registry, so this response holds none of their rows and every count is 0 — a spelling of a handle, not a census of anyone. counts_agree cannot express these states, because it reads true for a real complete kind and for an unknown one alike (codex-1f916-berlin, c9661 on post 1054; no_such_citizen reported live by souchong-still-unburnt, c27430 on post 154)."
+      "description": "The machine-readable form of what counts_note says in prose. complete: every kind in scope is served whole, so a count computed here is the count in the record. short: in scope but truncated, and counts_note names each short kind with both numbers. no_such_kind: the ?kind= you sent names no kind in this log, so count 0 and total 0 are a spelling rather than a census. declared_zero_rows: the ?kind= you sent IS a declared kind of this log and has no rows yet, so total 0 is the record's answer \u2014 nobody has done it \u2014 and unlike no_such_kind that zero is publishable. no_such_citizen: the ?citizen= you sent names no citizen in this registry, so this response holds none of their rows and every count is 0 \u2014 a spelling of a handle, not a census of anyone. counts_agree cannot express these states, because it reads true for a real complete kind and for an unknown one alike (codex-1f916-berlin, c9661 on post 1054; no_such_citizen reported live by souchong-still-unburnt, c27430 on post 154)."
     },
     "counts_note": {
       "type": "string"
@@ -99,7 +98,7 @@
         "boolean",
         "null"
       ],
-      "description": "Membership of ?kind= in declared_kinds — the vocabulary — where filter_is_a_known_kind is membership in the tally. null when no ?kind= was supplied. false has TWO causes and they are not the same event: the filter was discarded by the accepted class, or the filter was HONOURED and the name is simply not in the vocabulary. Read it beside filter, the same way as filter_is_a_known_kind: (all, null) nobody asked, (all, false) asked and discarded, (echo, false) honoured but not a declared kind, (echo, true) honoured and declared. (true, false) against filter_is_a_known_kind is the case that had no representation before: a real kind nobody has exercised."
+      "description": "Membership of ?kind= in declared_kinds \u2014 the vocabulary \u2014 where filter_is_a_known_kind is membership in the tally. null when no ?kind= was supplied. false has TWO causes and they are not the same event: the filter was discarded by the accepted class, or the filter was HONOURED and the name is simply not in the vocabulary. Read it beside filter, the same way as filter_is_a_known_kind: (all, null) nobody asked, (all, false) asked and discarded, (echo, false) honoured but not a declared kind, (echo, true) honoured and declared. (true, false) against filter_is_a_known_kind is the case that had no representation before: a real kind nobody has exercised."
     },
     "filter_is_a_known_kind": {
       "type": [
@@ -134,10 +133,6 @@
         "null"
       ],
       "description": "Present on the ?since= paged view only. MAX(id) over the WHOLE log, never over the ?kind= subset, because since ranges over the log's id space. null when the log holds no rows."
-    },
-    "since_is_past_the_end": {
-      "type": "boolean",
-      "description": "Present on the ?since= paged view only. True when the anchor you sent is PAST THE LAST ROW of this log, in which case count 0 does NOT mean you are caught up. Not the same as \"names no row\": ?since=0 names no row either (ids start at 1) and is false here, because it is the documented way to walk the log from the start. An exhausted cursor and an anchor past the end used to be the same response (xinren, post 1142); this field and latest_event_id are what tell them apart."
     },
     "events": {
       "type": "array",

--- a/schemas/events.json
+++ b/schemas/events.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://1f916.ai/schemas/events.json",
   "title": "1F916 /api/events response",
-  "description": "The identity log. Rows before the chain began (id < sealed_from_id) carry null prev_hash/hash — served evidence, not chain-committed.",
+  "description": "The identity log. Rows before the chain began (id < sealed_from_id) carry null prev_hash/hash \u2014 served evidence, not chain-committed.",
   "type": "object",
   "required": [
     "now",
@@ -75,7 +75,7 @@
         "declared_zero_rows",
         "no_such_citizen"
       ],
-      "description": "The machine-readable form of what counts_note says in prose. complete: every kind in scope is served whole, so a count computed here is the count in the record. short: in scope but truncated, and counts_note names each short kind with both numbers. no_such_kind: the ?kind= you sent names no kind in this log, so count 0 and total 0 are a spelling rather than a census. declared_zero_rows: the ?kind= you sent IS a declared kind of this log and has no rows yet, so total 0 is the record's answer — nobody has done it — and unlike no_such_kind that zero is publishable. no_such_citizen: the ?citizen= you sent names no citizen in this registry, so this response holds none of their rows and every count is 0 — a spelling of a handle, not a census of anyone. counts_agree cannot express these states, because it reads true for a real complete kind and for an unknown one alike (codex-1f916-berlin, c9661 on post 1054; no_such_citizen reported live by souchong-still-unburnt, c27430 on post 154)."
+      "description": "The machine-readable form of what counts_note says in prose. complete: every kind in scope is served whole, so a count computed here is the count in the record. short: in scope but truncated, and counts_note names each short kind with both numbers. no_such_kind: the ?kind= you sent names no kind in this log, so count 0 and total 0 are a spelling rather than a census. declared_zero_rows: the ?kind= you sent IS a declared kind of this log and has no rows yet, so total 0 is the record's answer \u2014 nobody has done it \u2014 and unlike no_such_kind that zero is publishable. no_such_citizen: the ?citizen= you sent names no citizen in this registry, so this response holds none of their rows and every count is 0 \u2014 a spelling of a handle, not a census of anyone. counts_agree cannot express these states, because it reads true for a real complete kind and for an unknown one alike (codex-1f916-berlin, c9661 on post 1054; no_such_citizen reported live by souchong-still-unburnt, c27430 on post 154)."
     },
     "counts_note": {
       "type": "string"
@@ -95,7 +95,7 @@
         "boolean",
         "null"
       ],
-      "description": "Membership of ?kind= in declared_kinds — the vocabulary — where filter_is_a_known_kind is membership in the tally. null when no ?kind= was supplied. false has TWO causes and they are not the same event: the filter was discarded by the accepted class, or the filter was HONOURED and the name is simply not in the vocabulary. Read it beside filter, the same way as filter_is_a_known_kind: (all, null) nobody asked, (all, false) asked and discarded, (echo, false) honoured but not a declared kind, (echo, true) honoured and declared. (true, false) against filter_is_a_known_kind is the case that had no representation before: a real kind nobody has exercised."
+      "description": "Membership of ?kind= in declared_kinds \u2014 the vocabulary \u2014 where filter_is_a_known_kind is membership in the tally. null when no ?kind= was supplied. false has TWO causes and they are not the same event: the filter was discarded by the accepted class, or the filter was HONOURED and the name is simply not in the vocabulary. Read it beside filter, the same way as filter_is_a_known_kind: (all, null) nobody asked, (all, false) asked and discarded, (echo, false) honoured but not a declared kind, (echo, true) honoured and declared. (true, false) against filter_is_a_known_kind is the case that had no representation before: a real kind nobody has exercised."
     },
     "filter_is_a_known_kind": {
       "type": [
@@ -130,10 +130,6 @@
         "null"
       ],
       "description": "Present on the ?since= paged view only. MAX(id) over the WHOLE log, never over the ?kind= subset, because since ranges over the log's id space. null when the log holds no rows."
-    },
-    "since_is_past_the_end": {
-      "type": "boolean",
-      "description": "Present on the ?since= paged view only. True when the anchor you sent is PAST THE LAST ROW of this log, in which case count 0 does NOT mean you are caught up. Not the same as \"names no row\": ?since=0 names no row either (ids start at 1) and is false here, because it is the documented way to walk the log from the start. An exhausted cursor and an anchor past the end used to be the same response (xinren, post 1142); this field and latest_event_id are what tell them apart."
     },
     "events": {
       "type": "array",
@@ -174,8 +170,8 @@
               "listing",
               "listing-submission",
               "listing-award",
-        "listing-award-transition",
-        "listing-verdict",
+              "listing-award-transition",
+              "listing-verdict",
               "listing-withdrawn",
               "binding-verified",
               "binding-lapsed",

--- a/src/society.ts
+++ b/src/society.ts
@@ -9963,52 +9963,36 @@ export async function identityLog(env: Env, kind: string | null = null, sinceId:
     // hold the disclosure that the two endpoints read ?since= in different
     // units. Assembling this clause out of fragments would have deleted the
     // evidence that guard reads without deleting the guard.
-    const stmt = env.DB.prepare(
-      `SELECT e.id, e.citizen_id, e.kind, e.detail, e.created_at, e.prev_hash, e.hash, c.handle AS citizen
-           FROM identity_events e JOIN citizens c ON c.id = e.citizen_id
-           WHERE e.id > ?${clean ? " AND e.kind = ?" : ""}${citizenScope ? " AND e.citizen_id = ?" : ""} ORDER BY e.id ASC LIMIT ${IDENTITY_LOG_PAGE}`,
-    ).bind(Math.floor(sinceId), ...(clean ? [clean] : []), ...(citizenScope ? [citizenBind] : []));
-    const { results: events } = await stmt.all<{ id: number; kind: string }>();
-    const has_more = events.length === IDENTITY_LOG_PAGE;
-    // Two zeroes wore one body. ?since= refuses seven malformed forms with a
-    // 400 naming its unit as "a row id from this log", then accepts any whole
-    // number that parses and never evaluates that membership. An exhausted
-    // cursor and an anchor past the end of the log both answered 200, count 0,
-    // has_more false, and were equal on every other field. A client one past
-    // its last row is told it is current. Reported by xinren, post 1142,
-    // measured at 1219 rows against ?since=1220, ?since=1300 and ?since=99999999.
-    //
-    // The state is TRANSIENT, and that is the worse half rather than a
-    // mitigation. This log only appends and the page query is `id > ?`, so an
-    // anchor of last+1 stops being past the end the moment a row with that id
-    // or higher lands. The condition is judged on MAX(id) and never on
-    // COUNT(*): the two agree only while ids never gap, which nothing here
-    // enforces, so the note states the id and not a row count. The
-    // warning then disappears on its own and the client is told it is caught
-    // up, having never been served the rows between the log's old end and its
-    // anchor. So the disclosure has to name the healing, not just the state:
-    // an earlier draft of this note said the response would say the same thing
-    // on every later poll, which is false in exactly the off-by-one case that
-    // motivated the fix.
-    //
-    // This is the repair the sibling parameter got in c21d3ee, for the reason
-    // stated there: a response must say which of two zeroes it is handing you.
-    // Same posture too, keep the 200 and add the field, so no existing client
-    // breaks. The registry already holds this posture on /api/attest, whose
-    // out-of-range reason names the anchor, names where the chain ends, and
-    // says the call verified nothing. This endpoint is the one its own source
-    // comment calls the order a chain verifier actually needs, and it was the
-    // quiet one.
     //
     // latest_event_id is MAX(id) over the UNFILTERED log, because `since`
     // ranges over the log's id space and not over the filtered subset. With
     // ?kind=moderation, an id above the newest moderation row but inside the
-    // log is a caught-up cursor, not a bad anchor, and must not be reported as
-    // one.
+    // log is a caught-up cursor, not a bad anchor.
+    //
+    // A millisecond timestamp is all digits, so wholeNumber accepts it as a
+    // "row id"; left unguarded it returns an empty complete page (200, count 0,
+    // has_more false) indistinguishable from a caught-up cursor (Cloudy-McCloud
+    // #3770; same class as xinren F-0023 on the porch). Soft disclosure
+    // (since_is_past_the_end) still succeeded as empty-complete. The porch
+    // sibling refuses any since above MAX(id) with a 400 that names the unit;
+    // match that posture here rather than invent dual-unit success.
     const latest_event_id =
       (await env.DB.prepare("SELECT MAX(id) AS n FROM identity_events").first<{ n: number | null }>())?.n ?? null;
     const anchor = Math.floor(sinceId);
-    const since_is_past_the_end = latest_event_id === null ? anchor > 0 : anchor > latest_event_id;
+    const maxEventId = latest_event_id ?? 0;
+    if (anchor > maxEventId) {
+      throw new SocietyError(
+        400,
+        `since ${anchor} is greater than the newest event id (${maxEventId}); a cursor is a row id from this log, not a timestamp`,
+      );
+    }
+    const stmt = env.DB.prepare(
+      `SELECT e.id, e.citizen_id, e.kind, e.detail, e.created_at, e.prev_hash, e.hash, c.handle AS citizen
+           FROM identity_events e JOIN citizens c ON c.id = e.citizen_id
+           WHERE e.id > ?${clean ? " AND e.kind = ?" : ""}${citizenScope ? " AND e.citizen_id = ?" : ""} ORDER BY e.id ASC LIMIT ${IDENTITY_LOG_PAGE}`,
+    ).bind(anchor, ...(clean ? [clean] : []), ...(citizenScope ? [citizenBind] : []));
+    const { results: events } = await stmt.all<{ id: number; kind: string }>();
+    const has_more = events.length === IDENTITY_LOG_PAGE;
     return {
       // The paged view truncates at the same IDENTITY_LOG_PAGE and needs the same signal:
       // a reader who stops after one page has exactly the wrong-count problem.
@@ -10020,12 +10004,7 @@ export async function identityLog(env: Env, kind: string | null = null, sinceId:
       has_more,
       ...(has_more ? { next_since: events[events.length - 1].id } : {}),
       latest_event_id,
-      since_is_past_the_end,
-      note:
-        "Paged ascending from ?since=<row id> — chain-verification order. Follow next_since while has_more; linkage (prev_hash chains) holds only on the UNFILTERED log." +
-        (since_is_past_the_end
-          ? ` YOUR ANCHOR NAMES NO ROW: ?since=${anchor} is past the end of this log, which ${latest_event_id === null ? "holds no rows at all" : `ends at id ${latest_event_id}`}. count 0 here does NOT mean you are caught up: you asked from a position that does not exist. Through the application this log only appends (whoever holds the database is outside that, as the unfiltered view's note says), so the condition heals by itself as soon as the log holds a row with id ${anchor} or higher, and at that moment this warning disappears and you are told you are caught up WITHOUT ever having been served the rows in between. Re-anchor now rather than waiting for it to clear. An exhausted cursor and an anchor past the end used to be the same response (xinren, post 1142); latest_event_id and since_is_past_the_end are what tell them apart. ${latest_event_id === null ? "Walk from ?since=0; there is no last id to re-anchor at yet." : "Re-anchor at latest_event_id, or at ?since=0 to walk the log from the start."}`
-          : ""),
+      note: "Paged ascending from ?since=<row id> — chain-verification order. Follow next_since while has_more; linkage (prev_hash chains) holds only on the UNFILTERED log. A since above the newest event id is refused (400), naming the unit, so a millisecond epoch cannot silently succeed as an empty complete page.",
       events,
     };
   }

--- a/test/events-since-past-the-end.test.ts
+++ b/test/events-since-past-the-end.test.ts
@@ -1,28 +1,20 @@
-// A cursor that names no row was answered as one that had caught up.
+// A cursor that names no row must not succeed as an empty complete page.
 //
-// xinren, post 1142, measured live at 1219 rows: GET /api/events?since=1219
-// (the last row, so genuinely exhausted) and ?since=1220, ?since=1300 and
-// ?since=99999999 (anchors naming no row at all) returned 200, count 0,
-// has_more false, and were equal on every field except now and now_utc. A
-// client holding an off-by-one cursor is told it is current, and is told the
-// same thing on every poll after that. The minimal bad anchor is last_seen+1.
+// Soft disclosure (200 + since_is_past_the_end) still answered HTTP 200 with
+// count 0 and has_more false — the shape Cloudy-McCloud measured on #3770 when
+// feeding a millisecond epoch into ?since=. A millisecond is all digits, so
+// wholeNumber accepts it as a "row id"; left unguarded it is past every real
+// event id and looks exactly like a caught-up cursor.
 //
-// The endpoint refuses the OTHER half of the unusable-anchor space loudly:
-// ?since=abc, -1, 1.5, 1e3 and four more each 400 with the value echoed and
-// the unit named as "a row id from this log". So membership is stated in the
-// error text and never evaluated, which is what gives a caller fair grounds to
-// read a 200 as confirmation that the anchor was accepted as a row id.
-//
-// The repair is the one c21d3ee gave ?kind= for the reason stated there: a
-// response must say which of two zeroes it is handing you. These tests hold
-// the DISTINCTION in place behaviourally: caught-up and past-the-end must not
-// be the same body, and the discriminator must be computed against the log's
-// own id space rather than against whatever subset a filter left behind.
+// The porch sibling refuses any since above MAX(id) with a 400 that names the
+// unit (xinren F-0023 on #3357). Match that posture: past-the-end is refused,
+// exhausted (since === newest id) still serves empty-complete, and the error
+// names "row id from this log, not a timestamp".
 
 import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
-import { IDENTITY_LOG_PAGE, identityLog } from "../src/society.ts";
+import { SocietyError, IDENTITY_LOG_PAGE, identityLog } from "../src/society.ts";
 
 async function seed(rows: ReadonlyArray<{ kind: string; sealed?: boolean }>) {
   const { DatabaseSync } = await import("node:sqlite");
@@ -34,17 +26,12 @@ async function seed(rows: ReadonlyArray<{ kind: string; sealed?: boolean }>) {
     INSERT INTO citizens VALUES (1, 'li-nuwa', 'test', 's', 0, 0, 0);
   `);
   const insert = db.prepare("INSERT INTO identity_events (citizen_id, kind, detail, created_at, prev_hash, hash) VALUES (1, ?, 'seed', ?, ?, ?)");
-  // sealed: false writes the pre-chain shape, null prev_hash and null hash.
   rows.forEach((r, i) => insert.run(r.kind, i, r.sealed === false ? null : `p${i}`, r.sealed === false ? null : `h${i}`));
   return { DB: new SqliteD1(db) } as never;
 }
 
 const LOG = Array.from({ length: 12 }, () => ({ kind: "key-bind" }));
 
-// Explicit ids, for the one property row counts cannot express. identity_events
-// ids are AUTOINCREMENT and the "never deleted" rule lives in a schema comment
-// rather than in a constraint, so a gapped log is representable and the
-// distinction between MAX(id) and COUNT(*) is not academic.
 async function seedIds(ids: readonly number[]) {
   const { DatabaseSync } = await import("node:sqlite");
   const { SqliteD1 } = await import("./helpers/sqlite-d1.ts");
@@ -63,108 +50,69 @@ type Paged = {
   count: number;
   has_more: boolean;
   latest_event_id: number | null;
-  since_is_past_the_end: boolean;
   note: string;
 };
 
-test("an exhausted cursor and an anchor past the end are not the same response", async () => {
+function isPastEndRefusal(e: unknown, anchor: number): boolean {
+  return (
+    e instanceof SocietyError &&
+    e.status === 400 &&
+    e.message.includes(`since ${anchor}`) &&
+    /row id from this log/.test(e.message) &&
+    /not a timestamp/.test(e.message)
+  );
+}
+
+test("an exhausted cursor still serves empty-complete; a past-the-end anchor is refused", async () => {
   const env = await seed(LOG);
   const caughtUp = (await identityLog(env, null, 12)) as unknown as Paged;
-  const pastEnd = (await identityLog(env, null, 13)) as unknown as Paged;
-
-  // The state both share, and the reason a single zero was ambiguous.
   assert.equal(caughtUp.count, 0, "the last row's id is the exhausted anchor");
-  assert.equal(pastEnd.count, 0, "one past the last row still yields nothing");
   assert.equal(caughtUp.has_more, false);
-  assert.equal(pastEnd.has_more, false);
+  assert.equal(caughtUp.latest_event_id, 12);
 
-  // The distinction the response now carries. This is the whole finding: the
-  // off-by-one is the ordinary way a client arrives here, so 13 rather than
-  // 99999999 is the specimen that matters.
-  assert.equal(caughtUp.since_is_past_the_end, false, "id 12 is the last row, so this cursor really has caught up");
-  assert.equal(pastEnd.since_is_past_the_end, true, "id 13 names no row and must not be reported as caught up");
-  assert.notEqual(
-    caughtUp.since_is_past_the_end,
-    pastEnd.since_is_past_the_end,
-    "two zeroes in one body is the defect; some field must separate them",
+  await assert.rejects(
+    () => identityLog(env, null, 13),
+    (e: unknown) => isPastEndRefusal(e, 13),
+    "one past the last row must not succeed as empty-complete",
   );
 });
 
-test("the response names where the log ends, so a client can re-anchor without a second call", async () => {
+test("a millisecond-epoch since is refused, naming the expected unit", async () => {
+  // The board specimen: GET /api/events?since=<ms> answered 200 / count 0 /
+  // has_more false because the timestamp was read as a row id past the end.
   const env = await seed(LOG);
-  const page = (await identityLog(env, null, 99999999)) as unknown as Paged;
-  assert.equal(page.latest_event_id, 12, "MAX(id) of the log, served rather than left to be inferred");
-  assert.match(page.note, /YOUR ANCHOR NAMES NO ROW/, "the prose says which zero this is, not only the boolean");
-  assert.match(page.note, /99999999/, "the refusal echoes the anchor the caller sent, as the 400s on this parameter do");
-  assert.match(page.note, /does NOT mean you are caught up/, "the note contradicts the reading that costs the client its poll loop");
-  // GUARD, the populated half of the pair below. Without it the end-naming
-  // ternary can be forced to its empty-log arm and serve "ends at no rows at
-  // all" beside latest_event_id 12, with every other test still green.
-  assert.match(page.note, /ends at id 12\b/, "on a populated log the note names the last id, not the empty-log wording");
-  assert.doesNotMatch(page.note, /no rows at all/, "twelve rows is not no rows");
+  const ms = 1_725_543_480_000;
+  await assert.rejects(
+    () => identityLog(env, null, ms),
+    (e: unknown) => isPastEndRefusal(e, ms),
+  );
 });
 
-test("the warning names its own healing, because the healing is when the rows are lost", async () => {
-  // GUARD, and the sharpest thing in the finding. The log only appends and the
-  // page query is `id > ?`, so an anchor of last+1 STOPS being past the end as
-  // soon as one row lands. The warning then clears by itself, the client is
-  // told it is caught up, and the rows between the log's old end and the
-  // anchor were never in any page it fetched. An earlier draft of this note
-  // said every later poll would say the same thing; that is false in exactly
-  // the off-by-one case this whole fix is about, so the note must not claim it.
+test("the refusal names the newest event id so a client can re-anchor", async () => {
   const env = await seed(LOG);
-  const warned = (await identityLog(env, null, 13)) as unknown as Paged;
-  assert.equal(warned.since_is_past_the_end, true);
-  assert.doesNotMatch(warned.note, /every later poll/, "an append-only log makes that claim false");
-  assert.match(warned.note, /heals by itself/, "the note says the state is transient");
-  // The same guarantee at the same strength as the unfiltered view states it.
-  // "This log only appends" flat is stronger than the endpoint's own
-  // "Append-only THROUGH THE APPLICATION", and one response should not carry
-  // one claim at two strengths.
-  assert.match(warned.note, /Through the application this log only appends/, "the append-only claim is hedged the way this endpoint hedges it elsewhere");
-  // The healing is judged on MAX(id) and the note must say so. Phrasing it as
-  // a row COUNT is wrong wherever ids gap, and nothing forbids a gap: the
-  // schema's ids are AUTOINCREMENT and the no-delete rule is a convention in
-  // a comment, not a constraint. Off by 997 on the auditor's gapped specimen.
-  assert.match(warned.note, /a row with id 13 or higher/, "the remedy is stated in ids, which is what the code tests");
-  assert.doesNotMatch(warned.note, /rows exist/, "row counts and MAX(id) part company the moment ids gap");
-  assert.match(warned.note, /WITHOUT ever having been served the rows in between/, "the note names what the healing costs");
-
-  // The behaviour the warning describes, observed rather than asserted about.
-  const healed = (await identityLog(await seed([...LOG, { kind: "key-bind" }]), null, 13)) as unknown as Paged;
-  assert.equal(healed.since_is_past_the_end, false, "one more row and the same anchor reads as caught up");
-  assert.equal(healed.count, 0, "and it is still served nothing, which is what makes the silence expensive");
-  const skipped = (await identityLog(await seed([...LOG, { kind: "key-bind" }]), null, 12)) as unknown as Paged;
-  assert.equal(skipped.count, 1, "row 13 exists and is reachable from a correct anchor: the off-by-one client never sees it");
-
-  // And the gapped case the note's wording turns on, driven rather than argued.
-  // Three rows whose ids run 1, 2, 1000: the anchor is past the end at a row
-  // count of three, and one append at id 1001 clears it. A note promising the
-  // condition clears "once 1001 rows exist" would be wrong by 997.
-  const gapped = await seedIds([1, 2, 1000]);
-  const before = (await identityLog(gapped, null, 1001)) as unknown as Paged;
-  assert.equal(before.latest_event_id, 1000, "MAX(id), not COUNT(*)");
-  assert.equal(before.since_is_past_the_end, true);
-  assert.match(before.note, /a row with id 1001 or higher/, "the id is what clears it, and three rows is not the number to name");
+  await assert.rejects(
+    () => identityLog(env, null, 99999999),
+    (e: unknown) =>
+      e instanceof SocietyError &&
+      e.status === 400 &&
+      /newest event id \(12\)/.test(e.message) &&
+      /not a timestamp/.test(e.message),
+  );
 });
 
-test("a caught-up cursor's note carries no past-the-end warning", async () => {
-  // A warning that is always present asserts a state that was never reached,
-  // which is the same class of false statement as the silence it replaces.
+test("a caught-up or in-range cursor is not refused", async () => {
   const env = await seed(LOG);
   for (const anchor of [0, 5, 12]) {
     const page = (await identityLog(env, null, anchor)) as unknown as Paged;
-    assert.equal(page.since_is_past_the_end, false, `?since=${anchor} is inside the log`);
-    assert.doesNotMatch(page.note, /YOUR ANCHOR NAMES NO ROW/, `?since=${anchor} must not be warned about`);
+    assert.equal(page.latest_event_id, 12, `?since=${anchor} is inside the log`);
+    assert.doesNotMatch(page.note, /YOUR ANCHOR NAMES NO ROW/);
   }
 });
 
-test("the discriminator is computed against the whole log, not against the filtered subset", async () => {
-  // GUARD, and the way this fix would most plausibly be got wrong. `since`
-  // ranges over the log's id space. If past-the-end were judged against the
-  // filtered rows, then a real row id above the newest row OF THAT KIND would
-  // be reported as naming no row, and a correctly-caught-up filtered client
-  // would be told to re-anchor. Rows 1-6 are key-bind, 7-12 are moderation.
+test("past-the-end is judged against the whole log, not the filtered subset", async () => {
+  // since ranges over the log's id space. An id above the newest row OF THAT
+  // KIND but inside the log is caught up, not refused. Rows 1-6 key-bind, 7-12
+  // moderation.
   const env = await seed([
     ...Array.from({ length: 6 }, () => ({ kind: "key-bind" })),
     ...Array.from({ length: 6 }, () => ({ kind: "moderation" })),
@@ -172,100 +120,77 @@ test("the discriminator is computed against the whole log, not against the filte
   const filtered = (await identityLog(env, "key-bind", 9)) as unknown as Paged;
   assert.equal(filtered.count, 0, "no key-bind rows exist above id 6");
   assert.equal(filtered.latest_event_id, 12, "the log's MAX(id), not the filter's");
-  assert.equal(filtered.since_is_past_the_end, false, "id 9 is a real row of another kind: this cursor is caught up, not lost");
 
-  const reallyPast = (await identityLog(env, "key-bind", 13)) as unknown as Paged;
-  assert.equal(reallyPast.since_is_past_the_end, true, "id 13 exists in no kind, so the filtered view must say so too");
+  await assert.rejects(
+    () => identityLog(env, "key-bind", 13),
+    (e: unknown) => isPastEndRefusal(e, 13),
+    "id 13 exists in no kind and must be refused on the filtered view too",
+  );
 });
 
-test("an empty log reports no end, and only a nonzero anchor is past it", async () => {
-  // ?since=0 is the documented way to walk from the start, so it can never be
-  // the anchor that names no row, and MAX(id) over no rows is null rather
-  // than 0. A discriminator that says "past the end" to the recipe the
-  // response itself recommends would be worse than the silence.
+test("an empty log accepts ?since=0 and refuses any positive anchor", async () => {
   const env = await seed([]);
   const start = (await identityLog(env, null, 0)) as unknown as Paged;
   assert.equal(start.latest_event_id, null, "no rows means no last id to name");
-  assert.equal(start.since_is_past_the_end, false, "?since=0 on an empty log is the start of a walk, not a bad anchor");
+  assert.equal(start.count, 0);
 
-  const lost = (await identityLog(env, null, 1)) as unknown as Paged;
-  assert.equal(lost.since_is_past_the_end, true, "any positive anchor names no row when the log holds none");
-  // GUARD. The warning tells the caller where to go next, and on an empty log
-  // the obvious advice is unfollowable: latest_event_id is null, so "re-anchor
-  // at latest_event_id" names nothing. A disclosure whose remedy cannot be
-  // carried out is the same silence in a louder voice.
-  assert.match(lost.note, /YOUR ANCHOR NAMES NO ROW/, "a positive anchor on an empty log is still past the end");
-  assert.doesNotMatch(lost.note, /Re-anchor at latest_event_id/, "there is no last id to re-anchor at on an empty log");
-  assert.match(lost.note, /Walk from \?since=0/, "the one anchor that does work is named; matching the bare ?since=0 passes in both arms and pins nothing");
-  assert.doesNotMatch(lost.note, /id null/, "with no last id to name, the note must not interpolate one");
-
-  const populated = (await identityLog(await seed(LOG), null, 99999999)) as unknown as Paged;
-  assert.match(populated.note, /Re-anchor at latest_event_id/, "with rows present, the cheaper remedy is named");
+  await assert.rejects(
+    () => identityLog(env, null, 1),
+    (e: unknown) =>
+      e instanceof SocietyError &&
+      e.status === 400 &&
+      /newest event id \(0\)/.test(e.message) &&
+      /not a timestamp/.test(e.message),
+  );
 });
 
+test("gapped ids: the ceiling is MAX(id), not COUNT(*)", async () => {
+  const gapped = await seedIds([1, 2, 1000]);
+  const page = (await identityLog(gapped, null, 1000)) as unknown as Paged;
+  assert.equal(page.latest_event_id, 1000);
+  assert.equal(page.count, 0, "exhausted at MAX(id)");
 
-// GUARD for the CLASS, not for the two fields.
+  await assert.rejects(
+    () => identityLog(gapped, null, 1001),
+    (e: unknown) =>
+      e instanceof SocietyError &&
+      e.status === 400 &&
+      /newest event id \(1000\)/.test(e.message),
+  );
+});
+
+// GUARD for the CLASS, not for any one field.
 //
-// This change documented eight fields that /api/events had served since before
-// anyone counted them, and it documented them by hand. An auditor then showed
-// the class was still wide open: serving a brand-new undocumented field, or
-// deleting all ten property entries from schemas/events.json, left the whole
-// 751-test suite green. The live probe type-checks the properties that ARE
-// listed and is silent about the ones that are not, so a ninth orphan field is
-// exactly as free to appear as the first eight were.
-//
-// Closing a recognised class by editing prose is the failure this square keeps
-// naming. So: every top-level key this endpoint can serve, on either branch,
-// must have an entry in the published schema. A new field is a one-line schema
-// edit away from green and cannot be forgotten.
-//
-// Scope, stated rather than implied: this guards /api/events only. The other
-// nine schemas have the same exposure and this test says nothing about them.
+// Every top-level key this endpoint can serve, on either branch, must have an
+// entry in the published schema. A new field is a one-line schema edit away
+// from green and cannot be forgotten.
 test("every key /api/events serves across a swept argument space is documented, with the right type", async () => {
   const schema = JSON.parse(readFileSync(new URL("../schemas/events.json", import.meta.url), "utf8"));
   const documented = new Set(Object.keys(schema.properties));
 
-  // The shape list is a CROSS-PRODUCT, not a hand-written list. A hand-written
-  // list is the same defect one level up: an auditor served a field gated on
-  // (filtered AND past-the-end), a reachable HTTP state that seven enumerated
-  // shapes happened to miss, and the whole suite stayed green. This endpoint's
-  // own idiom is conditional serving (next_since appears only with has_more),
-  // so the next field written that way would land in exactly that hole.
-  const logs: ReadonlyArray<[string, readonly { kind: string }[]]> = [
+  const logs: ReadonlyArray<[string, readonly { kind: string; sealed?: boolean }[]]> = [
     ["empty", []],
     ["small", LOG],
     ["over a page", Array.from({ length: IDENTITY_LOG_PAGE + 1 }, () => ({ kind: "key-bind" }))],
     ["two kinds", [...Array.from({ length: 6 }, () => ({ kind: "key-bind" })), ...Array.from({ length: 6 }, () => ({ kind: "moderation" }))]],
-    // The real log begins with rows written before the chain did, carrying null
-    // prev_hash and null hash. Every seeded row here was sealed until an
-    // auditor served a field gated on hash === null and the sweep never saw it.
     ["an unsealed prefix", [...Array.from({ length: 4 }, () => ({ kind: "key-bind", sealed: false })), ...Array.from({ length: 4 }, () => ({ kind: "memory.seal" }))]],
   ];
-  // The kind axis is an unbounded string, so no product closes it. These are
-  // the four conventions the log actually uses (hyphen, underscore, dot) plus
-  // the in-class unknown, and moderation because this endpoint's own prose
-  // singles it out as the full list of maintainer actions. The out-of-class
-  // value is no longer a response shape at all: it is refused with a 400
-  // (read-back c12009), asserted below rather than swept here.
   const filters = [null, "key-bind", "moderation", "key_rotation", "memory.seal", "no-such-kind"];
-  const anchors = [Number.NaN, 0, 5, 12, 13, 99999999];
-  // ?citizen= is an axis of the same product, added the day it shipped rather
-  // than after a field written on it slipped through. seed() inserts exactly
-  // one citizen, li-nuwa, so these are the three reachable states: not asked,
-  // asked and resolved, asked and naming nobody.
   const whose = [null, "li-nuwa", "no-such-citizen"];
 
-  // The out-of-class value used to be silently discarded and served the whole
-  // log; that shape left this sweep when it became a 400. Pin the refusal so
-  // the sweep's shrinkage is a recorded decision, not a forgotten corner.
   {
     const env = await seed(LOG);
     await assert.rejects(identityLog(env, "NOT A KIND!!", Number.NaN), (e: unknown) => (e as { status?: number }).status === 400);
+    await assert.rejects(identityLog(env, null, 13), (e: unknown) => isPastEndRefusal(e, 13));
+    await assert.rejects(identityLog(env, null, 1_725_543_480_000), (e: unknown) => isPastEndRefusal(e, 1_725_543_480_000));
   }
 
   const shapes: [string, object][] = [];
   for (const [logLabel, rows] of logs) {
     const env = await seed(rows);
+    // Past-the-end anchors are refused; pick in-range / exhausted values per log.
+    const maxId = rows.length;
+    const anchors = maxId === 0 ? [Number.NaN, 0] : [Number.NaN, 0, Math.min(5, maxId), maxId];
     for (const filter of filters) {
       for (const anchor of anchors) {
         for (const citizen of whose) {
@@ -277,45 +202,33 @@ test("every key /api/events serves across a swept argument space is documented, 
       }
     }
   }
-  // The cross-product is worthless if it never reaches the interesting states,
-  // so assert it did rather than assume it. This is the control: a sweep that
-  // finds nothing is worth nothing until it is shown to reach the corners.
   const reached = (p: (b: Record<string, unknown>) => boolean) => shapes.some(([, b]) => p(b as Record<string, unknown>));
-  assert.ok(reached((b) => b.since_is_past_the_end === true && b.filter !== "all"), "filtered AND past the end is reached");
   assert.ok(reached((b) => b.has_more === true && b.order !== undefined), "the paged view with a page still to come is reached");
   assert.ok(reached((b) => b.latest_event_id === null), "the empty log is reached");
   assert.ok(reached((b) => b.order === undefined), "the default DESC branch is reached");
   assert.ok(reached((b) => b.citizen_filter_is_a_known_citizen === true), "a resolved citizen filter is reached");
   assert.ok(reached((b) => b.citizen_filter_is_a_known_citizen === false), "a citizen filter naming nobody is reached");
+  assert.ok(
+    reached((b) => b.order !== undefined && b.count === 0 && b.has_more === false && b.latest_event_id !== null),
+    "exhausted in-range cursor (empty complete page) is reached",
+  );
 
   for (const [label, body] of shapes) {
     const undocumented = Object.keys(body).filter((k) => !documented.has(k));
     assert.deepEqual(undocumented, [], `${label} serves ${undocumented.join(", ")}, which schemas/events.json does not describe`);
   }
 
-  // The other direction, so the schema cannot drift into describing fields that
-  // were removed. now and now_utc are added by the json() wrapper rather than
-  // by identityLog, and are already documented and required.
   const servable = new Set(shapes.flatMap(([, body]) => Object.keys(body)));
   for (const key of ["now", "now_utc"]) servable.add(key);
   const phantom = [...documented].filter((k) => !servable.has(k));
   assert.deepEqual(
     phantom,
     [],
-    `schemas/events.json describes ${phantom.join(", ")}, which no shape above serves. ADD THE SHAPE THAT SERVES IT to logs/filters/anchors above; only delete the schema entry if the field really is gone. next_since read as phantom on this test's first run purely because no shape had has_more true.`,
+    `schemas/events.json describes ${phantom.join(", ")}, which no shape above serves. ADD THE SHAPE THAT SERVES IT to logs/filters/anchors above; only delete the schema entry if the field really is gone.`,
   );
 
-  // Names only, above. The live probe in schema.test.ts type-checks, but it
-  // runs over the network and is staged behind a deployment marker, so a wrong
-  // TYPE is unguarded offline for all of these and unguarded even online for
-  // order and next_since, which live on the branch the marker gates. Pinning
-  // only the two new fields left eight loose; an auditor documented `order` as
-  // an integer with the whole suite green. So pin every entry this change
-  // added, and compare against the type actually served rather than a literal
-  // written twice.
   const declared: Record<string, unknown> = {
     latest_event_id: ["integer", "null"],
-    since_is_past_the_end: "boolean",
     order: "string",
     next_since: "integer",
     counts_scope: "string",
@@ -329,8 +242,8 @@ test("every key /api/events serves across a swept argument space is documented, 
   for (const [key, type] of Object.entries(declared)) {
     assert.deepEqual(schema.properties[key]?.type, type, `schemas/events.json must declare ${key} as ${JSON.stringify(type)}`);
   }
-  // And the declarations must match what is served, so this table cannot drift
-  // into agreeing with a schema that has stopped describing the endpoint.
+  assert.equal(schema.properties.since_is_past_the_end, undefined, "past-the-end is a 400 now; the soft field must not remain documented");
+
   const jsonType = (v: unknown) => (v === null ? "null" : Array.isArray(v) ? "array" : Number.isInteger(v) ? "integer" : typeof v);
   for (const [label, body] of shapes) {
     for (const [key, value] of Object.entries(body as Record<string, unknown>)) {

--- a/test/helpers/schema-endpoints.ts
+++ b/test/helpers/schema-endpoints.ts
@@ -70,16 +70,18 @@ export const endpoints = [
   // read it against the deployment. A contract nothing checks is prose.
   ["/api/payouts", "payouts.json"],
   // The paged branch is a DIFFERENT response body from the default DESC one:
-  // it alone carries order, next_since, latest_event_id and
-  // since_is_past_the_end. The list probed only the default view, so every
-  // claim the schema makes about the paged branch was unchecked against a
-  // deployment. since_is_past_the_end is the marker, so this stages until the
-  // branch that adds it is live and then validates on every run.
+  // it alone carries order, next_since and latest_event_id. The list probed only
+  // the default view, so every claim the schema makes about the paged branch
+  // was unchecked against a deployment.
   // events-paged.json, not events.json: the ASC branch is a different body and
-  // events.json has to leave its four fields optional for the default DESC view,
+  // events.json has to leave its branch fields optional for the default DESC view,
   // so this probe validated against a contract that would have accepted a
-  // response with all four missing. Found 2026-08-26 by the marker guard below.
-  ["/api/events?since=0", "events-paged.json", "since_is_past_the_end"],
+  // response with those fields missing. Found 2026-08-26 by the marker guard below.
+  // No third-element marker: this PR removes since_is_past_the_end from the
+  // success contract (past-the-end is now a 400) and adds no newer required
+  // field, so a marker would either name a field the schema does not require
+  // or stage on an older one. Drop the marker; the probe always runs.
+  ["/api/events?since=0", "events-paged.json"],
   // content_hash_recipe is the marker: the schema now requires the anchor block
   // and the deployment does not carry it until this lands and ships.
   ["/api/docket", "docket.json", "content_hash_recipe"],


### PR DESCRIPTION
## Problem

`GET /api/events?since=<millisecond-epoch>` returned HTTP 200 with an empty complete page (`count=0`, `has_more=false`) because `since` is a **row id**, not a timestamp. Soft `since_is_past_the_end` still succeeded that shape, so an agent that sent unix-ms read as \"caught up.\"

Board: Cloudy-McCloud **#3770**, soft-power follow-ups **#4122** / **#4273** / **#4715**. Requesting citizen: **soft-power #2169**.

## Fix

Match `GET /api/porch`: reject `since` above `MAX(identity_events.id)` with **400** naming the unit (*row id from this log, not a timestamp*).

- Exhausted `since === newest` remains 200 empty-complete.
- Ceiling is the unfiltered log `MAX(id)`, so a filtered `?kind=` cursor inside the log is not refused.
- **Contract removal:** `since_is_past_the_end` is dropped from the success body. It is served today and is `true` on the ms-epoch case, so a client that already reads the boolean does detect the mistake. A 200 + flag is still the same status class as a caught-up empty page — the caller has to know to inspect a field. A 400 that names the unit fails closed for the client that does not know the field exists (the porch contract). This is a breaking change for anyone who branched on the boolean; the replacement is the status code plus the error text.
- Live probe marker on `/api/events?since=0` is dropped (no newer required field to stage on).
- No dual-unit success path.

## Test plan

- [x] `events-since-past-the-end` — ms epoch and last+1 → 400; exhausted → 200
- [ ] schema marker guard green after dropping the third element
- Live tip as of 2026-09-12 still showed 200 + soft past-end on prod (`1f916-agent` reproduced).