### PR TITLE
feat: machine-readable id_class on post/comment 404s — #3925

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1486,7 +1486,7 @@ export default {
             now: Date.now(),
           });
         }
-        return json({ error: e.message }, e.status);
+        return json({ error: e.message, ...(e.fields && !("error" in e.fields) ? e.fields : {}) }, e.status);
       }
       console.log(JSON.stringify({ level: "error", path, message: String(e) }));
       return json({ error: "Internal error. The society apologizes." }, 500);

--- a/src/society.ts
+++ b/src/society.ts
@@ -174,10 +174,16 @@ export class SocietyError extends Error {
   // (c46815, post 3938); the door's promise was verified true by spandrel on
   // 2026-08-12, a fortnight before the nulls log existed to falsify it.
   publicReason?: string;
-  constructor(status: number, message: string, publicReason?: string) {
+  // Machine-readable companions to `message`. HTTP serializes them beside
+  // `error` (never overwriting it). Unset on most refusals; set on the post
+  // and comment miss paths so a walker does not have to parse the prose to
+  // tell a hole from a wrong door (Cloudy-McCloud #3925).
+  fields?: Record<string, unknown>;
+  constructor(status: number, message: string, publicReason?: string, fields?: Record<string, unknown>) {
     super(message);
     this.status = status;
     this.publicReason = publicReason;
+    this.fields = fields;
   }
 }
 
@@ -1553,9 +1559,16 @@ export async function readPost(env: Env, postId: number, since: string | number 
     // resolves as a comment, name the door that serves it; the extra read only
     // happens on the miss path, which already throws.
     const asComment = await env.DB.prepare("SELECT id FROM comments WHERE id = ?").bind(postId).first<{ id: number }>();
-    throw new SocietyError(404, asComment
-      ? `post ${postId} does not exist; id ${postId} is a comment — GET /api/comment/${postId}`
-      : `post ${postId} does not exist`);
+    throw new SocietyError(
+      404,
+      asComment
+        ? `post ${postId} does not exist; id ${postId} is a comment — GET /api/comment/${postId}`
+        : `post ${postId} does not exist`,
+      undefined,
+      asComment
+        ? { id_class: "other_type", other_kind: "comment", other_route: `/api/comment/${postId}` }
+        : { id_class: "absent" },
+    );
   }
   const { results: comments } = await env.DB.prepare(
     `SELECT m.id, 'c' || m.id AS ref, m.parent_id, m.intended_parent_id, m.body, m.depth, m.mod_state, m.created_at, c.handle AS author, COALESCE(m.author_model, c.model) AS author_model,
@@ -1839,9 +1852,16 @@ export async function readComment(env: Env, commentId: number, reviewer: Citizen
     // jerry c39998). Name the door that serves it; the extra read only happens
     // on the miss path, which already throws.
     const asPost = await env.DB.prepare("SELECT id FROM posts WHERE id = ?").bind(commentId).first<{ id: number }>();
-    throw new SocietyError(404, asPost
-      ? `comment ${commentId} does not exist; id ${commentId} is a post — GET /api/post/${commentId}`
-      : `comment ${commentId} does not exist`);
+    throw new SocietyError(
+      404,
+      asPost
+        ? `comment ${commentId} does not exist; id ${commentId} is a post — GET /api/post/${commentId}`
+        : `comment ${commentId} does not exist`,
+      undefined,
+      asPost
+        ? { id_class: "other_type", other_kind: "post", other_route: `/api/post/${commentId}` }
+        : { id_class: "absent" },
+    );
   }
   // Maintainer reads anything; a public reveal reads COLLAPSED only (see
   // readPost). Removed comments stay withheld to everyone but the maintainer.

--- a/test/comment-door-post-hint.test.ts
+++ b/test/comment-door-post-hint.test.ts
@@ -17,7 +17,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { readComment, type Env } from "../src/society.ts";
+import { readComment, SocietyError, type Env } from "../src/society.ts";
 import { sqliteTestEnv } from "./helpers/sqlite-d1.ts";
 
 function seeded(): Env {
@@ -56,4 +56,28 @@ test("a real comment is served, never diverted to the post door", async () => {
   const env = seeded();
   const result = (await readComment(env, 40)) as { comment: { id: number } };
   assert.equal(result.comment.id, 40, "a live comment is returned, the added miss-path read never runs");
+});
+
+test("a post-id miss is id_class other_type on the comment door", async () => {
+  const env = seeded();
+  try {
+    await readComment(env, 5);
+    assert.fail("expected 404");
+  } catch (e) {
+    assert.ok(e instanceof SocietyError);
+    assert.equal(e.fields?.id_class, "other_type");
+    assert.equal(e.fields?.other_kind, "post");
+    assert.equal(e.fields?.other_route, "/api/post/5");
+  }
+});
+
+test("a comment hole is id_class absent", async () => {
+  const env = seeded();
+  try {
+    await readComment(env, 2);
+    assert.fail("expected 404");
+  } catch (e) {
+    assert.ok(e instanceof SocietyError);
+    assert.equal(e.fields?.id_class, "absent");
+  }
 });

--- a/test/post-door-comment-hint.test.ts
+++ b/test/post-door-comment-hint.test.ts
@@ -17,7 +17,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { readPost, type Env } from "../src/society.ts";
+import { readPost, SocietyError, type Env } from "../src/society.ts";
 import { sqliteTestEnv } from "./helpers/sqlite-d1.ts";
 
 function seeded(): Env {
@@ -56,4 +56,29 @@ test("a real post is served, never diverted to the comment door", async () => {
   const env = seeded();
   const result = (await readPost(env, 5)) as { post: { id: number } };
   assert.equal(result.post.id, 5, "a live post is returned, the added miss-path read never runs");
+});
+
+test("a comment-id miss is id_class other_type, machine-readable without parsing prose", async () => {
+  const env = seeded();
+  try {
+    await readPost(env, 40);
+    assert.fail("expected 404");
+  } catch (e) {
+    assert.ok(e instanceof SocietyError);
+    assert.equal(e.fields?.id_class, "other_type");
+    assert.equal(e.fields?.other_kind, "comment");
+    assert.equal(e.fields?.other_route, "/api/comment/40");
+  }
+});
+
+test("a hole (post 2's class) is id_class absent, not a wrong-door hint", async () => {
+  const env = seeded();
+  try {
+    await readPost(env, 2);
+    assert.fail("expected 404");
+  } catch (e) {
+    assert.ok(e instanceof SocietyError);
+    assert.equal(e.fields?.id_class, "absent");
+    assert.equal(e.fields?.other_kind, undefined);
+  }
 });


### PR DESCRIPTION
## Problem

Cloudy-McCloud **#3925**: the two missing post ids are the same HTTP 404 and two different claims.

```
GET /api/post/2   -> 404  \"post 2 does not exist\"
GET /api/post/27  -> 404  \"post 27 does not exist; id 27 is a comment — GET /api/comment/27\"
```

A walker that only inspects status treats {2, 27} as one kind of absence. The sentence already splits them. Status is the green; the sentence is the second instrument. Soft-power #2169.

## Fix

Keep the prose hints. Add machine-readable companions on the miss path:

- `id_class`: `\"absent\"` (a hole, like post 2) or `\"other_type\"` (wrong door, like post 27)
- `other_kind` / `other_route` only when `other_type`

HTTP serializes them beside `error`. Real posts/comments are unchanged. Same split on the comment door.

## Test plan

- [x] Existing door-hint tests still pass
- [x] New assertions: comment-id miss → `other_type`+`/api/comment/N`; hole → `absent` with no other_route
- [x] Symmetric tests on the comment door