### PR TITLE
fix: /api/proof/:id 404 names the query-shaped contract — #4036

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1457,6 +1457,30 @@ export default {
             now: Date.now(),
           });
         }
+        // #4036 (Cloudy-McCloud): /api/proof/20 and /api/proof?log=ledger&event=20
+        // were both 404 with different sentences. The query form names a missing
+        // leaf; the path form used to look like an unclassified route miss (and
+        // once suggested posts/comments). Path cannot know which log. Name the
+        // query-shaped contract and both legal logs; do not invent a proof.
+        const proofPath = method === "GET" ? want.match(/^\/api\/proof\/(\d+)$/) : null;
+        if (proofPath) {
+          const event = proofPath[1];
+          const try_routes = [
+            `/api/proof?log=ledger&event=${event}`,
+            `/api/proof?log=identity_events&event=${event}`,
+          ];
+          return json(
+            {
+              error: `Not found: GET /api/proof/${event} — proofs are query-shaped, not a path id. Try GET /api/proof?log=ledger&event=${event} or GET /api/proof?log=identity_events&event=${event}`,
+              did_you_mean: ["GET /api/proof"],
+              route_shape: "query_only",
+              event: Number(event),
+              try_routes,
+              hint: `${url.origin}/api/surface lists every route this registry serves; ${url.origin}/ is the same thing in prose.`,
+            },
+            404,
+          );
+        }
         return json(
           {
             error: `Not found: ${method} ${path}`,

--- a/test/proof-path-suggests-its-own-route.test.ts
+++ b/test/proof-path-suggests-its-own-route.test.ts
@@ -47,3 +47,39 @@ test("a same-length guess still falls back to the position scorer (unchanged)", 
     `same-length near-miss must still name the citizen route, got ${JSON.stringify(body.did_you_mean)}`,
   );
 });
+
+test("GET /api/proof/20 names the query-shaped contract, not a bare route miss", async () => {
+  // #4036 remainder: did_you_mean now points at GET /api/proof, but the
+  // sentence was still "Not found: GET /api/proof/20" — a walker treating
+  // both 404s as "no proof" collapsed a missing leaf with a missing route.
+  // Path cannot know the log; name both legal query forms and a machine field.
+  const { env } = sqliteTestEnv(schema);
+  const res = await worker.fetch(new Request(`${ORIGIN}/api/proof/20`), env);
+  assert.equal(res.status, 404);
+  const body = (await res.json()) as {
+    error?: string;
+    did_you_mean?: string[];
+    route_shape?: string;
+    event?: number;
+    try_routes?: string[];
+  };
+  assert.equal(body.route_shape, "query_only", "route_shape must be on the wire; prose-only is the #3925 class again");
+  assert.equal(body.event, 20);
+  assert.deepEqual(body.try_routes, [
+    "/api/proof?log=ledger&event=20",
+    "/api/proof?log=identity_events&event=20",
+  ]);
+  assert.match(String(body.error), /query-shaped/);
+  assert.match(String(body.error), /log=ledger&event=20/);
+  assert.match(String(body.error), /log=identity_events&event=20/);
+  assert.deepEqual(body.did_you_mean, ["GET /api/proof"]);
+});
+
+test("GET /api/proof?log=ledger&event=20 stays a typed leaf 404, not the path sentence", async () => {
+  const { env } = sqliteTestEnv(schema);
+  const res = await worker.fetch(new Request(`${ORIGIN}/api/proof?log=ledger&event=20`), env);
+  assert.equal(res.status, 404);
+  const body = (await res.json()) as { error?: string; route_shape?: string };
+  assert.match(String(body.error), /ledger has no row 20/);
+  assert.equal(body.route_shape, undefined, "query-form typed absence must not wear the path-form marker");
+});


### PR DESCRIPTION
## Problem

Cloudy-McCloud **#4036**: the same missing leaf is two 404s.

```
GET /api/proof?log=ledger&event=20  →  404  "ledger has no row 20"
GET /api/proof/20                   →  404  "Not found: GET /api/proof/20"
```

`did_you_mean` already points at `GET /api/proof` (337ffafb). The sentences still disagree. A walker that treats both 404s as "no proof" collapses a missing leaf with a missing route — the #3925 class, one surface over.

## Change

Keep the query-form typed 404. `GET /api/proof/<digits>` now:

- says proofs are query-shaped, not a path id
- names both legal tries (`?log=ledger&event=N` and `?log=identity_events&event=N`) — the path cannot know which log
- serves `route_shape: "query_only"`, `event`, and `try_routes` so a client need not parse prose
- still `did_you_mean: ["GET /api/proof"]` (no posts/comments/attestations)

Does not invent an inclusion proof on the path.

## Test plan

- [x] existing did_you_mean test still 4/4 with the new cases
- [x] path 404 carries `route_shape` / `try_routes` on the worker
- [x] query form stays `ledger has no row 20`
- [ ] CI node 22 / 22.23.2 / 24