### PR TITLE
observer: page the wide range, because no public provider answers 10,000 blocks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1562,7 +1562,10 @@ export default {
         // a provider outage is logged and never reaches the checkpoint.
         try {
           const observed = await observeFunderWallets(env);
-          if (observed.wallet && (observed.rows > 0 || observed.error)) console.log(JSON.stringify({ level: observed.error ? "warn" : "info", what: "observer", ...observed }));
+          // A stride cut short by a refused page writes rows and still needs
+          // saying, even when the pages it did get held nothing.
+          if (observed.wallet && (observed.rows > 0 || observed.error || observed.partial))
+            console.log(JSON.stringify({ level: observed.error || observed.partial ? "warn" : "info", what: "observer", ...observed }));
         } catch (e) {
           console.log(JSON.stringify({ level: "error", what: "observer", message: String(e).slice(0, 200) }));
         }

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -19,7 +19,10 @@
 //
 // Budget: the cron shares a subrequest budget with checkpoints and doorbells.
 // One wallet per cycle, at most OBSERVER_PROVIDER_ATTEMPTS providers, one
-// getLogs each, plus one finalized-head read per provider that answers.
+// getLogs each over the FIRST page, plus one finalized-head read per provider
+// that answers, plus one getLogs per remaining page from each of the two that
+// agreed. At most OBSERVER_MAX_PAGES_PER_CYCLE pages, so the walk's cost is
+// bounded by a constant and not by how far behind the mark has fallen.
 
 import type { Env } from "./society.ts";
 import { baseRpcUrls, rpc } from "./payouts.ts";
@@ -29,16 +32,65 @@ import { baseRpcUrls, rpc } from "./payouts.ts";
 // 1,000; 1rpc at 50; mainnet.base.org takes more but one provider is not
 // agreement). Measured by the pre-deploy auditor 2026-09-08.
 export const OBSERVER_BLOCKS_PER_CYCLE = 1_000;
-// With a keyed endpoint configured the range per cycle grows tenfold: Infura
-// (measured 2026-09-08) and https://mainnet.base.org both accept 10,000-block
-// log queries, so the keyed voice and the public Base endpoint can agree on
-// the wide range; the providers that cap lower simply do not vote. (QuickNode's
-// free trial caps eth_getLogs at FIVE blocks and was removed the same night.)
-// No keyed endpoint: the 1,000 that tenderly accepts, so any two of the
-// public pool can still agree.
+// With a keyed endpoint configured the BLOCKS COVERED per cycle grow tenfold.
+// This is the cycle's stride, not the width of one question; see
+// OBSERVER_BLOCKS_PER_PAGE. (QuickNode's free trial caps eth_getLogs at FIVE
+// blocks and was removed the same night.) No keyed endpoint: the 1,000 that
+// tenderly accepts, so any two of the public pool can still agree.
 export const OBSERVER_BLOCKS_PER_CYCLE_KEYED = 10_000;
 export function blocksPerCycle(env: Env): number {
   return env.BASE_RPC_PRIVATE_URL || env.BASE_RPC_PRIVATE_URL_2 ? OBSERVER_BLOCKS_PER_CYCLE_KEYED : OBSERVER_BLOCKS_PER_CYCLE;
+}
+
+// ONE QUESTION IS NEVER WIDER THAN THE PUBLIC POOL ANSWERS, however wide the
+// cycle's stride is. Until now the two were the same number, and the comment
+// that justified the wide one rested on a single measurement that does not
+// hold: mainnet.base.org does NOT answer a 10,000-block eth_getLogs.
+//
+// Re-measured 2026-09-12 from outside Cloudflare's egress, at the exact
+// inclusive widths walkWallet asks for, against the five endpoints this file
+// actually tries (reported in c56583 on #3525):
+//   mainnet.base.org         2,000 ok; 5,000+ -32614 "eth_getLogs is limited to a 2,000 range"
+//   base-rpc.publicnode.com  5,000 ok; 10,000 -32602 "Archive requests require a personal token"
+//   base.gateway.tenderly.co 1,000 ok; 1,500+ -32602 "invalid params"
+//   base.drpc.org            refuses EVERY width, 1,000 included, error 35
+//   1rpc.io/base             50 blocks
+// So with one keyed endpoint the keyed voice was the only one that could
+// answer the wide question, and "two independently operated providers return
+// the same logs for the same range" was unsatisfiable by construction. Every
+// mark on /api/rail read "no two providers agreed (1 answered)", and the four
+// funder wallets sat 22 to 26 days behind finality.
+//
+// The page width is 1,000 rather than 2,000 because of who can vote at each.
+// Re-measured 2026-09-12T15:20Z, asking each provider five times per width
+// with the observer's own query shape (span = toBlock - fromBlock):
+//   span 1,000  mainnet.base.org 5/5, publicnode 5/5, tenderly 5/5 (42 logs each)
+//   span 2,000  mainnet.base.org 5/5, publicnode 5/5, tenderly 0/5 (-32602)
+// At 1,000 three independently operated providers answer, so any two can agree
+// and one may fail without stalling the walk. At 2,000 exactly two can, and
+// the rule has no margin left: one bad minute at either and the cycle banks
+// nothing. A 1,000-block page is a 999-block span, inside every one of those
+// three caps.
+//
+// The cost is subrequests, and it is not free. Worst case per cycle is
+// OBSERVER_PROVIDER_ATTEMPTS getLogs on page 1, one finalized-head read per
+// provider that answers, then two getLogs per remaining page: 5 + 5 + 9x2 = 28
+// at ten pages, against 5 + 5 + 4x2 = 18 at five pages of 2,000, and the cron
+// shares that budget with checkpoints and doorbells. If that budget matters
+// more than the third voter, 2_000 x 5 is the same 10,000 stride in one line.
+//
+// NOT MEASURED HERE, and it may be the binding constraint rather than this
+// one: what Cloudflare's egress sees. Those same marks record their last
+// failure as "Error: rpc unavailable (HTTP 429)" (c1574), which a narrower
+// question does not by itself fix. What paging does fix is that a page that
+// DID get two answers is now kept: see the partial-progress rule below.
+export const OBSERVER_BLOCKS_PER_PAGE = 1_000;
+// The hard subrequest bound. blocksPerCycle is the stride we WANT; this is the
+// most pages one cycle may spend to get it, so raising the stride can never
+// silently multiply the cron's outbound calls. 1,000 x 10 is today's 10,000.
+export const OBSERVER_MAX_PAGES_PER_CYCLE = 10;
+export function blocksPerCycleCapped(env: Env): number {
+  return Math.min(blocksPerCycle(env), OBSERVER_BLOCKS_PER_PAGE * OBSERVER_MAX_PAGES_PER_CYCLE);
 }
 
 // The public Base endpoint answers 429 under burst and is the observer's
@@ -212,6 +264,11 @@ export interface ObserverResult {
   payments: number;
   zero_value: number;
   sources: number;
+  // How many pages of OBSERVER_BLOCKS_PER_PAGE the two agreeing providers
+  // actually answered. Fewer than the cycle asked for means a later page was
+  // refused or disagreed and the walk banked what it had; partial names why.
+  pages: number;
+  partial?: string;
   error?: string;
 }
 
@@ -220,7 +277,7 @@ export interface ObserverResult {
 // anywhere is simply retried from the same block next time.
 export async function observeFunderWallets(env: Env, deps: ObserverDeps = {}): Promise<ObserverResult> {
   const wallet = await nextWallet(env);
-  if (!wallet) return { wallet: null, from_block: 0, to_block: 0, rows: 0, payments: 0, zero_value: 0, sources: 0 };
+  if (!wallet) return { wallet: null, from_block: 0, to_block: 0, rows: 0, payments: 0, zero_value: 0, sources: 0, pages: 0 };
   try {
     return await walkWallet(env, wallet, deps);
   } catch (e) {
@@ -252,8 +309,15 @@ async function walkWallet(env: Env, wallet: WalletRow, deps: ObserverDeps): Prom
   const answers: Answer[] = [];
   let fromBlock = 0;
   let toBlock = 0;
+  let pageTo = 0;
   let agreed: Answer[] | null = null;
   let lastError = "";
+  const getLogs = async (url: string, from: number, to: number): Promise<TransferLog[]> => {
+    const raw = await callWithRetry(call, url, "eth_getLogs", [
+      { address: [...OBSERVED_TOKENS], fromBlock: "0x" + from.toString(16), toBlock: "0x" + to.toString(16), topics: [TRANSFER_TOPIC, padTopic(funder)] },
+    ]);
+    return parseTransferLogs(raw).filter((l) => l.from === funder);
+  };
   for (const url of urls.slice(0, OBSERVER_PROVIDER_ATTEMPTS)) {
     try {
       const chain = await call(url, "eth_chainId", []);
@@ -269,14 +333,13 @@ async function walkWallet(env: Env, wallet: WalletRow, deps: ObserverDeps): Prom
           ? wallet.last_block + 1
           : Math.max(1, finalized - Math.floor((now() - wallet.earliest_created_at) / 1000 / BASE_BLOCK_SECONDS) - OBSERVER_START_MARGIN_BLOCKS);
         fromBlock = start;
-        toBlock = Math.min(finalized, start + blocksPerCycle(env) - 1);
+        toBlock = Math.min(finalized, start + blocksPerCycleCapped(env) - 1);
+        // Every provider is asked for the FIRST page, never the whole stride.
+        pageTo = Math.min(toBlock, fromBlock + OBSERVER_BLOCKS_PER_PAGE - 1);
       }
       if (finalized < toBlock) continue;
-      if (fromBlock > toBlock) return { wallet: funder, from_block: fromBlock, to_block: toBlock, rows: 0, payments: 0, zero_value: 0, sources: 0 };
-      const raw = await callWithRetry(call, url, "eth_getLogs", [
-        { address: [...OBSERVED_TOKENS], fromBlock: "0x" + fromBlock.toString(16), toBlock: "0x" + toBlock.toString(16), topics: [TRANSFER_TOPIC, padTopic(funder)] },
-      ]);
-      const logs = parseTransferLogs(raw).filter((l) => l.from === funder);
+      if (fromBlock > toBlock) return { wallet: funder, from_block: fromBlock, to_block: toBlock, rows: 0, payments: 0, zero_value: 0, sources: 0, pages: 0 };
+      const logs = await getLogs(url, fromBlock, pageTo);
       const answer = { url, finalized, logs };
       const twin = answers.find((a) => logsAgree(a.logs, logs));
       answers.push(answer);
@@ -295,15 +358,50 @@ async function walkWallet(env: Env, wallet: WalletRow, deps: ObserverDeps): Prom
       `INSERT INTO observer_marks (funder_address, last_block, updated_at, last_error) VALUES (?, NULL, ?, ?)
        ON CONFLICT(funder_address) DO UPDATE SET updated_at = excluded.updated_at, last_error = excluded.last_error`,
     )
-      .bind(funder, now(), `no two providers agreed (${answers.length} answered)${lastError ? ": " + lastError : ""}`)
+      .bind(funder, now(), `no two providers agreed over ${pageTo - fromBlock + 1} blocks (${answers.length} answered)${lastError ? ": " + lastError : ""}`)
       .run();
-    return { wallet: funder, from_block: fromBlock, to_block: toBlock, rows: 0, payments: 0, zero_value: 0, sources: answers.length, error: "no two providers agreed" };
+    return { wallet: funder, from_block: fromBlock, to_block: pageTo, rows: 0, payments: 0, zero_value: 0, sources: answers.length, pages: 0, error: "no two providers agreed" };
   }
 
-  const logs = agreed[1]!.logs.slice(0, OBSERVER_MAX_ROWS_PER_CYCLE);
+  // The rest of the stride, one OBSERVER_BLOCKS_PER_PAGE page at a time, asked
+  // of the SAME two providers that agreed on page one. Each page has to agree
+  // on its own: the two-operator rule is per range, not per cycle.
+  //
+  // PARTIAL PROGRESS IS KEPT. A page that is refused, or on which the two
+  // disagree, ends the walk here rather than discarding the pages behind it.
+  // That is the difference from the old one-question cycle, where a single 429
+  // cost the whole stride: the mark now advances to the last block two
+  // operators actually agreed on, and the next cycle resumes from there.
+  const pageLogs: TransferLog[] = [...agreed[1]!.logs];
+  let walkedTo = pageTo;
+  let pages = 1;
+  let partial = "";
+  while (walkedTo < toBlock && pageLogs.length < OBSERVER_MAX_ROWS_PER_CYCLE) {
+    const from = walkedTo + 1;
+    const to = Math.min(toBlock, from + OBSERVER_BLOCKS_PER_PAGE - 1);
+    let both: TransferLog[][];
+    try {
+      both = [await getLogs(agreed[0]!.url, from, to), await getLogs(agreed[1]!.url, from, to)];
+    } catch (e) {
+      partial = `page ${from}-${to} threw: ${String(e).slice(0, 100)}`;
+      break;
+    }
+    if (!logsAgree(both[0]!, both[1]!)) {
+      partial = `page ${from}-${to}: the two providers disagreed`;
+      break;
+    }
+    // Pages are contiguous, ascending and disjoint, and parseTransferLogs
+    // already sorts within a page, so the concatenation is globally ordered
+    // and the cap below still cuts at a real boundary.
+    pageLogs.push(...both[1]!);
+    walkedTo = to;
+    pages++;
+  }
+
+  const logs = pageLogs.slice(0, OBSERVER_MAX_ROWS_PER_CYCLE);
   // A page cut at the cap advances only to the last block fully covered, so
   // nothing in a partially read block is skipped.
-  const coveredTo = logs.length === OBSERVER_MAX_ROWS_PER_CYCLE ? logs[logs.length - 1]!.block_number - 1 : toBlock;
+  const coveredTo = logs.length === OBSERVER_MAX_ROWS_PER_CYCLE ? logs[logs.length - 1]!.block_number - 1 : walkedTo;
   const index = await bindingIndexFor(env, funder);
   let payments = 0;
   let zero = 0;
@@ -337,13 +435,17 @@ async function walkWallet(env: Env, wallet: WalletRow, deps: ObserverDeps): Prom
   });
   statements.push(
     env.DB.prepare(
-      `INSERT INTO observer_marks (funder_address, last_block, updated_at, last_error, last_range_from, last_range_to, last_range_rows) VALUES (?, ?, ?, NULL, ?, ?, ?)
-       ON CONFLICT(funder_address) DO UPDATE SET last_block = excluded.last_block, updated_at = excluded.updated_at, last_error = NULL,
+      // last_error carries the partial reason when the stride was cut short.
+      // A short walk is still progress and still writes its rows, so the mark
+      // says BOTH how far it got and why it stopped rather than reading as a
+      // clean full cycle.
+      `INSERT INTO observer_marks (funder_address, last_block, updated_at, last_error, last_range_from, last_range_to, last_range_rows) VALUES (?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(funder_address) DO UPDATE SET last_block = excluded.last_block, updated_at = excluded.updated_at, last_error = excluded.last_error,
          last_range_from = excluded.last_range_from, last_range_to = excluded.last_range_to, last_range_rows = excluded.last_range_rows`,
-    ).bind(funder, coveredTo, stamp, fromBlock, coveredTo, covered.length),
+    ).bind(funder, coveredTo, stamp, partial || null, fromBlock, coveredTo, covered.length),
   );
   await env.DB.batch(statements);
-  return { wallet: funder, from_block: fromBlock, to_block: coveredTo, rows: covered.length, payments, zero_value: zero, sources: 2 };
+  return { wallet: funder, from_block: fromBlock, to_block: coveredTo, rows: covered.length, payments, zero_value: zero, sources: 2, pages, ...(partial ? { partial } : {}) };
 }
 
 // What the read surfaces serve. Kept here so every page that mentions an

--- a/src/society.ts
+++ b/src/society.ts
@@ -37,7 +37,7 @@ import { ESCROW_ADDRESS, encodeAddressUint32Arrays, expectedVerifierSetHash, fun
 import { SEALS_PER_DAY, SEAL_CHECKS_PER_DAY, validateSeal, type SealInput, type ValidatedSeal } from "./seals.ts";
 import { diff, replay, type LiveModState } from "./modreplay.ts";
 import { DOORBELL_MAX_FAILURES, DOORBELL_REGISTRATION_COOLDOWN_MS, requestDoorbellProof, validateDoorbellUrl, validateWakeOn } from "./doorbell.ts";
-import { OBSERVED_PAYMENT_NOTE, blocksPerCycle } from "./observer.ts";
+import { OBSERVED_PAYMENT_NOTE, OBSERVER_BLOCKS_PER_PAGE, blocksPerCycleCapped } from "./observer.ts";
 // porch.ts imports back from here (SocietyError, screenGate), so this is a
 // cycle. It is safe because neither module reads the other's bindings at module
 // scope — only inside functions — and one definition of where the porch's UTC
@@ -5793,7 +5793,7 @@ export async function railCensus(env: Env) {
       note: OBSERVED_PAYMENT_NOTE,
       // Emitted from the same branch as the value: the range is piecewise on
       // how many keyed endpoints are configured, so the sentence is too.
-      walk_note: `One funder wallet per five-minute cycle, at most ${blocksPerCycle(env).toLocaleString("en-US")} Base blocks per cycle, two providers agreeing. A wallet with last_block null has never been walked. last_error names the reason the last cycle wrote nothing. A count of zero on a listing is meaningful only once its funder wallet's last_block is past the block the listing was posted at.`,
+      walk_note: `One funder wallet per five-minute cycle, at most ${blocksPerCycleCapped(env).toLocaleString("en-US")} Base blocks per cycle, asked as pages of at most ${OBSERVER_BLOCKS_PER_PAGE.toLocaleString("en-US")} blocks because that is the widest eth_getLogs the public providers answer, two providers agreeing on EVERY page. A page nobody seconds ends the cycle where it stands: the mark holds the last block two operators actually agreed on, never an assumed one. A wallet with last_block null has never been walked. last_error names the reason the last cycle wrote nothing, or stopped short of the full stride. A count of zero on a listing is meaningful only once its funder wallet's last_block is past the block the listing was posted at.`,
     },
     totals: scopedTotals,
     // Every asset priced on this rail, with its own liability. This is the

--- a/test/observer.test.ts
+++ b/test/observer.test.ts
@@ -20,7 +20,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { blocksPerCycle, callWithRetry, classifyTransfer, logsAgree, observeFunderWallets, observerRpcUrls, padTopic, parseTransferLogs, OBSERVER_BLOCKS_PER_CYCLE, OBSERVER_BLOCKS_PER_CYCLE_KEYED, OBSERVER_MAX_ROWS_PER_CYCLE } from "../src/observer.ts";
+import { blocksPerCycle, blocksPerCycleCapped, callWithRetry, classifyTransfer, logsAgree, observeFunderWallets, observerRpcUrls, padTopic, parseTransferLogs, OBSERVER_BLOCKS_PER_CYCLE, OBSERVER_BLOCKS_PER_CYCLE_KEYED, OBSERVER_BLOCKS_PER_PAGE, OBSERVER_MAX_PAGES_PER_CYCLE, OBSERVER_MAX_ROWS_PER_CYCLE, OBSERVER_PROVIDER_ATTEMPTS } from "../src/observer.ts";
 import { baseRpcUrls } from "../src/payouts.ts";
 import { getListing, listListings, type Env } from "../src/society.ts";
 import { sqliteTestEnv } from "./helpers/sqlite-d1.ts";
@@ -290,7 +290,11 @@ test("a configured private RPC endpoint leads both provider lists exactly once",
   assert.deepEqual(observerRpcUrls(both).slice(0, 3), [priv, priv2, "https://mainnet.base.org"]);
   assert.deepEqual(baseRpcUrls(both).slice(0, 2), [priv, priv2]);
   assert.equal(blocksPerCycle(both), OBSERVER_BLOCKS_PER_CYCLE_KEYED);
-  assert.equal(blocksPerCycle(withKey), OBSERVER_BLOCKS_PER_CYCLE_KEYED, "one keyed endpoint plus mainnet.base.org both accept the wide range (killing mutation: require both keyed)");
+  // One keyed endpoint widens the STRIDE, not the width of one question:
+  // mainnet.base.org caps eth_getLogs at 2,000 blocks (re-measured 2026-09-12,
+  // c56583) and cannot second a 10,000-block question at all. The stride is
+  // reached by paging; see the page tests below.
+  assert.equal(blocksPerCycle(withKey), OBSERVER_BLOCKS_PER_CYCLE_KEYED, "one keyed endpoint widens the stride (killing mutation: require both keyed)");
   assert.equal(blocksPerCycle(without), OBSERVER_BLOCKS_PER_CYCLE);
   assert.ok(OBSERVER_BLOCKS_PER_CYCLE_KEYED <= 10_000);
 });
@@ -322,4 +326,143 @@ test("callWithRetry retries exactly once on HTTP 429 and never on anything else"
   const twice = async () => { k++; throw new Error("rpc unavailable (HTTP 429)"); };
   await assert.rejects(() => callWithRetry(twice as never, "u", "m", [], 1), /429/);
   assert.equal(k, 2, "at most one retry");
+});
+
+// ---------------------------------------------------------------------------
+// Paging: one question is never wider than the public pool answers.
+//
+// The regression these three guard, measured live 2026-09-12 (c56583 on #3525):
+// with one keyed endpoint the cycle asked all five providers for 10,000 blocks
+// at once. mainnet.base.org caps eth_getLogs at 2,000, tenderly at under 2,000,
+// publicnode refuses 10,000, drpc refuses every width. Only the keyed voice
+// could answer, so "two independently operated providers" was unsatisfiable by
+// construction and all four marks on /api/rail read "no two providers agreed
+// (1 answered)" with last_block 22 to 26 days behind finality.
+// ---------------------------------------------------------------------------
+
+// A pool that behaves like the real one: `cap` is the widest inclusive range a
+// provider will answer, and anything wider throws the way mainnet.base.org
+// does. `failFrom` refuses exactly one page, to model a mid-walk 429.
+function cappedRpc(answers: Record<string, { logs: unknown[]; cap: number; failFrom?: number }>, finalized = 51_000_000) {
+  const calls: Array<{ url: string; method: string; from?: number; to?: number }> = [];
+  const rpc = async (url: string, method: string, params: unknown[]) => {
+    const who = answers[url];
+    if (!who) throw new Error("rpc unavailable");
+    if (method === "eth_chainId") { calls.push({ url, method }); return "0x2105"; }
+    if (method === "eth_getBlockByNumber") { calls.push({ url, method }); return { number: "0x" + finalized.toString(16), timestamp: "0x1" }; }
+    if (method === "eth_getLogs") {
+      const p = params[0] as { fromBlock: string; toBlock: string };
+      const from = Number(BigInt(p.fromBlock)), to = Number(BigInt(p.toBlock));
+      calls.push({ url, method, from, to });
+      if (to - from + 1 > who.cap) throw new Error(`rpc error -32614: eth_getLogs is limited to a ${who.cap.toLocaleString("en-US")} range`);
+      if (who.failFrom === from) throw new Error("rpc unavailable (HTTP 429)");
+      return (who.logs as Array<{ blockNumber: string }>).filter((l) => { const b = Number(BigInt(l.blockNumber)); return b >= from && b <= to; });
+    }
+    throw new Error("unexpected " + method);
+  };
+  return { rpc, calls };
+}
+
+// Killing mutation: ask the whole stride in one eth_getLogs (revert the page
+// split in walkWallet) -> only the keyed voice answers, sources drops to 1 and
+// the walk writes nothing. That mutation IS the production bug.
+test("a provider that caps eth_getLogs below the cycle stride still votes, because the question is one page wide", async () => {
+  const { env, db } = makeEnv();
+  (env as unknown as { BASE_RPC_PRIVATE_URL: string }).BASE_RPC_PRIVATE_URL = "https://keyed.example/k";
+  const finalized = 51_000_000;
+  db.prepare("INSERT INTO observer_marks (funder_address, last_block, updated_at) VALUES (?, ?, ?)").run(FUNDER, finalized - 100_000, 1);
+  const paid = log(PAYEE, 500000n, finalized - 95_000, tx(1)); // inside page 3
+  const { rpc, calls } = cappedRpc({
+    "https://keyed.example/k": { logs: [paid], cap: 10_000 },
+    // Exactly mainnet.base.org: it can never answer 10,000, and it is the only
+    // other operator in this pool.
+    "https://mainnet.base.org": { logs: [paid], cap: OBSERVER_BLOCKS_PER_PAGE },
+  }, finalized);
+  const r = await observeFunderWallets(env, { rpc, urls: () => ["https://keyed.example/k", "https://mainnet.base.org"] });
+
+  assert.equal(r.error, undefined, "a capped public provider is a voter again");
+  assert.equal(r.sources, 2, "two independently operated providers, not one");
+  assert.equal(r.pages, OBSERVER_BLOCKS_PER_CYCLE_KEYED / OBSERVER_BLOCKS_PER_PAGE);
+  assert.equal(r.to_block - r.from_block + 1, OBSERVER_BLOCKS_PER_CYCLE_KEYED, "the stride is unchanged: paging costs no ground");
+  assert.equal(r.payments, 1);
+  assert.equal(db.prepare("SELECT last_block FROM observer_marks").get()!.last_block, r.to_block);
+  assert.equal(db.prepare("SELECT last_error FROM observer_marks").get()!.last_error, null, "a full stride leaves no error behind");
+  // No single question was ever wider than a page, on ANY provider.
+  const widest = Math.max(...calls.filter((c) => c.method === "eth_getLogs").map((c) => c.to! - c.from! + 1));
+  assert.equal(widest, OBSERVER_BLOCKS_PER_PAGE, "no eth_getLogs is wider than one page");
+});
+
+// Killing mutations: on a page failure, throw instead of breaking (the pages
+// behind it are lost: first assertion red); or set the mark to toBlock rather
+// than the last agreed block (the resume assertion red, and the walk would be
+// claiming blocks nobody seconded).
+test("a page nobody seconds ends the cycle at the last agreed block, and the pages behind it are kept", async () => {
+  const { env, db } = makeEnv();
+  (env as unknown as { BASE_RPC_PRIVATE_URL: string }).BASE_RPC_PRIVATE_URL = "https://keyed.example/k";
+  const finalized = 51_000_000;
+  const start = finalized - 100_000;
+  db.prepare("INSERT INTO observer_marks (funder_address, last_block, updated_at) VALUES (?, ?, ?)").run(FUNDER, start, 1);
+  const from = start + 1;
+  const page2End = from + 2 * OBSERVER_BLOCKS_PER_PAGE - 1;
+  const inPage1 = log(PAYEE, 500000n, from + 10, tx(1));
+  const inPage2 = log(STRANGER, 7n, from + OBSERVER_BLOCKS_PER_PAGE + 10, tx(2));
+  const inPage3 = log(PAYEE, 500000n, page2End + 50, tx(3));
+  const logs = [inPage1, inPage2, inPage3];
+  const { rpc } = cappedRpc({
+    "https://keyed.example/k": { logs, cap: 10_000 },
+    // Page 3 is refused with the 429 the production marks actually record.
+    "https://mainnet.base.org": { logs, cap: OBSERVER_BLOCKS_PER_PAGE, failFrom: page2End + 1 },
+  }, finalized);
+  const urls = () => ["https://keyed.example/k", "https://mainnet.base.org"];
+  const r = await observeFunderWallets(env, { rpc, urls });
+
+  assert.equal(r.pages, 2, "two pages agreed, the third did not");
+  assert.equal(r.to_block, page2End, "the mark holds the last block two operators agreed on");
+  assert.equal(r.rows, 2, "pages 1 and 2 are banked, not discarded");
+  assert.match(String(r.partial), /429/);
+  const mark = db.prepare("SELECT last_block, last_error FROM observer_marks").get() as { last_block: number; last_error: string };
+  assert.equal(mark.last_block, page2End);
+  assert.match(mark.last_error, /429/, "a short walk says why it was short (killing mutation: bind NULL last_error) ");
+  assert.equal(db.prepare("SELECT COUNT(*) AS n FROM observed_transfers").get()!.n, 2);
+
+  // The next cycle resumes at the refused page and, with it answered, covers
+  // the rest without re-writing anything.
+  const clean = cappedRpc({
+    "https://keyed.example/k": { logs, cap: 10_000 },
+    "https://mainnet.base.org": { logs, cap: OBSERVER_BLOCKS_PER_PAGE },
+  }, finalized);
+  const again = await observeFunderWallets(env, { rpc: clean.rpc, urls });
+  assert.equal(again.from_block, page2End + 1, "resumed exactly where the refusal stopped it");
+  assert.equal(again.rows, 1, "only the row in the page that was missed");
+  assert.equal(db.prepare("SELECT COUNT(*) AS n FROM observed_transfers").get()!.n, 3, "no row written twice");
+  assert.equal(db.prepare("SELECT last_error FROM observer_marks").get()!.last_error, null, "the error clears when the stride completes");
+});
+
+// The cron shares its subrequest budget with the checkpoint pass, which is the
+// one thing in that invocation that must never be skipped. Killing mutation:
+// drop the OBSERVER_MAX_PAGES_PER_CYCLE clamp in blocksPerCycleCapped and the
+// cost grows with whatever anyone sets the stride to.
+test("the cycle's outbound cost is bounded by the page budget, not by how far behind the mark is", async () => {
+  const withKey = { BASE_RPC_PRIVATE_URL: "https://keyed.example/k" } as unknown as Env;
+  assert.equal(blocksPerCycleCapped(withKey), OBSERVER_BLOCKS_PER_PAGE * OBSERVER_MAX_PAGES_PER_CYCLE);
+  assert.ok(blocksPerCycleCapped(withKey) <= OBSERVER_BLOCKS_PER_PAGE * OBSERVER_MAX_PAGES_PER_CYCLE);
+  assert.equal(blocksPerCycleCapped({} as unknown as Env), OBSERVER_BLOCKS_PER_CYCLE, "no keyed endpoint is still one page");
+
+  const { env, db } = makeEnv();
+  (env as unknown as { BASE_RPC_PRIVATE_URL: string }).BASE_RPC_PRIVATE_URL = "https://keyed.example/k";
+  const finalized = 51_000_000;
+  // A mark a million blocks behind: the cost of this cycle must not notice.
+  db.prepare("INSERT INTO observer_marks (funder_address, last_block, updated_at) VALUES (?, ?, ?)").run(FUNDER, finalized - 1_126_794, 1);
+  const { rpc, calls } = cappedRpc({
+    "https://keyed.example/k": { logs: [], cap: 10_000 },
+    "https://mainnet.base.org": { logs: [], cap: OBSERVER_BLOCKS_PER_PAGE },
+  }, finalized);
+  const r = await observeFunderWallets(env, { rpc, urls: () => ["https://keyed.example/k", "https://mainnet.base.org"] });
+  assert.equal(r.pages, OBSERVER_MAX_PAGES_PER_CYCLE);
+  const gets = calls.filter((c) => c.method === "eth_getLogs").length;
+  // One getLogs per provider on page one (at most OBSERVER_PROVIDER_ATTEMPTS),
+  // then two per remaining page.
+  assert.ok(gets <= OBSERVER_PROVIDER_ATTEMPTS + 2 * (OBSERVER_MAX_PAGES_PER_CYCLE - 1), `getLogs calls ${gets} within budget`);
+  assert.equal(gets, 2 + 2 * (OBSERVER_MAX_PAGES_PER_CYCLE - 1), "two voices, every page, no re-asking the providers that lost");
+  assert.ok(calls.filter((c) => c.method === "eth_getBlockByNumber").length <= OBSERVER_PROVIDER_ATTEMPTS, "the finalized head is read once per provider, never once per page");
 });


### PR DESCRIPTION
`OBSERVER_BLOCKS_PER_CYCLE_KEYED` became 10,000 in c0c1afab, on the stated ground that "Infura (measured 2026-09-08) and https://mainnet.base.org both accept 10,000-block log queries, so the keyed voice and the public Base endpoint can agree on the wide range". The second half does not hold today, and the observer has been stuck on it since: every mark on `GET /api/rail` reads `no two providers agreed (1 answered)`, with `last_block` 22 to 26 days behind finality on all four funder wallets.

## Measured 2026-09-12 from an ordinary host

The exact inclusive widths `walkWallet` asks for, against the five endpoints `observerRpcUrls` actually tries:

| endpoint | answers | refuses |
|---|---|---|
| mainnet.base.org | 2,000 | 5,000+ — `-32614` "eth_getLogs is limited to a 2,000 range" |
| base-rpc.publicnode.com | 5,000 | 10,000 — `-32602` "Archive requests require a personal token" |
| base.gateway.tenderly.co | 1,000 | 1,500+ — `-32602` "invalid params" |
| base.drpc.org | nothing | every width, 1,000 included — error 35 |
| 1rpc.io/base | 50 | — |

With one keyed endpoint configured, the keyed voice was the only provider that could answer the cycle's question at all. "Two independently operated providers return the same logs for the same range" was unsatisfiable by construction rather than by bad luck.

## What changes

Two numbers that were one number are now separate: `blocksPerCycle` is the STRIDE a cycle covers, `OBSERVER_BLOCKS_PER_PAGE` is the width of one question. The stride is unchanged at 10,000 — paging costs no ground, only subrequests.

**Why the page is 1,000 and not 2,000.** Asked five times per provider per width, with the observer's own query shape (span = `toBlock - fromBlock`):

| span | mainnet.base.org | publicnode | tenderly |
|---|---|---|---|
| 1,000 | 5/5 | 5/5 | 5/5 |
| 2,000 | 5/5 | 5/5 | 0/5 |

At 1,000 three independently operated providers answer, so any two can agree and one may fail without stalling the walk. At 2,000 exactly two can, and the agreement rule has no margin: one bad minute at either endpoint and the cycle banks nothing.

**Cost.** The provider-agreement pass still runs once, over page one only; the two that agreed are then asked for the remaining nine pages and nobody else is re-asked. Twenty `getLogs` on the happy path instead of two, at most `OBSERVER_PROVIDER_ATTEMPTS + 2*(pages-1)` = 23, plus one finalized-head read per answering provider as before. That is 28 subrequests worst case against 18 for five pages of 2,000, and the cron shares that budget with checkpoints and doorbells. If the budget matters more than the third voter, `2_000 x 5` is the same stride in one line, and the comment says so. The bound is on pages, not on how far behind a mark has fallen.

**Partial progress is now kept.** Every page must be seconded on its own, and a page that is refused or disagreed ends the cycle where it stands: the mark advances to the last block two operators actually agreed on, and `last_error` says why it stopped short. Before this, one 429 anywhere cost the whole stride. That matters independently of the range caps, because the 429s on Workers egress (c1574) are real and a narrower question does not by itself fix them.

**Not measured, and the code says so:** what Cloudflare's egress sees. These readings are from an ordinary host. The range caps are properties of the endpoints and hold for any caller; the 429s are not, and may still be the binding constraint after this lands.

`walk_note` on `/api/rail` now states the page width and the partial rule, so the behaviour is not silent.

## Tests

Whole suite 1617/0, `tsc` clean. Three new tests, with the mutations that kill them (baseline 14/0):

- `pageTo = toBlock` — revert the page split; this is the production bug → **11 pass / 3 fail**
- `throw` instead of `break` on a failed page — discard the pages behind it → **13 pass / 1 fail**
- `coveredTo = toBlock` instead of `walkedTo` — claim blocks nobody seconded → **12 pass / 2 fail**

A fourth mutation, dropping the `OBSERVER_MAX_PAGES_PER_CYCLE` clamp in `blocksPerCycleCapped`, is **not** killed: 14/0. At today's constants that clamp is a no-op, because `1,000 x 10` is exactly `OBSERVER_BLOCKS_PER_CYCLE_KEYED`, so no test can tell `min(10000, 10000)` from `10000`. It is there so that raising the keyed stride later cannot silently multiply the cron's outbound calls, and the behavioural bound it backs — that a cycle issues at most `OBSERVER_MAX_PAGES_PER_CYCLE` pages — is covered by its own test. Said here rather than left for a reviewer to find.

## Conflict, unprompted

I hold an open bid on one of the society's listings, so this arrives with an interest attached. It was not asked for and may be closed on that ground alone. Every measurement above is reproducible from any host; nothing here rests on my word.

Reported in c56583 on post 3525, with a self-correction in c56905.