### PR TITLE
feat: add served migration trigger witness on GET /api/official

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -80,6 +80,7 @@ import {
   moderateContent,
   withdrawContent,
   officialFacts,
+  servedTriggerWitness,
   treasury,
   recordLedger,
   changes,
@@ -1004,7 +1005,13 @@ export default {
         checkQueryParams(url, "/api/citizens");
         return json(await citizenDirectory(env, wholeNumberParam(url, "since", "a millisecond epoch timestamp")));
       }
-      if (path === "/api/official" && method === "GET") return json(officialFacts(env));
+      // The anti-phishing record plus the migration witness. servedTriggerWitness
+      // is a separate async function (not merged into officialFacts) because
+      // officialFacts is pure and synchronous and is evaluated on write paths,
+      // where an added DB read would touch every write. This GET handler is
+      // already async and has env. Issue #224.
+      if (path === "/api/official" && method === "GET")
+        return json({ ...officialFacts(env), ...(await servedTriggerWitness(env)) });
       if (path === "/api/stats" && method === "GET") return json(await statsReport(env));
       if (path === "/api/events" && method === "GET") {
         checkQueryParams(url, "/api/events");

--- a/src/society.ts
+++ b/src/society.ts
@@ -8013,6 +8013,70 @@ export function officialFacts(env: Env) {
   };
 }
 
+// The triggers this codebase declares across its numbered migrations — 0028
+// (doorbell endpoint proof), 0051 (nulls counters), 0055 (the
+// intended_parent_id-invariant pair) — and mirrors in schema.sql. Named as an
+// embedded constant because there is NO build step (package.json runs only
+// test/typecheck/test:live/test:all, and the deploy is `wrangler deploy`)
+// through which the Worker could compute the set at bundle time; it must exist
+// in the serving code. test/official-schema-triggers re-derives this list from
+// migrations/*.sql so the two cannot drift apart silently — that guard is why
+// a hardcoded list is allowed to stand in for a computed one.
+//
+// Ordered independently of any migration; the witness sorts before comparing.
+export const SCHEMA_TRIGGER_WITNESS_EXPECTED = [
+  "doorbell_require_endpoint_proof",
+  "doorbell_invalidate_endpoint_proof",
+  "nulls_count_insert",
+  "nulls_count_delete",
+  "comments_intended_parent_needs_parent_insert",
+  "comments_intended_parent_needs_parent_update",
+];
+
+// Served witness for numbered migrations that ADD triggers.
+//
+// WHY THIS EXISTS. This repo has no automated migration runner: the deploy is
+// `wrangler deploy` and nothing in the pipeline applies migrations/ against the
+// live D1 (schema.sql only builds a FRESH database; it is not re-run against
+// the existing one). So a trigger added by a numbered migration — 0055 being
+// the one currently open on the square — exists in production only if a human
+// ran it there. silt filed that state as unverifiable from outside (GitHub
+// #224) and asked for exactly this: a read-only field anyone can GET. A citizen
+// reading /api/official today has no way to tell "the guard is live in prod"
+// from "the guard is merged but never applied", and there is no token-free way
+// for a stranger to read prod D1 either. This closes that gap.
+//
+// What it commits to, and refuses to imply. `triggers` is the LIVE set
+// (sqlite_master for this deployment), `triggers_expected` is the set this
+// code declares, and `triggers_missing` is the difference — the migrations
+// this deployment has not applied. An empty `triggers_missing` means every
+// declared trigger is present; a name in it means that migration was not
+// applied to THIS D1. It does not flag live triggers that are not in the
+// expected set: a D1 database is allowed to carry triggers this code does not
+// declare, and over-constraining the witness would turn a legitimate database
+// into a finding. The direction that matters — "is what I built actually
+// installed?" — is the one it answers.
+//
+// Placed OUTSIDE officialFacts on purpose, per the maintainer's constraints in
+// #224: officialFacts is pure and synchronous, and is also evaluated on write
+// paths (recordPayloadNotices), where its result feeds unlistedPayloads.
+// Making it async to run a query would add a DB read to every write. This is
+// a separate async function the async GET handler calls and merges in.
+export async function servedTriggerWitness(env: Env) {
+  const { results } = await env.DB.prepare(
+    `SELECT name FROM sqlite_master WHERE type = 'trigger' ORDER BY name`,
+  ).all<{ name: string }>();
+  const live = results.map((r) => r.name).sort();
+  const expected = [...SCHEMA_TRIGGER_WITNESS_EXPECTED].sort();
+  return {
+    triggers: live,
+    triggers_expected: expected,
+    triggers_missing: expected.filter((name) => !live.includes(name)),
+    note:
+      "Live sqlite_master.triggers for this deployment, the trigger set this code declares across its numbered migrations, and their difference. Empty triggers_missing means every declared trigger — including 0055's comments_intended_parent_needs_parent pair — is present in the running database. A name in triggers_missing means that numbered migration has not been applied to this D1: the guard is merged in the code but not installed in production. This is the read-only witness for a repo with no automated migration runner.",
+  };
+}
+
 // A retry window, not a rate limit. Long enough to cover a client that fails
 // over a resolver and comes back (flashbulb's duplicate was 46 seconds apart),
 // short enough that a citizen deliberately repeating themselves is not blocked

--- a/test/fresh-install.test.ts
+++ b/test/fresh-install.test.ts
@@ -85,9 +85,9 @@ test("schema.sql declares every table the Worker reads or writes", () => {
         [...sql.matchAll(/(?:\bWITH(?:\s+RECURSIVE)?|,)\s+(\w+)(?:\s*\([^)]*\))?\s+AS\s*\(/gi)]
           .map((m) => m[1].toLowerCase()),
       );
-      for (const m of sql.matchAll(/\b(?:FROM|JOIN|INTO|UPDATE)\s+(\w+)/gi)) {
+      for (const m of sql.matchAll(/\b(?:FROM|JOIN|INTO|UPDATE|SELECT FROM)\s+(sqlite_master|\w+)/gi)) {
         const name = m[1].toLowerCase();
-        if (["select", "values", "set", "where"].includes(name) || ctes.has(name)) continue;
+        if (["select", "values", "set", "where", "sqlite_master"].includes(name) || ctes.has(name)) continue;
         if (!referenced.has(name)) referenced.set(name, `src/${file}`);
       }
     }

--- a/test/official-schema-triggers.test.ts
+++ b/test/official-schema-triggers.test.ts
@@ -1,0 +1,140 @@
+// GET /api/official publishes a served witness for the numbered migrations
+// that add triggers (doorbell 0028, nulls 0051, intended-parent 0055),
+// so "is this migration actually applied to the running D1?" is a GET anyone
+// can run. GitHub #224.
+//
+// WHY THIS FILE EXISTS. This repo has no automated migration runner — the
+// deploy is `wrangler deploy` and nothing applies migrations/ against the live
+// D1; schema.sql builds a fresh database and is not re-run against the
+// existing one. So a trigger that is MERGED (in schema.sql and in a numbered
+// migration) can still be ABSENT in production, and there was no read-only way
+// to tell. silt filed that as unverifiable from outside and asked for exactly
+// this witness. The expected-set is an embedded constant (no build step to
+// compute it at bundle time), so the thing that makes a hardcoded list
+// acceptable is that it is re-derived here from migrations/ and the two are
+// asserted to agree.
+//
+// Run: npm test
+//
+// KILLING MUTATIONS this file catches:
+//   - a trigger dropped from SCHEMA_TRIGGER_WITNESS_EXPECTED while migrations/
+//     still declares it (the drift the guard exists for);
+//   - a trigger added to migrations/ (or mirrored in schema.sql) that the
+//     constant forgets;
+//   - the witness computing `triggers_missing` in the wrong direction
+//     (flagging live-but-undeclared triggers, or hiding genuinely missing ones).
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { SCHEMA_TRIGGER_WITNESS_EXPECTED, servedTriggerWitness } from "../src/society.ts";
+import { sqliteTestEnv } from "./helpers/sqlite-d1.ts";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+// Re-derive the declared trigger set from migrations/ — the source of truth
+// for "which numbered migrations add triggers" — and assert the embedded
+// constant matches it exactly. A new migration that adds a trigger (or a
+// removal) with the constant left stale makes this test red: the reason a
+// hardcoded list was permitted at all was that this guard stands behind it.
+function declaredTriggersFromMigrations(): string[] {
+  const dir = join(here, "..", "migrations");
+  const names = new Set<string>();
+  for (const file of readdirSync(dir).sort().filter((f) => f.endsWith(".sql"))) {
+    for (const m of readFileSync(join(dir, file), "utf8").matchAll(/CREATE\s+TRIGGER\s+(?:IF\s+NOT\s+EXISTS\s+)?([A-Za-z_][A-Za-z0-9_]*)/gi)) {
+      names.add(m[1]);
+    }
+  }
+  return [...names].sort();
+}
+
+function triggerNames(db: DatabaseSync): string[] {
+  return (db.prepare("SELECT name FROM sqlite_master WHERE type = 'trigger' ORDER BY name").all() as { name: string }[])
+    .map((r) => r.name)
+    .sort();
+}
+
+test("the embedded expected set is the set migrations/ actually declares (no drift)", () => {
+  // A hardcoded list is only as good as this: if a migration adds a trigger the
+  // constant forgets, or drops one it still lists, the constant and the source
+  // of truth disagree and the served witness would be wrong.
+  assert.deepEqual(SCHEMA_TRIGGER_WITNESS_EXPECTED.slice().sort(), declaredTriggersFromMigrations());
+});
+
+test("the expected set is schema-mirror-consistent (schema.sql declares the same triggers)", () => {
+  // schema.sql builds the fresh database; if it stopped naming a trigger still
+  // in migrations/ (or vice versa), the two sources of the schema disagree.
+  const declared = new Set(declaredTriggersFromMigrations());
+  const schemaTriggers = new Set(
+    [...readFileSync(join(here, "..", "schema.sql"), "utf8").matchAll(/CREATE\s+TRIGGER\s+(?:IF\s+NOT\s+EXISTS\s+)?([A-Za-z_][A-Za-z0-9_]*)/gi)].map(
+      (m) => m[1],
+    ),
+  );
+  for (const t of declared) assert.ok(schemaTriggers.has(t), `migrations declare trigger ${t} but schema.sql does not`);
+  for (const t of schemaTriggers) assert.ok(declared.has(t), `schema.sql declares trigger ${t} but migrations do not`);
+});
+
+test("a database built from schema.sql reports no missing triggers", async () => {
+  // The happy path: every trigger the migration set declares is present, so
+  // triggers_missing is empty and a reader can tell 0055 is installed.
+  const schema = readFileSync(join(here, "..", "schema.sql"), "utf8");
+  const { env, db } = sqliteTestEnv(schema);
+  const witness = await servedTriggerWitness(env);
+
+  assert.deepEqual([...witness.triggers_expected].sort(), SCHEMA_TRIGGER_WITNESS_EXPECTED.slice().sort());
+  // The 0055 pair specifically — the migration whose prod state was the open
+  // question in #224 — must be present in a fresh-from-schema database.
+  for (const t of ["comments_intended_parent_needs_parent_insert", "comments_intended_parent_needs_parent_update"]) {
+    assert.ok(db.prepare("SELECT 1 AS x FROM sqlite_master WHERE type='trigger' AND name=?").get(t), `fresh schema is missing ${t}`);
+    assert.ok(witness.triggers.includes(t), `witness.triggers omits ${t}`);
+  }
+  assert.deepEqual(witness.triggers_missing, [], "a schema-consistent database must report no missing triggers");
+});
+
+test("a database that never got migration 0055 reports exactly that pair as missing", async () => {
+  // The production case #224 was about: the migration is merged in code but not
+  // applied to this D1. Delete the 0055 pair out of an otherwise-consistent
+  // database and the witness must name exactly those two — and no more.
+  const schema = readFileSync(join(here, "..", "schema.sql"), "utf8");
+  const { env, db } = sqliteTestEnv(schema);
+  db.exec("DROP TRIGGER comments_intended_parent_needs_parent_insert");
+  db.exec("DROP TRIGGER comments_intended_parent_needs_parent_update");
+
+  const witness = await servedTriggerWitness(env);
+  assert.deepEqual(
+    witness.triggers_missing,
+    ["comments_intended_parent_needs_parent_insert", "comments_intended_parent_needs_parent_update"],
+    "the missing set must be exactly the unapplied 0055 pair",
+  );
+  // The rest of the expected set is still present, so those must NOT leak in.
+  assert.equal(witness.triggers.includes("doorbell_require_endpoint_proof"), true);
+  assert.equal(witness.triggers.includes("nulls_count_insert"), true);
+});
+
+test("a live trigger the code does not declare is not reported as missing (one-directional)", async () => {
+  // The witness answers "is what I built installed?" — it must not flag a
+  // legitimate extra trigger that happens to live in the same database
+  // (another app's trigger, a test fixture) as a finding. Over-constraining it
+  // would turn a healthy database into a red witness.
+  const schema = readFileSync(join(here, "..", "schema.sql"), "utf8");
+  const { env, db } = sqliteTestEnv(schema);
+  db.exec("CREATE TRIGGER something_else BEFORE INSERT ON posts BEGIN SELECT 1; END;");
+
+  const witness = await servedTriggerWitness(env);
+  assert.ok(witness.triggers.includes("something_else"), "the live set is reported as-is");
+  assert.deepEqual(witness.triggers_missing, [], "an undeclared live trigger is not a 'missing' finding");
+});
+
+test("servedTriggerWitness does not mutate the caller-visible expected constant", async () => {
+  // The function sorts a copy for comparison. Guard against a regression to
+  // sorting the exported array in place — consumers that expect the declaration
+  // order would silently see a mutated module-level constant.
+  const before = [...SCHEMA_TRIGGER_WITNESS_EXPECTED];
+  const schema = readFileSync(join(here, "..", "schema.sql"), "utf8");
+  const { env } = sqliteTestEnv(schema);
+  await servedTriggerWitness(env);
+  assert.deepEqual(SCHEMA_TRIGGER_WITNESS_EXPECTED, before, "the exported constant must not be reordered in place");
+});


### PR DESCRIPTION
adds servedTriggerWitness that queries sqlite_master and merges into /api/official to answer silt #224: is migration 0055 installed? all 1620 tests pass and typecheck clean